### PR TITLE
feat(optics | stage 3.2): extract paper-aligned propagation core from sdn_upstream

### DIFF
--- a/src/models/optics/diffractive_decoder.py
+++ b/src/models/optics/diffractive_decoder.py
@@ -1,0 +1,376 @@
+"""Paper-aligned diffractive decoder skeleton for Stage 3 Issue 2.
+
+This module intentionally implements only the optical core:
+
+`phi_lr -> U0 -> U_out_full`
+
+Intensity readout, ROI crop, and optical losses belong to later Stage 3 issues.
+The scheduling here is explicit and config-driven:
+
+- `L` means the number of trainable diffractive phase masks.
+- propagation from the last mask to the sensor plane is explicit.
+- there is no hidden `layer == 2` or `depth + 1` logic.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+import torch
+import torch.nn as nn
+
+from src.models.optics.phase_utils import (
+    center_embed_tensor,
+    ensure_complex_field,
+    map_phase,
+    normalize_hw,
+    normalize_spacing,
+    phase_to_field,
+    validate_single_channel_image,
+)
+from src.models.optics.propagation import PropagationOperator, apply_phase_modulation
+
+
+@dataclass(frozen=True)
+class DistanceSchedule:
+    """Explicit Stage 3 propagation distances."""
+
+    input_to_first: float
+    inter_layer: tuple[float, ...]
+    last_to_sensor: float
+
+    @classmethod
+    def from_config(cls, config: "DistanceSchedule | Mapping[str, object]") -> "DistanceSchedule":
+        if isinstance(config, cls):
+            return config
+        if not isinstance(config, Mapping):
+            raise TypeError("distance_schedule must be a DistanceSchedule or a mapping.")
+
+        inter_layer_raw = config.get("inter_layer", ())
+        if not isinstance(inter_layer_raw, Sequence) or isinstance(inter_layer_raw, (str, bytes)):
+            raise TypeError("distance_schedule.inter_layer must be a sequence of distances.")
+
+        return cls(
+            input_to_first=float(config["input_to_first"]),
+            inter_layer=tuple(float(distance) for distance in inter_layer_raw),
+            last_to_sensor=float(config["last_to_sensor"]),
+        )
+
+    def validate_for_layers(self, num_diffractive_layers: int) -> None:
+        if num_diffractive_layers < 1:
+            raise ValueError("num_diffractive_layers must be >= 1.")
+        expected_inter_layers = max(0, num_diffractive_layers - 1)
+        if len(self.inter_layer) != expected_inter_layers:
+            raise ValueError(
+                "distance_schedule.inter_layer must contain exactly "
+                f"{expected_inter_layers} entries for L={num_diffractive_layers}, "
+                f"got {len(self.inter_layer)}."
+            )
+        all_distances = (self.input_to_first, *self.inter_layer, self.last_to_sensor)
+        if any(distance <= 0.0 for distance in all_distances):
+            raise ValueError(f"All propagation distances must be positive, got {all_distances}.")
+
+
+@dataclass(frozen=True)
+class OpticalGridConfig:
+    """Grid and padding contract used by the Stage 3 optical decoder."""
+
+    input_pattern_hw: tuple[int, int]
+    layer_hw: tuple[int, int]
+    propagation_hw: tuple[int, int]
+
+    @classmethod
+    def from_config(cls, config: "OpticalGridConfig | Mapping[str, object]") -> "OpticalGridConfig":
+        if isinstance(config, cls):
+            return config
+        if not isinstance(config, Mapping):
+            raise TypeError("grid_config must be an OpticalGridConfig or a mapping.")
+
+        return cls(
+            input_pattern_hw=normalize_hw(config["input_pattern_hw"], name="input_pattern_hw"),
+            layer_hw=normalize_hw(config["layer_hw"], name="layer_hw"),
+            propagation_hw=normalize_hw(config["propagation_hw"], name="propagation_hw"),
+        )
+
+    def __post_init__(self) -> None:
+        input_h, input_w = self.input_pattern_hw
+        layer_h, layer_w = self.layer_hw
+        prop_h, prop_w = self.propagation_hw
+
+        if input_h > prop_h or input_w > prop_w:
+            raise ValueError(
+                "input_pattern_hw must fit inside propagation_hw, "
+                f"got input={self.input_pattern_hw}, propagation={self.propagation_hw}."
+            )
+        if layer_h > prop_h or layer_w > prop_w:
+            raise ValueError(
+                "layer_hw must fit inside propagation_hw, "
+                f"got layer={self.layer_hw}, propagation={self.propagation_hw}."
+            )
+
+    @property
+    def input_padding_hw(self) -> tuple[int, int]:
+        return (
+            self.propagation_hw[0] - self.input_pattern_hw[0],
+            self.propagation_hw[1] - self.input_pattern_hw[1],
+        )
+
+    @property
+    def layer_padding_hw(self) -> tuple[int, int]:
+        return (
+            self.propagation_hw[0] - self.layer_hw[0],
+            self.propagation_hw[1] - self.layer_hw[1],
+        )
+
+
+@dataclass(frozen=True)
+class PhaseMaskConfig:
+    """Explicit phase-mask parameterization for trainable diffractive layers."""
+
+    init_mode: str = "zeros"
+    init_scale: float = 0.05
+    phase_mapping: str = "tanh"
+    phase_range: tuple[float, float] = (-math.pi, math.pi)
+
+    @classmethod
+    def from_config(cls, config: "PhaseMaskConfig | Mapping[str, object] | None") -> "PhaseMaskConfig":
+        if config is None:
+            return cls()
+        if isinstance(config, cls):
+            return config
+        if not isinstance(config, Mapping):
+            raise TypeError("phase_mask_config must be a PhaseMaskConfig, mapping, or None.")
+
+        phase_range_raw = config.get("phase_range", (-math.pi, math.pi))
+        if not isinstance(phase_range_raw, Sequence) or len(phase_range_raw) != 2:
+            raise TypeError("phase_mask_config.phase_range must be a length-2 sequence.")
+
+        return cls(
+            init_mode=str(config.get("init_mode", "zeros")),
+            init_scale=float(config.get("init_scale", 0.05)),
+            phase_mapping=str(config.get("phase_mapping", "tanh")),
+            phase_range=(float(phase_range_raw[0]), float(phase_range_raw[1])),
+        )
+
+
+class DiffractiveDecoder(nn.Module):
+    """Stage 3 optical decoder skeleton with explicit layer semantics."""
+
+    VALID_LAYER_COUNTS = (1, 3, 5)
+
+    def __init__(
+        self,
+        *,
+        num_diffractive_layers: int,
+        wavelength: float,
+        pixel_pitch: float | Sequence[float],
+        grid_config: OpticalGridConfig | Mapping[str, object],
+        distance_schedule: DistanceSchedule | Mapping[str, object],
+        phase_mask_config: PhaseMaskConfig | Mapping[str, object] | None = None,
+        kernel_dtype: torch.dtype = torch.float32,
+    ) -> None:
+        super().__init__()
+
+        if num_diffractive_layers not in self.VALID_LAYER_COUNTS:
+            raise ValueError(
+                "Stage 3 currently supports only L in {1, 3, 5}, "
+                f"got L={num_diffractive_layers}."
+            )
+        if wavelength <= 0.0:
+            raise ValueError(f"wavelength must be positive, got {wavelength}.")
+
+        self.num_diffractive_layers = int(num_diffractive_layers)
+        self.wavelength = float(wavelength)
+        self.pixel_pitch = normalize_spacing(pixel_pitch, name="pixel_pitch")
+        self.grid_config = OpticalGridConfig.from_config(grid_config)
+        self.distance_schedule = DistanceSchedule.from_config(distance_schedule)
+        self.phase_mask_config = PhaseMaskConfig.from_config(phase_mask_config)
+        self.distance_schedule.validate_for_layers(self.num_diffractive_layers)
+
+        self.phase_masks_raw = nn.Parameter(
+            torch.empty(
+                self.num_diffractive_layers,
+                1,
+                *self.grid_config.layer_hw,
+                dtype=torch.float32,
+            )
+        )
+        self._reset_phase_masks()
+
+        self.input_to_first = PropagationOperator(
+            self.grid_config.propagation_hw,
+            pixel_pitch=self.pixel_pitch,
+            wavelength=self.wavelength,
+            distance=self.distance_schedule.input_to_first,
+            kernel_dtype=kernel_dtype,
+        )
+        self.inter_layer = nn.ModuleList(
+            PropagationOperator(
+                self.grid_config.propagation_hw,
+                pixel_pitch=self.pixel_pitch,
+                wavelength=self.wavelength,
+                distance=distance,
+                kernel_dtype=kernel_dtype,
+            )
+            for distance in self.distance_schedule.inter_layer
+        )
+        self.last_to_sensor = PropagationOperator(
+            self.grid_config.propagation_hw,
+            pixel_pitch=self.pixel_pitch,
+            wavelength=self.wavelength,
+            distance=self.distance_schedule.last_to_sensor,
+            kernel_dtype=kernel_dtype,
+        )
+
+    def _reset_phase_masks(self) -> None:
+        mode = self.phase_mask_config.init_mode
+        scale = abs(self.phase_mask_config.init_scale)
+
+        with torch.no_grad():
+            if mode == "zeros":
+                self.phase_masks_raw.zero_()
+            elif mode == "uniform_small":
+                self.phase_masks_raw.uniform_(-scale, scale)
+            elif mode == "normal_small":
+                self.phase_masks_raw.normal_(mean=0.0, std=scale)
+            else:
+                raise ValueError(f"Unsupported phase-mask init mode: {mode}.")
+
+    def _mapped_phase_masks(self) -> torch.Tensor:
+        return map_phase(
+            self.phase_masks_raw,
+            mode=self.phase_mask_config.phase_mapping,
+            phase_range=self.phase_mask_config.phase_range,
+        )
+
+    def _embedded_phase_masks(self, *, dtype: torch.dtype, device: torch.device) -> torch.Tensor:
+        mapped_masks = self._mapped_phase_masks().to(device=device, dtype=dtype)
+        return center_embed_tensor(
+            mapped_masks,
+            self.grid_config.propagation_hw,
+            fill_value=0.0,
+        )
+
+    def build_input_field(
+        self,
+        phi_lr: torch.Tensor,
+        *,
+        amplitude: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Convert `phi_lr` into `U0` on the propagation grid."""
+        validate_single_channel_image(
+            phi_lr,
+            name="phi_lr",
+            expected_hw=self.grid_config.input_pattern_hw,
+        )
+        if amplitude is not None:
+            validate_single_channel_image(
+                amplitude,
+                name="amplitude",
+                expected_hw=self.grid_config.input_pattern_hw,
+            )
+            if amplitude.shape != phi_lr.shape:
+                raise ValueError(
+                    "amplitude and phi_lr must have identical shapes, "
+                    f"got {tuple(amplitude.shape)} vs {tuple(phi_lr.shape)}."
+                )
+
+        input_field = phase_to_field(
+            phi_lr,
+            amplitude=amplitude,
+            phase_mapping="identity",
+        )
+        return center_embed_tensor(
+            input_field,
+            self.grid_config.propagation_hw,
+            fill_value=0.0,
+        )
+
+    def forward_from_field(
+        self,
+        U0: torch.Tensor,
+        *,
+        return_intermediates: bool = False,
+    ) -> torch.Tensor | dict[str, torch.Tensor | list[torch.Tensor]]:
+        """Run `U0 -> U_out_full` with explicit Stage 3 propagation semantics."""
+        ensure_complex_field(
+            U0,
+            name="U0",
+            expected_hw=self.grid_config.propagation_hw,
+        )
+
+        propagation_device = U0.device
+        propagation_dtype = U0.real.dtype
+        phase_masks_full = self._embedded_phase_masks(
+            dtype=propagation_dtype,
+            device=propagation_device,
+        )
+
+        field_after_input_to_first = self.input_to_first(U0)
+        field = field_after_input_to_first
+        fields_after_mask_modulation: list[torch.Tensor] = []
+        fields_after_inter_layer: list[torch.Tensor] = []
+
+        for layer_index in range(self.num_diffractive_layers):
+            field = apply_phase_modulation(field, phase_masks_full[layer_index : layer_index + 1])
+            if return_intermediates:
+                fields_after_mask_modulation.append(field)
+
+            if layer_index < self.num_diffractive_layers - 1:
+                field = self.inter_layer[layer_index](field)
+                if return_intermediates:
+                    fields_after_inter_layer.append(field)
+
+        U_out_full = self.last_to_sensor(field)
+        if not return_intermediates:
+            return U_out_full
+
+        return {
+            "U0": U0,
+            "field_after_input_to_first": field_after_input_to_first,
+            "phase_masks_full": phase_masks_full,
+            "fields_after_mask_modulation": fields_after_mask_modulation,
+            "fields_after_inter_layer": fields_after_inter_layer,
+            "U_out_full": U_out_full,
+        }
+
+    def forward_from_phase(
+        self,
+        phi_lr: torch.Tensor,
+        *,
+        amplitude: torch.Tensor | None = None,
+        return_intermediates: bool = False,
+    ) -> torch.Tensor | dict[str, torch.Tensor | list[torch.Tensor]]:
+        """Run the Stage 3 front-half chain `phi_lr -> U0 -> U_out_full`."""
+        U0 = self.build_input_field(phi_lr, amplitude=amplitude)
+        output = self.forward_from_field(U0, return_intermediates=return_intermediates)
+        if not return_intermediates:
+            return output
+
+        if not isinstance(output, dict):
+            raise RuntimeError("Expected a dictionary when return_intermediates=True.")
+        output["U0"] = U0
+        return output
+
+    def forward(
+        self,
+        phi_lr: torch.Tensor,
+        *,
+        amplitude: torch.Tensor | None = None,
+        return_intermediates: bool = False,
+    ) -> torch.Tensor | dict[str, torch.Tensor | list[torch.Tensor]]:
+        return self.forward_from_phase(
+            phi_lr,
+            amplitude=amplitude,
+            return_intermediates=return_intermediates,
+        )
+
+
+__all__ = [
+    "DiffractiveDecoder",
+    "DistanceSchedule",
+    "OpticalGridConfig",
+    "PhaseMaskConfig",
+]

--- a/src/models/optics/phase_utils.py
+++ b/src/models/optics/phase_utils.py
@@ -1,0 +1,237 @@
+"""Phase and field helpers for the Stage 3 optical decoder contract.
+
+The upstream project exposes optics tensors through ambiguous `amp/phase`
+names even when the tensors are really real/imag parts of a coherent field.
+This rewrite keeps the Stage 3 contract explicit:
+
+- `phi_*` means phase in radians.
+- complex tensors represent coherent optical fields directly.
+- padding / embedding rules are separate for input fields vs. phase masks.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+
+import torch
+
+
+def normalize_hw(hw: int | Sequence[int], *, name: str) -> tuple[int, int]:
+    """Normalize an integer or pair-like shape into `(height, width)`."""
+    if isinstance(hw, int):
+        if hw <= 0:
+            raise ValueError(f"{name} must be positive, got {hw}.")
+        return (hw, hw)
+
+    if len(hw) != 2:
+        raise ValueError(f"{name} must be an int or length-2 sequence, got {hw}.")
+
+    height = int(hw[0])
+    width = int(hw[1])
+    if height <= 0 or width <= 0:
+        raise ValueError(f"{name} must contain positive values, got {hw}.")
+    return (height, width)
+
+
+def normalize_spacing(
+    spacing: float | Sequence[float], *, name: str
+) -> tuple[float, float]:
+    """Normalize a scalar or pair-like sampling interval into `(dy, dx)`."""
+    if isinstance(spacing, (int, float)):
+        value = float(spacing)
+        if value <= 0.0:
+            raise ValueError(f"{name} must be positive, got {spacing}.")
+        return (value, value)
+
+    if len(spacing) != 2:
+        raise ValueError(f"{name} must be a float or length-2 sequence, got {spacing}.")
+
+    dy = float(spacing[0])
+    dx = float(spacing[1])
+    if dy <= 0.0 or dx <= 0.0:
+        raise ValueError(f"{name} must contain positive values, got {spacing}.")
+    return (dy, dx)
+
+
+def validate_single_channel_image(
+    tensor: torch.Tensor,
+    *,
+    name: str,
+    expected_hw: tuple[int, int] | None = None,
+) -> torch.Tensor:
+    """Validate a `[B, 1, H, W]` real-valued tensor."""
+    if tensor.ndim != 4:
+        raise ValueError(f"{name} must be 4D NCHW, got shape {tuple(tensor.shape)}.")
+    if tensor.shape[1] != 1:
+        raise ValueError(f"{name} must have channel size 1, got {tensor.shape[1]}.")
+    if expected_hw is not None and tuple(tensor.shape[-2:]) != tuple(expected_hw):
+        raise ValueError(
+            f"{name} must have spatial shape {expected_hw}, got {tuple(tensor.shape[-2:])}."
+        )
+    if tensor.is_complex():
+        raise ValueError(f"{name} must be real-valued, got dtype {tensor.dtype}.")
+    return tensor
+
+
+def ensure_complex_field(
+    field: torch.Tensor,
+    *,
+    name: str,
+    expected_hw: tuple[int, int] | None = None,
+) -> torch.Tensor:
+    """Validate a `[B, 1, H, W]` complex field tensor."""
+    if field.ndim != 4:
+        raise ValueError(f"{name} must be 4D NCHW, got shape {tuple(field.shape)}.")
+    if field.shape[1] != 1:
+        raise ValueError(f"{name} must have channel size 1, got {field.shape[1]}.")
+    if not field.is_complex():
+        raise ValueError(f"{name} must be complex-valued, got dtype {field.dtype}.")
+    if expected_hw is not None and tuple(field.shape[-2:]) != tuple(expected_hw):
+        raise ValueError(
+            f"{name} must have spatial shape {expected_hw}, got {tuple(field.shape[-2:])}."
+        )
+    return field
+
+
+def resolve_complex_dtype(
+    dtype_or_tensor: torch.dtype | torch.Tensor,
+) -> torch.dtype:
+    """Resolve an explicit complex dtype from a real or complex reference."""
+    dtype = dtype_or_tensor.dtype if isinstance(dtype_or_tensor, torch.Tensor) else dtype_or_tensor
+
+    if dtype == torch.complex128:
+        return torch.complex128
+    if dtype in (torch.float64,):
+        return torch.complex128
+    if dtype in (torch.complex64, torch.float16, torch.bfloat16, torch.float32):
+        return torch.complex64
+    raise TypeError(f"Unsupported dtype for complex field construction: {dtype}.")
+
+
+def complex_to_real_dtype(complex_dtype: torch.dtype) -> torch.dtype:
+    """Return the matching real dtype for a complex dtype."""
+    if complex_dtype == torch.complex128:
+        return torch.float64
+    if complex_dtype == torch.complex64:
+        return torch.float32
+    raise TypeError(f"Unsupported complex dtype: {complex_dtype}.")
+
+
+def map_phase(
+    phase_raw: torch.Tensor,
+    *,
+    mode: str = "identity",
+    phase_range: tuple[float, float] = (-math.pi, math.pi),
+) -> torch.Tensor:
+    """Map raw phase parameters into physical phase values in radians.
+
+    The Stage 3 docs leave the exact parameterization open, but require the
+    mapping to be explicit rather than hidden inside the decoder. This helper
+    keeps that rule local and configurable.
+    """
+    if phase_raw.is_complex():
+        raise ValueError("phase_raw must be real-valued.")
+
+    phase_min, phase_max = float(phase_range[0]), float(phase_range[1])
+    if phase_max <= phase_min:
+        raise ValueError(f"phase_range must satisfy max > min, got {phase_range}.")
+
+    if mode == "identity":
+        return phase_raw
+
+    center = 0.5 * (phase_min + phase_max)
+    half_span = 0.5 * (phase_max - phase_min)
+
+    if mode == "tanh":
+        return center + half_span * torch.tanh(phase_raw)
+    if mode == "sigmoid":
+        return phase_min + (phase_max - phase_min) * torch.sigmoid(phase_raw)
+
+    raise ValueError(f"Unsupported phase mapping mode: {mode}.")
+
+
+def phase_to_field(
+    phase: torch.Tensor,
+    *,
+    amplitude: torch.Tensor | None = None,
+    phase_mapping: str = "identity",
+    phase_range: tuple[float, float] = (-math.pi, math.pi),
+    complex_dtype: torch.dtype | None = None,
+) -> torch.Tensor:
+    """Convert a phase-only pattern into a complex coherent field.
+
+    By Stage 3 contract the mainline uses phase-only modulation with amplitude
+    fixed to 1. This helper keeps that default while allowing an explicit
+    amplitude tensor for future ablations.
+    """
+    validate_single_channel_image(phase, name="phase")
+
+    mapped_phase = map_phase(
+        phase,
+        mode=phase_mapping,
+        phase_range=phase_range,
+    )
+    if amplitude is None:
+        amplitude = torch.ones_like(mapped_phase)
+    else:
+        validate_single_channel_image(
+            amplitude,
+            name="amplitude",
+            expected_hw=tuple(mapped_phase.shape[-2:]),
+        )
+        if amplitude.shape != mapped_phase.shape:
+            raise ValueError(
+                "amplitude and phase must have the same full shape, "
+                f"got {tuple(amplitude.shape)} vs {tuple(mapped_phase.shape)}."
+            )
+
+    complex_dtype = complex_dtype or resolve_complex_dtype(mapped_phase)
+    real_dtype = complex_to_real_dtype(complex_dtype)
+    mapped_phase = mapped_phase.to(dtype=real_dtype)
+    amplitude = amplitude.to(dtype=real_dtype)
+
+    field_real = amplitude * torch.cos(mapped_phase)
+    field_imag = amplitude * torch.sin(mapped_phase)
+    return torch.complex(field_real, field_imag).to(dtype=complex_dtype)
+
+
+def center_embed_tensor(
+    tensor: torch.Tensor,
+    target_hw: int | Sequence[int],
+    *,
+    fill_value: float | complex = 0.0,
+) -> torch.Tensor:
+    """Embed a tensor into a larger spatial grid with centered placement."""
+    target_h, target_w = normalize_hw(target_hw, name="target_hw")
+    source_h, source_w = tensor.shape[-2:]
+
+    if source_h > target_h or source_w > target_w:
+        raise ValueError(
+            "Cannot center-embed tensor into a smaller target grid: "
+            f"source={(source_h, source_w)}, target={(target_h, target_w)}."
+        )
+
+    if source_h == target_h and source_w == target_w:
+        return tensor
+
+    offset_h = (target_h - source_h) // 2
+    offset_w = (target_w - source_w) // 2
+
+    output_shape = (*tensor.shape[:-2], target_h, target_w)
+    output = tensor.new_full(output_shape, fill_value)
+    output[..., offset_h : offset_h + source_h, offset_w : offset_w + source_w] = tensor
+    return output
+
+
+__all__ = [
+    "center_embed_tensor",
+    "complex_to_real_dtype",
+    "ensure_complex_field",
+    "map_phase",
+    "normalize_hw",
+    "normalize_spacing",
+    "phase_to_field",
+    "resolve_complex_dtype",
+    "validate_single_channel_image",
+]

--- a/src/models/optics/propagation.py
+++ b/src/models/optics/propagation.py
@@ -1,0 +1,210 @@
+"""Optical propagation primitives for the Stage 3 decoder skeleton.
+
+This module keeps only the optics core that is worth reusing from
+`external/sdn_upstream`:
+
+- centered FFT / IFFT propagation flow derived from upstream `FFT` / `IFFT`
+- Rayleigh-Sommerfeld transfer kernel derived from upstream `getH2`
+- phase-only mask modulation derived from upstream `sublayer.forward`
+
+Task heads, datasets, electrical decoders, and any layer-index special cases
+are intentionally removed.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+
+import torch
+import torch.nn as nn
+
+from src.models.optics.phase_utils import (
+    ensure_complex_field,
+    normalize_hw,
+    normalize_spacing,
+    phase_to_field,
+)
+
+
+def fft2_centered(field: torch.Tensor) -> torch.Tensor:
+    """Apply the same centered FFT layout used by the upstream optics code."""
+    shifted = torch.fft.fftshift(field, dim=(-2, -1))
+    transformed = torch.fft.fft2(shifted, dim=(-2, -1))
+    return torch.fft.fftshift(transformed, dim=(-2, -1))
+
+
+def ifft2_centered(spectrum: torch.Tensor) -> torch.Tensor:
+    """Apply the inverse centered FFT layout used by the upstream optics code."""
+    shifted = torch.fft.fftshift(spectrum, dim=(-2, -1))
+    transformed = torch.fft.ifft2(shifted, dim=(-2, -1))
+    return torch.fft.fftshift(transformed, dim=(-2, -1))
+
+
+def build_rayleigh_sommerfeld_transfer_kernel(
+    propagation_hw: int | Sequence[int],
+    *,
+    pixel_pitch: float | Sequence[float],
+    wavelength: float,
+    distance: float,
+    device: torch.device | str | None = None,
+    dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    """Build the transfer kernel used for a single free-space propagation.
+
+    The mathematical form follows the upstream `getH2` Rayleigh-Sommerfeld
+    primitive, but is rewritten with pure torch instead of scipy/numpy glue.
+    """
+    height, width = normalize_hw(propagation_hw, name="propagation_hw")
+    pitch_y, pitch_x = normalize_spacing(pixel_pitch, name="pixel_pitch")
+
+    if wavelength <= 0.0:
+        raise ValueError(f"wavelength must be positive, got {wavelength}.")
+    if distance <= 0.0:
+        raise ValueError(f"distance must be positive, got {distance}.")
+    if dtype not in (torch.float32, torch.float64):
+        raise TypeError(f"Kernel dtype must be float32 or float64, got {dtype}.")
+
+    y = torch.linspace(
+        -(height / 2.0 - 0.5) * pitch_y,
+        (height / 2.0 - 0.5) * pitch_y,
+        steps=height,
+        device=device,
+        dtype=dtype,
+    )
+    x = torch.linspace(
+        -(width / 2.0 - 0.5) * pitch_x,
+        (width / 2.0 - 0.5) * pitch_x,
+        steps=width,
+        device=device,
+        dtype=dtype,
+    )
+    yy, xx = torch.meshgrid(y, x, indexing="ij")
+
+    radial_distance = torch.sqrt(distance * distance + xx.square() + yy.square())
+    wavenumber = (2.0 * math.pi) / wavelength
+
+    carrier = torch.polar(torch.ones_like(radial_distance), wavenumber * radial_distance)
+    rs_real = 1.0 / (2.0 * math.pi * radial_distance)
+    rs_imag = -torch.full_like(radial_distance, 1.0 / wavelength)
+    rs_term = torch.complex(rs_real, rs_imag)
+    geometry_term = distance / (distance * distance + xx.square() + yy.square())
+
+    spatial_kernel = carrier * geometry_term * rs_term
+    transfer_kernel = fft2_centered(spatial_kernel) * (pitch_y * pitch_x)
+    return transfer_kernel
+
+
+def propagation_inverse_scale(
+    propagation_hw: int | Sequence[int],
+    *,
+    pixel_pitch: float | Sequence[float],
+) -> float:
+    """Match the discrete scaling used by the upstream propagation routine."""
+    height, width = normalize_hw(propagation_hw, name="propagation_hw")
+    pitch_y, pitch_x = normalize_spacing(pixel_pitch, name="pixel_pitch")
+
+    physical_size_y = height * pitch_y
+    physical_size_x = width * pitch_x
+    return ((height + 1) * (width + 1)) / (physical_size_y * physical_size_x)
+
+
+def propagate_with_transfer_kernel(
+    field: torch.Tensor,
+    *,
+    transfer_kernel: torch.Tensor,
+    pixel_pitch: float | Sequence[float],
+) -> torch.Tensor:
+    """Propagate a complex field with a precomputed transfer kernel."""
+    ensure_complex_field(field, name="field")
+
+    if transfer_kernel.ndim != 2:
+        raise ValueError(
+            f"transfer_kernel must be 2D [H, W], got shape {tuple(transfer_kernel.shape)}."
+        )
+    if tuple(transfer_kernel.shape) != tuple(field.shape[-2:]):
+        raise ValueError(
+            "transfer_kernel spatial shape must match the field grid, "
+            f"got kernel={tuple(transfer_kernel.shape)} vs field={tuple(field.shape[-2:])}."
+        )
+
+    pitch_y, pitch_x = normalize_spacing(pixel_pitch, name="pixel_pitch")
+    scaled_spectrum = fft2_centered(field) * (pitch_y * pitch_x)
+    propagated_spectrum = scaled_spectrum * transfer_kernel.view(1, 1, *transfer_kernel.shape)
+    propagated = ifft2_centered(propagated_spectrum)
+    return propagated * propagation_inverse_scale(
+        transfer_kernel.shape,
+        pixel_pitch=(pitch_y, pitch_x),
+    )
+
+
+def apply_phase_modulation(field: torch.Tensor, phase_mask: torch.Tensor) -> torch.Tensor:
+    """Apply a phase-only mask to a complex field."""
+    ensure_complex_field(field, name="field")
+
+    if phase_mask.ndim == 2:
+        phase_mask = phase_mask.unsqueeze(0).unsqueeze(0)
+    elif phase_mask.ndim != 4:
+        raise ValueError(
+            f"phase_mask must be 2D [H, W] or 4D [B, 1, H, W], got {tuple(phase_mask.shape)}."
+        )
+    if phase_mask.shape[-2:] != field.shape[-2:]:
+        raise ValueError(
+            "phase_mask spatial shape must match the field grid, "
+            f"got mask={tuple(phase_mask.shape[-2:])} vs field={tuple(field.shape[-2:])}."
+        )
+
+    phase_mask = phase_mask.to(device=field.device, dtype=field.real.dtype)
+    modulation_field = phase_to_field(
+        phase_mask,
+        phase_mapping="identity",
+        complex_dtype=field.dtype,
+    )
+    return field * modulation_field
+
+
+class PropagationOperator(nn.Module):
+    """Single config-driven free-space propagation operator."""
+
+    def __init__(
+        self,
+        propagation_hw: int | Sequence[int],
+        *,
+        pixel_pitch: float | Sequence[float],
+        wavelength: float,
+        distance: float,
+        kernel_dtype: torch.dtype = torch.float32,
+    ) -> None:
+        super().__init__()
+        self.propagation_hw = normalize_hw(propagation_hw, name="propagation_hw")
+        self.pixel_pitch = normalize_spacing(pixel_pitch, name="pixel_pitch")
+        self.wavelength = float(wavelength)
+        self.distance = float(distance)
+
+        transfer_kernel = build_rayleigh_sommerfeld_transfer_kernel(
+            self.propagation_hw,
+            pixel_pitch=self.pixel_pitch,
+            wavelength=self.wavelength,
+            distance=self.distance,
+            dtype=kernel_dtype,
+        )
+        self.register_buffer("transfer_kernel", transfer_kernel, persistent=False)
+
+    def forward(self, field: torch.Tensor) -> torch.Tensor:
+        ensure_complex_field(field, name="field", expected_hw=self.propagation_hw)
+        kernel = self.transfer_kernel.to(device=field.device, dtype=field.dtype)
+        return propagate_with_transfer_kernel(
+            field,
+            transfer_kernel=kernel,
+            pixel_pitch=self.pixel_pitch,
+        )
+
+
+__all__ = [
+    "PropagationOperator",
+    "apply_phase_modulation",
+    "build_rayleigh_sommerfeld_transfer_kernel",
+    "fft2_centered",
+    "ifft2_centered",
+    "propagate_with_transfer_kernel",
+]


### PR DESCRIPTION
rewrite Stage 3 optical propagation into a clean config-driven core with explicit distance scheduling and layer semantics, keeping only phase-to-field, FFT/IFFT, Rayleigh-Sommerfeld propagation, and phase-mask modulation while removing upstream task coupling, decoder/head logic, and implicit final-layer hacks

ref: #18