### PR TITLE
feat(optics | stage 3.3): add output FOV crop and optical direct-read out contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,6 @@
 
 More order see docs/run_order.md. Here are some frequently used orders.
 
+- Validate Stage 3 Issue 3 optical readout/crop:
+  `python scripts/check_optical_readout.py`
+

--- a/docs/ai/CodexFeedback/stage3/feedback_stage3-2.md
+++ b/docs/ai/CodexFeedback/stage3/feedback_stage3-2.md
@@ -1,0 +1,25 @@
+本次我按 Stage 3 freeze 的边界实现了纯 optical core，范围严格停在 phi_lr -> U0 -> U_out_full。L 只表示可训练 diffractive phase masks 数量，最终到 sensor 的传播单独建模；没有带入 upstream 的 classification head、electrical decoder、Pet/OAM/LG/HG 耦合，也没有实现 Issue 3 的 readout/crop。
+
+本次实际新增文件：
+
+[phase_utils.py](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/src/models/optics/phase_utils.py):154
+[propagation.py](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/src/models/optics/propagation.py):44
+[diffractive_decoder.py](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/src/models/optics/diffractive_decoder.py):158
+变更内容：
+
+[phase_utils.py](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/src/models/optics/phase_utils.py):154 提供了显式 phase -> complex field 转换、可配置 phase mapping，以及 centered embedding。输入 field 和 mask 的语义分开处理，避免继续沿用 upstream 含混的 amp/phase 命名。
+[propagation.py](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/src/models/optics/propagation.py):44 把 upstream 的 centered FFT/IFFT、getH2 风格 Rayleigh-Sommerfeld kernel、phase-mask modulation 抽成独立 primitive，并重写成纯 torch、config-driven 的 PropagationOperator。
+[diffractive_decoder.py](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/src/models/optics/diffractive_decoder.py):158 新建了 paper-aligned decoder skeleton。这里用 DistanceSchedule、OpticalGridConfig、PhaseMaskConfig 明确了 distance_schedule.input_to_first / inter_layer / last_to_sensor、grid/padding 关系和 mask 参数化；forward_from_phase 与 forward_from_field 都只返回 U_out_full，但保留了 return_intermediates 方便后续接 Issue 3。
+验证结果：
+
+我用内联 smoke check 跑通了 L=1/3/5 的独立 import 和 forward，输出是 complex tensor，且无 NaN/Inf。
+改变输入 phase 后，U_out_full 发生变化，平均差异约 2.27e-03。
+改变第一层 mask raw phase 后，U_out_full 发生变化，平均差异约 3.85e-03。
+没有提交仓库内的 smoke test 文件；apply_patch 在新增 tests/test_optics_core_smoke.py 时反复触发 Windows sandbox refresh 错误，所以这部分只做了命令级验证。
+风险点：
+
+当前只完成了前半链路，I_out_full / I_out_roi 还没接上，Issue 3 才能真正把 Stage 3 frozen readout/crop contract 落完整。
+传播数值现在是按 upstream primitive 重写后的 clean version，仍需要在 Issue 4 的 forward sanity 中继续做更系统的 shape / crop / visualization 检查。
+下一步建议直接进入 Issue 3：在这个 core 上补 U_out_full -> I_out_full -> I_out_roi 的显式 readout/crop contract，不要提前跳到 Stage 4 的 joint training。
+
+

--- a/docs/ai/CodexFeedback/stage3/feedback_stage3-3.md
+++ b/docs/ai/CodexFeedback/stage3/feedback_stage3-3.md
@@ -1,0 +1,24 @@
+Contract
+本次严格按 frozen Stage 3 contract 只做 Issue 3 的 readout/crop 落地：把现有链路从 phi_lr -> U0 -> U_out_full 扩成 phi_lr -> U0 -> U_out_full -> I_out_full -> I_out_roi。范围只到 direct optical readout，不回头重写 propagation core，也不提前做 trainer、joint training、single-sample fitting 或 capacity experiment。
+
+Files
+
+新增 [readout.py](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/src/models/optics/readout.py)
+修改 [diffractive_decoder.py](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/src/models/optics/diffractive_decoder.py)
+Implementation
+
+在 [readout.py](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/src/models/optics/readout.py):21 新增 ReadoutConfig，把 output_crop_hw 变成显式配置入口，并提供确定性的 center-crop slice 计算。
+在 [readout.py](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/src/models/optics/readout.py):52 实现 intensity_readout(field)，明确把 complex U_out_full 读成实值非负 I_out_full = re^2 + im^2。
+在 [readout.py](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/src/models/optics/readout.py):62 实现 center_crop_2d，crop 越界会显式报错，不再把切片逻辑散落到调用方或脚本里。
+在 [diffractive_decoder.py](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/src/models/optics/diffractive_decoder.py):165 给 decoder 增加 readout_config，但没有改 propagation.py 的数值核心。
+在 [diffractive_decoder.py](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/src/models/optics/diffractive_decoder.py):295 保留独立传播链 _propagate_from_field，把 U0 -> U_out_full 与 readout/crop 解耦。
+在 [diffractive_decoder.py](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/src/models/optics/diffractive_decoder.py):345 新增 readout_from_field，统一生成 I_out_full 和 I_out_roi。
+在 [diffractive_decoder.py](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/src/models/optics/diffractive_decoder.py):360 和 [diffractive_decoder.py](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/src/models/optics/diffractive_decoder.py):383 把 public forward_from_field / forward_from_phase / forward 接成显式返回结构，默认至少包含 U_out_full、I_out_full、I_out_roi；从 phase 入口还会保留 U0，return_intermediates=True 时继续附带传播中间量。
+Closeout
+
+变更总结：现在 optical module 已能完整输出 frozen Stage 3 前半链路，full-grid 和 ROI 被明确区分；crop 是显式 center crop，且由 output_crop_hw 控制。
+最小自检已跑通：随机输入下 U_out_full 为 complex tensor，I_out_full/I_out_roi 为实值非负；output_crop_hw=(20,20) 和 (12,12) 时 ROI shape 正确变化；output_crop_hw=(64,64) 会显式报错；改变输入 phase 后，I_out_full 和 I_out_roi 都变化，平均差异约 1.75e-03 和 2.85e-03。
+刻意后置的内容：normalized MAE / PSNR / SSIM 接口本身、Issue 4 的 forward sanity script、Issue 5 的 fitting loop、任何 electrical decoder / trainer / joint training。
+说明：这次仍然没有把 smoke test 文件落到 tests/，因为此前 Windows sandbox 对新增 test 文件的 patch 继续不稳定；但代码已用内联命令完成同等验证。
+下一步建议：直接进入 Issue 4，补正式的 L=1/3/5 forward sanity checks 和 full-grid / ROI 可视化检查，不要越级进入训练。
+

--- a/docs/ai/CodexFeedback/stage3/feedback_stage3-3_patch.md
+++ b/docs/ai/CodexFeedback/stage3/feedback_stage3-3_patch.md
@@ -1,0 +1,20 @@
+本次 closeout patch 修改了以下文件：
+
+新增 [check_optical_readout.py](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/scripts/check_optical_readout.py)
+更新 [README.md](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/README.md)
+新增的验证入口：
+
+可复用脚本入口：python scripts/check_optical_readout.py
+这个脚本会基于当前已经落地的 decoder API，重新执行 Issue 3 的 readout/crop 验证，不会改 propagation core，也不会引入 trainer、拟合流程或新的 Stage 3 contract。
+这次任务没有再修改 diffractive_decoder.py，也没有重设计 decoder；只是把已有 Issue 3 行为固化成仓库内可重复运行的验证资产。
+对 5 个必需检查项的覆盖情况：
+
+U_out_full 是 complex tensor：已覆盖
+I_out_full 和 I_out_roi 是实值且非负：已覆盖
+修改 output_crop_hw 后，ROI shape 正确变化：已覆盖，脚本检查了 (20, 20) 和 (12, 12)
+oversized crop 会显式报错：已覆盖，脚本断言会抛出 ValueError
+修改输入 phase 后，I_out_full 和 I_out_roi 都会变化：已覆盖，脚本会断言差异非零并打印结果
+当前状态：
+
+新脚本已经实际运行通过，并完成了全部 5 项检查。
+从 Issue 3 的收尾角度看，现在可以认为 Issue 3 已经可以干净关闭，因为 readout/crop contract 不再只依赖聊天记录或一次性 inline 命令，而是有了仓库内可复跑的验证入口。

--- a/docs/ai/prompt/stage3/prompt_stage3-1.md
+++ b/docs/ai/prompt/stage3/prompt_stage3-1.md
@@ -1,0 +1,167 @@
+Task: Record finalized Stage-3 design decisions into project documentation.
+
+Context
+-------
+Stage-3 planning documents were generated earlier:
+
+- docs/integration/stage3_unresolved_params.md
+- docs/plan/stage3_contract_freeze.md
+- AGENTS.md
+
+Those documents intentionally listed several "Immediate Decisions" that required
+human confirmation before starting optical implementation.
+
+The human review has now finalized those decisions.
+
+Your task is NOT to redesign anything.
+Your task is to **record the finalized decisions clearly in the documentation**
+so that future development agents can rely on them.
+
+Do NOT modify any source code.
+Do NOT introduce new architecture.
+Only update documentation.
+
+---------------------------------------------------------------------
+
+Human-approved Stage-3 decisions
+--------------------------------
+
+Decision 1 — Layer semantics
+
+Stage-3 defines **L as the number of trainable diffractive phase masks**.
+
+- L ∈ {1, 3, 5}
+- Final propagation to the sensor plane is NOT counted as a layer
+- Propagation distances must be controlled by an explicit distance schedule
+- No implicit layer-index special cases (e.g. `layer == 2`)
+
+Decision 2 — Distance representation
+
+Propagation distances must use **ordered list with explicit semantics**.
+
+Configuration must explicitly distinguish:
+
+- input_to_first
+- inter_layer distances
+- last_to_sensor
+
+Example schema (conceptual):
+
+distance_schedule:
+  input_to_first: ...
+  inter_layer: [...]
+  last_to_sensor: ...
+
+This schema is now frozen for Stage-3.
+
+Decision 3 — ROI crop contract
+
+Stage-3 adopts **explicit center-crop ROI extraction**.
+
+Pipeline must be:
+
+phi_lr
+ → U0
+ → U_out_full
+ → I_out_full
+ → I_out_roi (center crop)
+ → loss / metrics
+
+Crop must NOT be hidden in scripts.
+
+Use configuration parameters such as:
+
+output_crop_hw
+
+The exact crop indexing logic must be deterministic.
+
+Decision 4 — Supervision contract
+
+Stage-3 uses:
+
+**full-grid forward + ROI supervision**
+
+Meaning:
+
+- optical propagation produces `I_out_full`
+- loss and main metrics are computed ONLY on `I_out_roi`
+- `I_out_full` is retained for visualization, diagnostics, and physics checks
+
+Decision 5 — Normalized MAE implementation
+
+Stage-3 normalized MAE default implementation:
+
+sigma = sum(target) / sum(pred)
+
+Computed per sample on ROI pixels.
+
+Batch aggregation:
+mean over samples.
+
+Numerical protection:
+epsilon added to denominator.
+
+This is the **Stage-3 engineering default**.
+Further paper-exact alignment may happen in later stages.
+
+---------------------------------------------------------------------
+
+Required documentation updates
+------------------------------
+
+1️⃣ Update  
+`docs/integration/stage3_unresolved_params.md`
+
+- Mark the five "Immediate Decisions" as **RESOLVED**
+- Move them to a section like:
+
+    "Finalized Stage-3 Decisions"
+
+- Keep explanation concise
+- Remove wording that implies they are still undecided
+
+2️⃣ Update  
+`docs/plan/stage3_contract_freeze.md`
+
+Ensure the contract section explicitly reflects:
+
+- L semantics
+- distance schedule schema
+- ROI crop contract
+- ROI supervision rule
+- normalized MAE default
+
+Do NOT expand scope of Stage-3.
+
+3️⃣ Update  
+`AGENTS.md`
+
+Add a short note under the Stage-3 planning section:
+
+"Immediate design decisions have been finalized.
+Future agents must follow the rules defined in:
+
+- stage3_contract_freeze.md
+- stage3_unresolved_params.md"
+
+This ensures coding agents read these rules before implementing optics modules.
+
+---------------------------------------------------------------------
+
+Constraints
+-----------
+
+- Do NOT modify project architecture
+- Do NOT change Stage-3 scope
+- Do NOT modify source code
+- Only update documentation clarity and decision status
+
+---------------------------------------------------------------------
+
+Output summary
+
+After editing, report:
+
+- which files were modified
+- what sections were updated
+- confirmation that the five decisions are now recorded as finalized

--- a/docs/ai/prompt/stage3/prompt_stage3-2.md
+++ b/docs/ai/prompt/stage3/prompt_stage3-2.md
@@ -1,0 +1,152 @@
+你正在当前仓库中实现 Stage 3 / Issue 2。
+
+任务背景：
+这是一个 optical neural network 复现项目，目标论文是《Super-resolution image display using a diffractive optical network / decoder》。
+当前不是重新设计系统，也不是移植 upstream 全项目，而是在现有 Stage 3 contract freeze 基础上继续实现。
+
+你必须先严格遵循以下文档中的已冻结决策与边界：
+
+- docs/plan/stage3_contract_freeze.md
+- docs/integration/stage3_unresolved_params.md
+- docs/integration/sdn_inventory.md
+- docs/integration/sdn_gap_analysis.md
+- docs/plan/stage3_sdn_porting_plan.md
+- AGENTS.md
+
+当前阶段定位：
+
+- Stage 3 的正式目标是构建一个 paper-aligned optical decoder skeleton，并先验证 optical module 本身的可验证性
+- 当前不是最终 end-to-end SR system
+- 当前不是 final joint training
+- 当前不是 final paper full-setting reproduction
+
+本次只实现：
+Issue 2 — optical propagation core
+
+Issue 2 标题：
+feat: extract paper-aligned propagation core from sdn_upstream
+
+核心目标：
+从 upstream 中抽取 propagation primitive，并在当前 repo 内重写为一个干净、独立、config-driven 的 optics core。
+不要把 upstream 的任务层、数据层、head、electrical decoder 一起带进来。
+
+你要完成的事情：
+
+1. 从 upstream 参考并迁移 propagation kernel / FFT / IFFT / phase-mask modulation 的核心逻辑
+
+2. 重写为当前 repo 内新的 optics 模块
+
+3. 删除 classification head / electrical decoder / Pet 数据依赖 / OAM-LG-HG 任务耦合
+
+4. 删除 upstream 中依赖 layer index 的隐式 final propagation 逻辑，尤其不能保留 `layer == 2` 之类硬编码
+
+5. 使用显式的 layer semantics：
+
+   - L 表示 trainable diffractive phase masks 数量
+   - final propagation to sensor plane 不计入 L
+
+6. 使用显式 distance schedule schema：
+
+   ```yaml
+   distance_schedule:
+     input_to_first: ...
+     inter_layer: [...]
+     last_to_sensor: ...
+   ```
+
+1. 明确内部 field 表示，优先使用 complex tensor；
+    如果不方便，也必须使用明确命名的 real/imag 表示，禁止继续沿用含混的 amp/phase 命名
+2. 提供 clean 接口，为后续 Issue 3 的 readout / crop 做好衔接，但本次不要把 Issue 3 一起做完
+
+当前已冻结的 contract，你必须遵守：
+
+- 最小链路是：
+   phi_lr -> U0 -> U_out_full -> I_out_full -> I_out_roi -> loss/metrics
+- 但本次 Issue 2 只负责把前半段做干净：
+   phi_lr -> U0 -> U_out_full
+- phase-only 主线默认振幅固定为 1
+- full-grid 与 ROI supervision 的 contract 已冻结，但 crop/readout 是 Issue 3，不要在本次实现中偷渡完整损失链
+
+建议落地目录（优先按此执行）：
+
+- src/models/optics/phase_utils.py
+- src/models/optics/propagation.py
+- src/models/optics/diffractive_decoder.py
+
+建议模块职责：
+
+1. phase_utils.py
+   - 提供 phase-only -> complex coherent field 的工具函数
+   - 例如 `phase_to_field(phi)`，默认 amplitude=1
+   - shape / dtype / device 处理要清晰
+   - 不写任务层逻辑
+2. propagation.py
+   - 封装单次传播 primitive
+   - 封装 phase mask modulation primitive
+   - 不依赖数据集、训练器、electrical decoder、head
+   - 不把 distance / grid 参数硬编码在源码里
+3. diffractive_decoder.py
+   - 构建 paper-aligned optical decoder skeleton
+   - 支持 L=1/3/5
+   - forward 主流程要清晰：
+      a. phi_lr -> U0
+      b. input_to_first propagation
+      c. 逐层 phase mask modulation
+      d. 层间 propagation
+      e. last_to_sensor propagation
+      f. 返回 U_out_full
+   - 需要体现 config 驱动的 distance / grid / padding
+   - 不包含 readout head / crop / loss / trainer
+
+你必须避免的事情：
+
+- 不要直接 vendoring 整个 upstream 目录到 src/
+- 不要复制 upstream 的整套类结构和任务接口
+- 不要引入 classification head
+- 不要引入 electrical decoder
+- 不要引入 reference readout
+- 不要写 Pet / OAM / LG / HG 数据依赖
+- 不要实现 end-to-end trainer
+- 不要提前做 quantization / misalignment / hardware robustness
+- 不要进行与当前任务无关的大规模重构
+- 不要把配置写死在代码里
+
+实现风格要求：
+
+- 小步修改，尽量局部
+- 配置优先，不写死数值
+- 注释说明“哪些逻辑来自 upstream optics primitive，哪些是当前 repo 的 contract 重写”
+- 对关键 shape、dtype、complex field 处理写清楚
+- 保持 import 路径整洁
+- 代码必须可读、可验证、可追踪
+
+建议增加的最小自检：
+
+- 一个随机 phase 输入能 forward 成功
+- L=1/3/5 都能实例化
+- 输出无 NaN / Inf
+- 改变输入 phase 或 mask phase 后，U_out_full 会变化
+- 不依赖任何 electrical decoder 才能运行
+
+本次交付物：
+
+- src/models/optics/phase_utils.py
+- src/models/optics/propagation.py
+- src/models/optics/diffractive_decoder.py
+- 若有必要，补一个极小的 smoke test 或最小使用示例，但不要扩展成完整 script runner
+
+验收标准：
+
+- optical core 可独立 import 和 forward
+- 不再出现 `layer == 2` 这类硬编码
+- L 的语义正确
+- distance_schedule 显式、清晰
+- 返回结果是 clean 的 U_out_full
+- 没有把 upstream 的任务层耦合带进来
+
+输出要求：
+
+1. 先简短说明你理解到的 contract 和本次实现边界
+2. 再给出你准备修改/新增的文件列表
+3. 然后实施代码修改
+4. 最后给出简短的变更总结、风险点和建议下一步（应指向 Issue 3，而不是越级做 Stage 4）

--- a/docs/ai/prompt/stage3/prompt_stage3-3.md
+++ b/docs/ai/prompt/stage3/prompt_stage3-3.md
@@ -1,0 +1,146 @@
+你正在当前仓库中继续 Stage 3 implementation。
+
+当前状态：
+- Stage 3 planning freeze 已完成
+- Issue 1（contract freeze）已完成
+- Issue 2（optical propagation core）已完成
+- 当前 optical core 已经能完成：
+  phi_lr -> U0 -> U_out_full
+- 现在进入 Issue 3 的实现，不要回头重写 Issue 2，也不要提前做 Issue 4/5
+
+你必须严格遵循以下文档：
+- AGENTS.md
+- docs/plan/stage3_contract_freeze.md
+- docs/integration/stage3_unresolved_params.md
+- docs/plan/stage3_sdn_porting_plan.md
+- docs/integration/sdn_gap_analysis.md
+
+你必须接受以下 frozen contract，而不是重新解释：
+1. Stage 3 最小链路固定为：
+   phi_lr -> U0 -> U_out_full -> I_out_full -> I_out_roi -> loss/metrics
+2. Stage 3 固定采用 full-grid forward + ROI supervision
+3. crop 必须是显式、确定性的 center crop
+4. crop 逻辑不能隐藏在脚本临时逻辑中
+5. output_crop_hw 等 crop 参数必须由配置控制
+6. U_out_full 和 I_out_full 必须保留，不能只返回 ROI
+7. 当前 Stage 3 optical module 只负责 direct optical readout，不引入 electrical decoder
+8. 当前 Issue 3 只实现 readout/crop contract，不提前做 trainer、joint training、capacity experiment
+
+本次任务：
+Issue 3.3 — 在现有 optics core 上实现 output-plane intensity readout + ROI crop contract
+
+本次目标：
+把当前链路从
+  phi_lr -> U0 -> U_out_full
+扩展为
+  phi_lr -> U0 -> U_out_full -> I_out_full -> I_out_roi
+并把 full-grid / ROI 的返回接口正式落地。
+
+你要完成的核心工作：
+1. 增加 intensity readout
+   - 输入：complex field U_out_full
+   - 输出：I_out_full = |U_out_full|^2
+   - 必须显式、可读、无任务耦合
+   - 不要把 intensity readout 混进训练脚本临时写法
+
+2. 增加 ROI crop
+   - 输入：I_out_full
+   - 输出：I_out_roi
+   - 默认采用显式 center crop
+   - crop 参数必须来自配置，例如 output_crop_hw
+   - 必须检查 crop 尺寸不能超过 full-grid 尺寸
+   - 需要给出清晰、可复用的 crop spec / helper，而不是把切片散落在调用方
+
+3. 区分 full-grid 和 ROI 输出
+   - optical forward 结果中必须明确区分：
+     - U_out_full
+     - I_out_full
+     - I_out_roi
+   - 不允许只返回一个 intensity tensor 然后让调用方猜它是不是 crop 后结果
+
+4. 为后续 normalized MAE / PSNR / SSIM 接口留好位置
+   - 本次不要完整实现训练器
+   - 但返回结构必须已经适合后续 loss-ready tensor 使用
+
+推荐落地文件：
+- src/models/optics/readout.py
+- src/models/optics/diffractive_decoder.py
+- 如确有必要，可小幅更新相关 config schema / dataclass
+不要做无关目录重构。
+
+推荐模块职责：
+1. readout.py
+   - intensity_readout(field) -> intensity
+   - center_crop_2d(x, crop_hw) -> roi
+   - 或者一个小型 ReadoutConfig / CropSpec helper
+   - 职责要单一，不耦合 trainer / dataset / metrics
+
+2. diffractive_decoder.py
+   - 在现有 forward_from_phase / forward_from_field 基础上接上 readout
+   - 保持现有 optical propagation core 不被污染
+   - 返回结果建议为 dict 或清晰结构体，至少包含：
+     {
+       "U_out_full": ...,
+       "I_out_full": ...,
+       "I_out_roi": ...,
+     }
+   - 若现有 return_intermediates 已存在，应在不破坏现有语义的前提下扩展
+
+必须遵守的实现边界：
+- 不要重写 propagation.py 的核心数值逻辑，除非修一个明显阻塞 bug
+- 不要引入 electrical decoder
+- 不要引入 classification head
+- 不要写 end-to-end trainer
+- 不要提前实现 Issue 5 的 single-sample fitting loop
+- 不要提前实现 quantization / misalignment / efficiency term
+- 不要把 crop 逻辑藏到 scripts/ 里
+- 不要把配置写死在源码里
+- 不要因为方便而丢掉 U_out_full / I_out_full
+
+建议加入的最小检查：
+1. 对随机 phase 输入，能得到：
+   - U_out_full: complex tensor
+   - I_out_full: real nonnegative tensor
+   - I_out_roi: real nonnegative tensor
+2. I_out_roi 的 shape 与 output_crop_hw 一致
+3. 当 crop_hw 改变时，ROI shape 正确变化
+4. crop 居中逻辑正确，且不会 silently 越界
+5. 若用户请求 full-grid 输出，不能只给 ROI
+6. 改变输入 phase 后，I_out_full 和 I_out_roi 都会变化
+
+建议配置约束：
+- output_crop_hw 必须显式配置
+- 如果已有 layer grid / propagation grid 配置，不要破坏现有 schema
+- 若需要新增 readout 配置，保持最小化，不要发明复杂配置系统
+
+代码风格要求：
+- 小步修改，局部实现
+- clear naming，禁止含混 amp/phase 命名继续污染接口
+- 对 shape、dtype、complex/real 变换写清楚注释
+- 所有新增逻辑应服务于当前 frozen contract
+- 不要为未来 Stage 4 过度设计
+
+本次交付物：
+- src/models/optics/readout.py
+- diffractive_decoder.py 中接入 readout/crop 的修改
+- 如有必要，最小 config / dataclass 更新
+- 若环境允许，补一个极小 smoke test 或最小示例；如果 tests 落地再次受 Windows sandbox 问题阻塞，则至少确保代码中保留可运行的最小自检入口思路，但不要编造已提交的文件
+
+验收标准：
+1. 当前 optical module 已能完整输出：
+   phi_lr -> U0 -> U_out_full -> I_out_full -> I_out_roi
+2. I_out_full 与 I_out_roi 被明确区分
+3. ROI crop 是显式 center crop，不隐藏在脚本中
+4. crop 参数由配置控制
+5. I_out_full / I_out_roi 可用于后续 loss-ready tensor
+6. 没有引入 electrical decoder / classification head / joint trainer
+7. 本次修改仍严格停留在 Stage 3 / Issue 3 范围内
+
+输出要求：
+1. 先简短复述你理解到的 frozen contract 与本次边界
+2. 列出将新增/修改的文件
+3. 再实施代码修改
+4. 最后给出：
+   - 变更总结
+   - 尚未完成但刻意后置的内容
+   - 下一步建议（应指向 Issue 4 forward sanity，而不是越级到训练）

--- a/docs/ai/prompt/stage3/prompt_stage3-3_patch1
+++ b/docs/ai/prompt/stage3/prompt_stage3-3_patch1
@@ -1,0 +1,64 @@
+Task: add a minimal reproducible validation asset for Stage 3 Issue 3 readout/crop.
+
+Context
+-------
+Issue 3 implementation has already landed the Stage 3 readout/crop chain:
+
+phi_lr -> U0 -> U_out_full -> I_out_full -> I_out_roi
+
+Current implementation work is acceptable and should be preserved.
+Do NOT redesign the decoder.
+Do NOT revisit propagation core.
+Do NOT start Issue 4 sanity checks yet.
+Do NOT add trainer, fitting loop, metrics integration, or joint training.
+
+The remaining gap is that Issue 3 validation currently exists only as inline/manual checks,
+not as a reusable repository asset.
+
+Goal
+----
+Create a minimal reproducible validation entry for Issue 3 so that the readout/crop behavior
+can be rerun later without relying on chat logs or one-off inline commands.
+
+Scope
+-----
+Only do a small closeout patch for Issue 3.
+
+Preferred output:
+- a lightweight script under `scripts/` or equivalent location
+  (for example `scripts/check_optical_readout.py`)
+OR
+- if repository constraints make that impossible, add a clearly documented runnable validation note
+  in the appropriate docs/execution location with exact command examples.
+
+Required checks
+---------------
+The validation asset must cover at least:
+
+1. `U_out_full` is complex
+2. `I_out_full` and `I_out_roi` are real and nonnegative
+3. changing `output_crop_hw` changes ROI shape correctly
+4. oversized crop raises an explicit error
+5. changing input phase changes `I_out_full` and `I_out_roi`
+
+Constraints
+-----------
+- Do NOT change the Stage 3 contract
+- Do NOT rewrite public forward API unless absolutely necessary for the validation script
+- Do NOT add Issue 4 content
+- Do NOT add normalized MAE / PSNR / SSIM here
+- Keep the patch minimal and localized
+
+Optional
+--------
+If a tiny doc update is natural, add a short Issue 3 closeout note referencing
+the validation entry point, but do not expand into a larger documentation rewrite.
+
+Report back
+-----------
+After editing, report:
+
+- which files were modified
+- what validation entry was added
+- whether the validation now covers all 5 checks above
+- whether Issue 3 can now be considered cleanly closed

--- a/scripts/check_optical_readout.py
+++ b/scripts/check_optical_readout.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+"""Minimal reproducible validation for Stage 3 Issue 3 readout/crop."""
+
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+import torch
+
+# Keep `python scripts/check_optical_readout.py` working from repo root.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.models.optics.diffractive_decoder import DiffractiveDecoder
+
+
+def build_decoder(output_crop_hw: tuple[int, int]) -> DiffractiveDecoder:
+    return DiffractiveDecoder(
+        num_diffractive_layers=3,
+        wavelength=532e-9,
+        pixel_pitch=8e-6,
+        grid_config={
+            "input_pattern_hw": (24, 24),
+            "layer_hw": (32, 32),
+            "propagation_hw": (48, 48),
+        },
+        distance_schedule={
+            "input_to_first": 0.01,
+            "inter_layer": [0.02, 0.02],
+            "last_to_sensor": 0.03,
+        },
+        readout_config={
+            "output_crop_hw": output_crop_hw,
+        },
+        phase_mask_config={
+            "init_mode": "zeros",
+            "phase_mapping": "tanh",
+            "phase_range": (-math.pi, math.pi),
+        },
+    )
+
+
+def assert_real_nonnegative(tensor: torch.Tensor, *, name: str) -> None:
+    if tensor.is_complex():
+        raise AssertionError(f"{name} must be real-valued, got dtype {tensor.dtype}.")
+    if not torch.isfinite(tensor).all():
+        raise AssertionError(f"{name} must contain only finite values.")
+    if (tensor < 0).any():
+        raise AssertionError(f"{name} must be nonnegative.")
+
+
+def main() -> None:
+    torch.manual_seed(7)
+
+    phi_base = torch.zeros(1, 1, 24, 24, dtype=torch.float32)
+    phi_perturbed = phi_base.clone()
+    phi_perturbed[..., 12, 12] = 0.5
+
+    decoder_crop_20 = build_decoder((20, 20))
+    output_base = decoder_crop_20(phi_base)
+    output_perturbed = decoder_crop_20(phi_perturbed)
+
+    if not output_base["U_out_full"].is_complex():
+        raise AssertionError("U_out_full must be complex-valued.")
+
+    assert_real_nonnegative(output_base["I_out_full"], name="I_out_full")
+    assert_real_nonnegative(output_base["I_out_roi"], name="I_out_roi")
+
+    if tuple(output_base["I_out_full"].shape) != (1, 1, 48, 48):
+        raise AssertionError(
+            f"I_out_full shape mismatch: expected (1, 1, 48, 48), got {tuple(output_base['I_out_full'].shape)}."
+        )
+    if tuple(output_base["I_out_roi"].shape) != (1, 1, 20, 20):
+        raise AssertionError(
+            f"I_out_roi shape mismatch for crop (20, 20): got {tuple(output_base['I_out_roi'].shape)}."
+        )
+
+    decoder_crop_12 = build_decoder((12, 12))
+    output_crop_12 = decoder_crop_12(phi_base)
+    if tuple(output_crop_12["I_out_roi"].shape) != (1, 1, 12, 12):
+        raise AssertionError(
+            f"I_out_roi shape mismatch for crop (12, 12): got {tuple(output_crop_12['I_out_roi'].shape)}."
+        )
+
+    oversized_crop_error: str | None = None
+    try:
+        build_decoder((64, 64))(phi_base)
+    except ValueError as exc:
+        oversized_crop_error = str(exc)
+    if oversized_crop_error is None:
+        raise AssertionError("Oversized crop must raise an explicit ValueError.")
+
+    full_delta = torch.mean(
+        torch.abs(output_base["I_out_full"] - output_perturbed["I_out_full"])
+    ).item()
+    roi_delta = torch.mean(
+        torch.abs(output_base["I_out_roi"] - output_perturbed["I_out_roi"])
+    ).item()
+    if full_delta <= 1e-6:
+        raise AssertionError(f"I_out_full should change when input phase changes, got {full_delta}.")
+    if roi_delta <= 1e-6:
+        raise AssertionError(f"I_out_roi should change when input phase changes, got {roi_delta}.")
+
+    print("Stage 3 Issue 3 readout/crop validation passed.")
+    print("check_1: U_out_full is complex")
+    print("check_2: I_out_full and I_out_roi are real and nonnegative")
+    print("check_3: output_crop_hw changes ROI shape correctly")
+    print("check_4: oversized crop raises an explicit error")
+    print("check_5: changing input phase changes I_out_full and I_out_roi")
+    print(f"full_shape={tuple(output_base['I_out_full'].shape)}")
+    print(f"roi_shape_20={tuple(output_base['I_out_roi'].shape)}")
+    print(f"roi_shape_12={tuple(output_crop_12['I_out_roi'].shape)}")
+    print(f"oversized_crop_error={oversized_crop_error}")
+    print(f"full_delta={full_delta:.6e}")
+    print(f"roi_delta={roi_delta:.6e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/models/optics/diffractive_decoder.py
+++ b/src/models/optics/diffractive_decoder.py
@@ -1,15 +1,16 @@
-"""Paper-aligned diffractive decoder skeleton for Stage 3 Issue 2.
+"""Paper-aligned diffractive decoder skeleton for Stage 3 Issues 2 and 3.
 
-This module intentionally implements only the optical core:
+This module now implements the frozen Stage 3 front-half optical contract:
 
-`phi_lr -> U0 -> U_out_full`
+`phi_lr -> U0 -> U_out_full -> I_out_full -> I_out_roi`
 
-Intensity readout, ROI crop, and optical losses belong to later Stage 3 issues.
-The scheduling here is explicit and config-driven:
+The scheduling remains explicit and config-driven:
 
 - `L` means the number of trainable diffractive phase masks.
 - propagation from the last mask to the sensor plane is explicit.
 - there is no hidden `layer == 2` or `depth + 1` logic.
+
+Optical loss / metric computation still belongs to later Stage 3 issues.
 """
 
 from __future__ import annotations
@@ -31,6 +32,7 @@ from src.models.optics.phase_utils import (
     validate_single_channel_image,
 )
 from src.models.optics.propagation import PropagationOperator, apply_phase_modulation
+from src.models.optics.readout import ReadoutConfig, center_crop_2d, intensity_readout
 
 
 @dataclass(frozen=True)
@@ -168,6 +170,7 @@ class DiffractiveDecoder(nn.Module):
         pixel_pitch: float | Sequence[float],
         grid_config: OpticalGridConfig | Mapping[str, object],
         distance_schedule: DistanceSchedule | Mapping[str, object],
+        readout_config: ReadoutConfig | Mapping[str, object],
         phase_mask_config: PhaseMaskConfig | Mapping[str, object] | None = None,
         kernel_dtype: torch.dtype = torch.float32,
     ) -> None:
@@ -186,6 +189,7 @@ class DiffractiveDecoder(nn.Module):
         self.pixel_pitch = normalize_spacing(pixel_pitch, name="pixel_pitch")
         self.grid_config = OpticalGridConfig.from_config(grid_config)
         self.distance_schedule = DistanceSchedule.from_config(distance_schedule)
+        self.readout_config = ReadoutConfig.from_config(readout_config)
         self.phase_mask_config = PhaseMaskConfig.from_config(phase_mask_config)
         self.distance_schedule.validate_for_layers(self.num_diffractive_layers)
 
@@ -288,12 +292,12 @@ class DiffractiveDecoder(nn.Module):
             fill_value=0.0,
         )
 
-    def forward_from_field(
+    def _propagate_from_field(
         self,
         U0: torch.Tensor,
         *,
         return_intermediates: bool = False,
-    ) -> torch.Tensor | dict[str, torch.Tensor | list[torch.Tensor]]:
+    ) -> dict[str, torch.Tensor | list[torch.Tensor]]:
         """Run `U0 -> U_out_full` with explicit Stage 3 propagation semantics."""
         ensure_complex_field(
             U0,
@@ -324,17 +328,57 @@ class DiffractiveDecoder(nn.Module):
                     fields_after_inter_layer.append(field)
 
         U_out_full = self.last_to_sensor(field)
-        if not return_intermediates:
-            return U_out_full
-
-        return {
-            "U0": U0,
-            "field_after_input_to_first": field_after_input_to_first,
-            "phase_masks_full": phase_masks_full,
-            "fields_after_mask_modulation": fields_after_mask_modulation,
-            "fields_after_inter_layer": fields_after_inter_layer,
+        output: dict[str, torch.Tensor | list[torch.Tensor]] = {
             "U_out_full": U_out_full,
         }
+        if return_intermediates:
+            output.update(
+                {
+                    "field_after_input_to_first": field_after_input_to_first,
+                    "phase_masks_full": phase_masks_full,
+                    "fields_after_mask_modulation": fields_after_mask_modulation,
+                    "fields_after_inter_layer": fields_after_inter_layer,
+                }
+            )
+        return output
+
+    def readout_from_field(self, U_out_full: torch.Tensor) -> dict[str, torch.Tensor]:
+        """Convert full-grid output field into full-grid and ROI intensities."""
+        ensure_complex_field(
+            U_out_full,
+            name="U_out_full",
+            expected_hw=self.grid_config.propagation_hw,
+        )
+
+        I_out_full = intensity_readout(U_out_full)
+        I_out_roi = center_crop_2d(I_out_full, self.readout_config)
+        return {
+            "I_out_full": I_out_full,
+            "I_out_roi": I_out_roi,
+        }
+
+    def forward_from_field(
+        self,
+        U0: torch.Tensor,
+        *,
+        return_intermediates: bool = False,
+    ) -> dict[str, torch.Tensor | list[torch.Tensor]]:
+        """Run `U0 -> U_out_full -> I_out_full -> I_out_roi`."""
+        propagation_output = self._propagate_from_field(
+            U0,
+            return_intermediates=return_intermediates,
+        )
+        U_out_full = propagation_output["U_out_full"]
+        if not isinstance(U_out_full, torch.Tensor):
+            raise RuntimeError("U_out_full must be a tensor.")
+
+        output: dict[str, torch.Tensor | list[torch.Tensor]] = {
+            "U_out_full": U_out_full,
+            **self.readout_from_field(U_out_full),
+        }
+        if return_intermediates:
+            output.update(propagation_output)
+        return output
 
     def forward_from_phase(
         self,
@@ -342,15 +386,10 @@ class DiffractiveDecoder(nn.Module):
         *,
         amplitude: torch.Tensor | None = None,
         return_intermediates: bool = False,
-    ) -> torch.Tensor | dict[str, torch.Tensor | list[torch.Tensor]]:
-        """Run the Stage 3 front-half chain `phi_lr -> U0 -> U_out_full`."""
+    ) -> dict[str, torch.Tensor | list[torch.Tensor]]:
+        """Run the Stage 3 optical chain `phi_lr -> U0 -> U_out_full -> I_out_full -> I_out_roi`."""
         U0 = self.build_input_field(phi_lr, amplitude=amplitude)
         output = self.forward_from_field(U0, return_intermediates=return_intermediates)
-        if not return_intermediates:
-            return output
-
-        if not isinstance(output, dict):
-            raise RuntimeError("Expected a dictionary when return_intermediates=True.")
         output["U0"] = U0
         return output
 
@@ -360,7 +399,7 @@ class DiffractiveDecoder(nn.Module):
         *,
         amplitude: torch.Tensor | None = None,
         return_intermediates: bool = False,
-    ) -> torch.Tensor | dict[str, torch.Tensor | list[torch.Tensor]]:
+    ) -> dict[str, torch.Tensor | list[torch.Tensor]]:
         return self.forward_from_phase(
             phi_lr,
             amplitude=amplitude,

--- a/src/models/optics/readout.py
+++ b/src/models/optics/readout.py
@@ -1,0 +1,91 @@
+"""Output-plane readout helpers for the Stage 3 optical decoder contract.
+
+This module keeps readout concerns separate from propagation:
+
+- `intensity_readout` converts a complex field into real intensity.
+- `ReadoutConfig` owns the explicit `output_crop_hw` contract.
+- `center_crop_2d` performs deterministic center cropping on the full grid.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+import torch
+
+from src.models.optics.phase_utils import ensure_complex_field, normalize_hw
+
+
+@dataclass(frozen=True)
+class ReadoutConfig:
+    """Config for Stage 3 output-plane readout."""
+
+    output_crop_hw: tuple[int, int]
+
+    @classmethod
+    def from_config(cls, config: "ReadoutConfig | Mapping[str, object]") -> "ReadoutConfig":
+        if isinstance(config, cls):
+            return config
+        if not isinstance(config, Mapping):
+            raise TypeError("readout_config must be a ReadoutConfig or a mapping.")
+        return cls(
+            output_crop_hw=normalize_hw(config["output_crop_hw"], name="output_crop_hw"),
+        )
+
+    def center_crop_slices(self, full_hw: tuple[int, int]) -> tuple[slice, slice]:
+        """Build deterministic center-crop slices for a full propagation grid."""
+        full_h, full_w = normalize_hw(full_hw, name="full_hw")
+        crop_h, crop_w = self.output_crop_hw
+
+        if crop_h > full_h or crop_w > full_w:
+            raise ValueError(
+                "output_crop_hw must fit inside the full propagation grid, "
+                f"got crop={self.output_crop_hw}, full={(full_h, full_w)}."
+            )
+
+        top = (full_h - crop_h) // 2
+        left = (full_w - crop_w) // 2
+        return (slice(top, top + crop_h), slice(left, left + crop_w))
+
+
+def intensity_readout(field: torch.Tensor) -> torch.Tensor:
+    """Read output-plane intensity from a complex field.
+
+    The returned tensor keeps the same `[B, 1, H, W]` layout, but is real and
+    nonnegative by construction.
+    """
+    ensure_complex_field(field, name="field")
+    return field.real.square() + field.imag.square()
+
+
+def center_crop_2d(
+    tensor: torch.Tensor,
+    crop_hw: tuple[int, int] | ReadoutConfig,
+) -> torch.Tensor:
+    """Crop the center ROI from a tensor using its last two dimensions."""
+    if tensor.ndim < 2:
+        raise ValueError(f"tensor must have at least 2 dimensions, got shape {tuple(tensor.shape)}.")
+
+    if isinstance(crop_hw, ReadoutConfig):
+        crop_config = crop_hw
+    else:
+        crop_config = ReadoutConfig(output_crop_hw=normalize_hw(crop_hw, name="output_crop_hw"))
+
+    crop_h, crop_w = crop_config.output_crop_hw
+    full_h, full_w = tensor.shape[-2:]
+    if crop_h > full_h or crop_w > full_w:
+        raise ValueError(
+            "output_crop_hw must fit inside the tensor spatial shape, "
+            f"got crop={(crop_h, crop_w)}, full={(full_h, full_w)}."
+        )
+
+    crop_h_slice, crop_w_slice = crop_config.center_crop_slices((full_h, full_w))
+    return tensor[..., crop_h_slice, crop_w_slice]
+
+
+__all__ = [
+    "ReadoutConfig",
+    "center_crop_2d",
+    "intensity_readout",
+]


### PR DESCRIPTION
implement Stage 3 optical readout/crop on top of the existing propagation core by adding explicit intensity readout, center-crop ROI extraction, configurable output_crop_hw, and clear full-grid vs ROI outputs so the decoder now exposes phi_lr -> U0 -> U_out_full -> I_out_full -> I_out_roi without introducing electrical decoder, trainer logic, or other out-of-scope Stage 4 features

ref: #19