### PR TITLE
docs(stage 3.8): update Stage 3 execution log, results summary, and design notes

### DIFF
--- a/docs/ai/CodexFeedback/stage3/feedback_stage3-1.md
+++ b/docs/ai/CodexFeedback/stage3/feedback_stage3-1.md
@@ -1,0 +1,18 @@
+已只更新文档，没有修改任何源码或实现代码。
+
+修改的文件：
+- [AGENTS.md](D:/AI%20project/ONN%20research/sdn-for-super-resolution-reproduction/AGENTS.md#L35)
+- [docs/integration/stage3_unresolved_params.md](D:/AI%20project/ONN%20research/sdn-for-super-resolution-reproduction/docs/integration/stage3_unresolved_params.md#L30)
+- [docs/plan/stage3_contract_freeze.md](D:/AI%20project/ONN%20research/sdn-for-super-resolution-reproduction/docs/plan/stage3_contract_freeze.md#L78)
+
+更新的内容：
+- [docs/integration/stage3_unresolved_params.md](D:/AI%20project/ONN%20research/sdn-for-super-resolution-reproduction/docs/integration/stage3_unresolved_params.md#L30) 新增了 `Finalized Stage-3 Decisions`，把 5 个 Immediate Decisions 全部标记为 `RESOLVED`，并移出“待拍板”语境；同时保留 `P1` / `P2` 作为仍可后续收敛的事项。
+- [docs/integration/stage3_unresolved_params.md](D:/AI%20project/ONN%20research/sdn-for-super-resolution-reproduction/docs/integration/stage3_unresolved_params.md#L63) 更新了使用说明，明确先执行 finalized decisions，再处理剩余 P1/P2。
+- [docs/plan/stage3_contract_freeze.md](D:/AI%20project/ONN%20research/sdn-for-super-resolution-reproduction/docs/plan/stage3_contract_freeze.md#L86) 在 contract 部分明确写入了 `L` 语义、distance schedule schema、center-crop ROI contract、ROI-only supervision 规则，以及 normalized MAE 的 Stage-3 默认实现。
+- [docs/plan/stage3_contract_freeze.md](D:/AI%20project/ONN%20research/sdn-for-super-resolution-reproduction/docs/plan/stage3_contract_freeze.md#L109) 新增了显式 `distance_schedule` schema。
+- [AGENTS.md](D:/AI%20project/ONN%20research/sdn-for-super-resolution-reproduction/AGENTS.md#L35) 在 Stage-3 planning freeze 小节下加入了短说明，要求后续 agent 先遵循 `stage3_contract_freeze.md` 和 `stage3_unresolved_params.md`。
+
+确认：
+- 5 项人审通过的 Stage-3 决策现在都已经记录为 finalized。
+- 文档中已明确这 5 项不再属于待拍板项。
+- 本次没有扩展 Stage-3 scope，也没有引入新架构。

--- a/docs/ai/CodexFeedback/stage3/feedback_stage3-7.md
+++ b/docs/ai/CodexFeedback/stage3/feedback_stage3-7.md
@@ -1,0 +1,40 @@
+我对本任务的理解是：只做 Stage 3 的接口整理，把 optical core 与未来 encoder 解耦，但不实现 encoder、不实现 joint model / joint trainer，也不改 Stage 3 已冻结的 optical/readout/crop 行为。目标是稳定 `forward_from_phase(...)`、`forward_from_field(...)` 的语义，并补一个最小的 phase-provider hook，让未来 Stage 4 只需要“提供 phase”就能接入。
+
+本次修改的文件：
+- 新增 [phase_provider.py](/d:/AI%20project/ONN%20research/sdn-for-super-resolution-reproduction/src/models/optics/phase_provider.py#L1)
+- 修改 [diffractive_decoder.py](/d:/AI%20project/ONN%20research/sdn-for-super-resolution-reproduction/src/models/optics/diffractive_decoder.py#L161)
+
+**变更总结**
+- 在 [phase_provider.py](/d:/AI%20project/ONN%20research/sdn-for-super-resolution-reproduction/src/models/optics/phase_provider.py#L26) 新增了 `PhaseProvider` protocol，约定“给一个上游 tensor，返回一个 real-valued `[B, 1, H, W]` phase tensor”。
+- 在 [phase_provider.py](/d:/AI%20project/ONN%20research/sdn-for-super-resolution-reproduction/src/models/optics/phase_provider.py#L40) 新增了最小 stub `DirectPhaseProvider`，它只是把调用方直接给的 phase 原样返回，用来表达“当前 Stage 3 默认仍是外部直接提供 phase”。
+- 在 [diffractive_decoder.py](/d:/AI%20project/ONN%20research/sdn-for-super-resolution-reproduction/src/models/optics/diffractive_decoder.py#L275) 把 `build_input_field(...)` 的 contract 写清楚了：输入是 real-valued phase tensor，decoder 负责 phase-to-field，默认 amplitude=1。
+- 在 [diffractive_decoder.py](/d:/AI%20project/ONN%20research/sdn-for-super-resolution-reproduction/src/models/optics/diffractive_decoder.py#L397) 明确了 `forward_from_field(...)` 只接收 complex coherent field，并直接进入 propagation/readout，不再承担任何 phase mapping 责任。
+- 在 [diffractive_decoder.py](/d:/AI%20project/ONN%20research/sdn-for-super-resolution-reproduction/src/models/optics/diffractive_decoder.py#L440) 明确了 `forward_from_phase(...)` 是稳定的 Stage 3 相位输入入口。
+- 在 [diffractive_decoder.py](/d:/AI%20project/ONN%20research/sdn-for-super-resolution-reproduction/src/models/optics/diffractive_decoder.py#L480) 新增了 `forward_from_phase_provider(...)`，它只做一件事：通过 provider 取 phase，再委托给 `forward_from_phase(...)`。这就是 future Stage 4 的接入点，但它本身不是 encoder 实现。
+
+**Phase-provider Hook**
+接口约束现在是：
+- provider 形态：可调用对象，满足 `PhaseProvider(upstream_input) -> phi_lr`
+- provider 输出：real-valued `torch.Tensor`
+- shape 语义：`[B, 1, H, W]`
+- batch 维：允许，且由 provider/caller 负责保持一致
+- dtype/device：provider 输出什么 dtype/device，decoder 就在该设备上继续执行，但 phase 必须是 real-valued
+- phase mapping 责任：provider 只“提供 phase-domain tensor”，不负责变成 field；decoder 仍通过 `forward_from_phase(...)` 内部完成 `phase -> U0`
+- 当前 Stage 3 默认用法：直接外部提供 `phi_lr`，或者用 `DirectPhaseProvider` 包一层后走 `forward_from_phase_provider(...)`
+- future Stage 4 接入位置：learned encoder 只需要产出满足上述 contract 的 phase tensor，然后喂给 `forward_from_phase(...)` 或 `forward_from_phase_provider(...)`
+
+**刻意未实现的 Stage 4 内容**
+- 没有实现任何 encoder module
+- 没有实现 joint model / joint trainer
+- 没有实现 end-to-end training loop
+- 没有改 loss、metrics、ROI supervision contract
+- 没有把 dataset、trainer、loss 逻辑塞进 provider hook
+- 没有重构 optics core 的 propagation/readout 数值逻辑
+
+**验证与风险**
+- `py_compile` 已通过：`phase_provider.py`、`diffractive_decoder.py`
+- inline smoke 已通过：`forward_from_phase(...)`、`forward_from_field(...)`、`forward_from_phase_provider(DirectPhaseProvider(), ...)` 都能运行，且 provider 路径与直接 phase 路径输出一致
+- 现有脚本回归已通过：
+  - `scripts/train_decoder_only_single_sample.py --depth 3 --steps 2`
+  - `scripts/train_decoder_only_small_subset_sweep.py --depths 1 --subset-size 1 --steps 2`
+- 当前风险点主要不在代码，而在未来 Stage 4 接入时必须守住 contract：encoder 输出必须仍是 real-valued `[B,1,H,W]` phase tensor，不能把 field、loss 或训练控制逻辑混进 optical core。建议下一步就在 Stage 4 开始时，把 encoder 输出直接接到这次新增的 phase-provider contract 上，而不是再改 decoder 内部接口。

--- a/docs/ai/prompt/stage3/prompt_stage3-7.md
+++ b/docs/ai/prompt/stage3/prompt_stage3-7.md
@@ -1,0 +1,137 @@
+你正在当前仓库中实现已有任务：
+
+[Task3-7] feat: add clean phase-provider hook for future Stage 4 integration
+
+请先明确理解本任务边界：
+- Stage 4 未来会需要 encoder
+- 但 Stage 3 当前不能提前实现 encoder / joint trainer / end-to-end training
+- 本任务只做“phase-provider hook + 接口约束 + 最小 stub/adapter”
+- 目标是让 optical core 与未来 encoder 的实现解耦
+- 绝不能借此任务偷偷进入 Stage 4
+
+你必须严格遵循：
+- AGENTS.md
+- docs/plan/stage3_contract_freeze.md
+- docs/integration/stage3_unresolved_params.md
+- docs/plan/stage3_sdn_porting_plan.md
+- 当前仓库中 Stage 3 已实现的 optics core / readout / validation 代码
+- 当前 Task3-7 issue 的描述：
+  - 定义 forward_from_phase
+  - 定义 forward_from_field
+  - 写明 encoder hook 约束
+  - deliverables 是接口说明 + 最小 stub/adapter
+  - acceptance criteria 是 optical core 与 encoder 实现解耦
+
+当前已知前提：
+- 当前 optical decoder 已具备稳定的 Stage 3 contract
+- 现有主链路已经落到：
+  phase -> field -> optical propagation -> intensity -> ROI
+- Stage 3 当前验证逻辑已完成，不要回头重写 Issue 2~6
+- 本任务不是验证任务，而是接口整理任务
+
+本次任务目标：
+1. 明确 optical module 的两类输入入口：
+   - forward_from_phase(...)
+   - forward_from_field(...)
+2. 增加一个 clean phase-provider hook / adapter / protocol
+3. 写清楚 future encoder 若要接入，需要满足什么 contract
+4. 保持当前 Stage 3 行为不变，不破坏现有实验脚本
+5. 不引入 Stage 4 训练系统
+
+你要完成的核心工作：
+
+A. 稳定 forward_from_phase(...) 的语义
+要求：
+1. 输入是 phase-domain tensor（例如 phi_lr 或其等价 phase representation）
+2. optical module 内部负责 phase -> field 的映射
+3. 然后进入已有 propagation/readout chain
+4. 接口注释中必须写清楚：
+   - 输入 shape 语义
+   - dtype/device 约束
+   - batch 维约定
+   - phase mapping 的责任归属
+
+B. 稳定 forward_from_field(...) 的语义
+要求：
+1. 输入是已经构造好的 coherent complex field
+2. 跳过 phase mapping
+3. 直接进入 propagation/readout chain
+4. 接口注释中必须写清楚：
+   - field 必须是 complex tensor
+   - shape 语义
+   - 与 forward_from_phase 的职责区别
+
+C. 增加最小 phase-provider hook / adapter / protocol
+要求：
+1. 只是一个“谁来提供 phase”的接口约定，不是真正 encoder 实现
+2. 可以采用最轻量方案，例如：
+   - typing.Protocol
+   - callable contract
+   - 小型 adapter/stub class
+3. 它应该表达：
+   - 给定某种上游输入，provider 产出 phase tensor
+   - optical decoder 只消费 phase，不关心 phase 是手工提供还是将来由 encoder 生成
+4. 禁止把训练逻辑、损失逻辑、dataset 逻辑塞进去
+
+D. 写清楚 contract 文档 / 注释
+至少应明确：
+1. phase provider 输出 tensor 的语义
+2. 期望 shape / dtype / device
+3. 是否允许 batch 维
+4. optical module 对 phase range / mapping 的假设
+5. 当前 Stage 3 默认仍是“外部直接提供 phase”
+6. future Stage 4 可以在什么位置接 learned encoder，但当前不实现它
+
+推荐改动范围（尽量小）：
+- src/models/optics/diffractive_decoder.py
+- 如有必要，新增一个非常小的接口文件，例如：
+  - src/models/optics/phase_provider.py
+  或
+  - src/models/interfaces/phase_provider.py
+- 如有必要，补少量开发文档或 README 注释
+不要做大规模目录重构。
+不要重写 propagation.py / readout.py 的核心数值逻辑。
+
+必须遵守的边界：
+1. 不实现真正 encoder
+2. 不实现 joint model
+3. 不实现 end-to-end trainer
+4. 不新增训练循环
+5. 不修改 Stage 3 的 optical/readout/crop contract
+6. 不破坏已有 Issue 2~6 的实验行为
+7. 不做过度抽象（例如复杂 registry/factory/plugin framework）
+8. 不因为“为未来准备”而重构整个 models 目录
+
+实现风格要求：
+- small, local, readable changes
+- clear naming
+- 接口注释优先，把语义写清楚
+- 明确标注：
+  - 哪些属于当前 Stage 3 稳定 contract
+  - 哪些只是 future Stage 4 integration hook
+- 尽量保证现有脚本无需修改或仅最小修改即可继续运行
+
+建议最小验收检查：
+1. 现有 forward_from_phase(...) 仍可正常工作
+2. 现有 forward_from_field(...) 仍可正常工作
+3. 新增 provider hook / adapter 不影响现有 Stage 3 sweep / fitting 脚本
+4. 从代码结构上能清楚看出：
+   - optical core 不负责生成 phase
+   - future encoder 只需满足 provider contract 即可接入
+5. 没有引入任何 joint training / Stage 4 trainer 代码
+
+本次交付物：
+- 稳定后的 forward_from_phase / forward_from_field 接口
+- 一个最小的 phase-provider hook / adapter / protocol
+- 必要的接口说明 / 注释 / 小文档更新
+- 如环境允许，可补一个极小的 smoke-level usage example，但不要扩展成新训练脚本
+
+输出要求：
+1. 先简短复述你理解到的任务边界
+2. 列出你准备新增/修改的文件
+3. 再实施代码修改
+4. 最后给出：
+   - 变更总结
+   - phase-provider hook 的接口说明
+   - 当前刻意未实现的 Stage 4 内容
+   - 风险点与后续建议

--- a/docs/ai/prompt/stage3/prompt_stage3-8.md
+++ b/docs/ai/prompt/stage3/prompt_stage3-8.md
@@ -1,0 +1,117 @@
+你正在当前仓库中继续推进已有任务：
+
+[Task3-8] Stage3 模块验证文档与设计记录更新
+
+当前前提：
+- Stage 3 contract freeze 已完成
+- optical propagation core / readout / crop / validation 链路已完成
+- decoder-only single-sample 与 small-subset sweep 已完成
+- Task3-7 phase-provider hook 已完成
+- 当前任务不是继续写模型代码，而是把 Stage 3 的关键实现决策、验证结果、设计边界和已知问题沉淀到文档中
+
+你必须严格遵循：
+- AGENTS.md
+- docs/plan/stage3_contract_freeze.md
+- docs/integration/stage3_unresolved_params.md
+- docs/plan/stage3_sdn_porting_plan.md
+- 当前仓库内已经落地的 Stage 3 代码与脚本
+- 当前已有实验结果与 summary 文件
+- 不要重新设计系统
+- 不要改 Stage 3 contract
+- 不要伪造未运行的实验结果
+
+本次任务目标：
+把 Stage 3 的关键决定固定下来，并更新以下文档：
+- docs/execution/experiment_log.md
+- docs/execution/results_summary.md
+- docs/execution/design_notes.md
+
+至少要记录以下内容：
+1. propagation 实现采用什么模型/primitive
+2. grid / padding / readout / crop 如何定义
+3. phase 参数化方式
+4. 单层/多层 decoder 的最小测试结果
+5. 已知数值问题 / 当前限制
+6. phase-provider hook 的接口边界（只需简要记载，不要展开成 Stage 4 设计文档）
+
+你要完成的核心工作：
+
+A. 更新 docs/execution/experiment_log.md
+要求：
+1. 记录 Stage 3 的关键执行路径和里程碑
+2. 至少包括：
+   - Issue 2 optical propagation core
+   - Issue 3 readout/crop contract
+   - Issue 4 forward sanity
+   - Issue 5 decoder-only single-sample fitting
+   - Issue 6 decoder-only small-subset depth sweep
+   - Task3-7 phase-provider hook
+3. 对每项记录：
+   - 做了什么
+   - 为什么做
+   - 得到什么最小结论
+4. 语言应简洁、可追溯，避免空话
+
+B. 更新 docs/execution/results_summary.md
+要求：
+1. 汇总 Stage 3 当前已获得的“事实性结果”
+2. 至少包含：
+   - L=1/3/5 depth sweep 的 fixed-protocol 结果摘要
+   - success_count / total_count / mean_best_loss / mean_loss_decrease 等关键指标
+   - 对结果的克制性解释：
+     - 可以说明“当前 tiny protocol 下三种 depth 都具备可优化容量”
+     - 不能夸大为“论文性能已复现”或“depth 优势已严格证明”
+3. 明确哪些结论是当前可说的，哪些结论仍不能说
+
+C. 更新 docs/execution/design_notes.md
+要求：
+1. 固化 Stage 3 的关键设计决策
+2. 至少包括：
+   - propagation primitive 的来源与当前实现方式
+   - L 的语义：trainable diffractive phase masks 数量
+   - distance schedule 的显式语义
+   - full-grid forward + ROI supervision contract
+   - intensity readout / center crop 的定义
+   - phase -> field 的责任归属
+   - forward_from_phase / forward_from_field / forward_from_phase_provider 的职责边界
+   - phase-provider contract 的最小定义
+3. 明确哪些是 Stage 3 stable contract，哪些只是 future Stage 4 integration hook
+4. 不要把 design notes 写成愿景文档，重点记录“当前仓库已实现并确认的边界”
+
+D. 文档写作要求
+1. 只记录真实存在的实现与实验
+2. 若某项只是最小 smoke / tiny protocol 验证，要明确写清，不要夸大
+3. 文档结构清晰，最好使用小标题和简短列表
+4. 允许补充少量 cross-reference，但不要大改整个 docs 结构
+5. 不要顺手重写无关文档
+
+必须遵守的边界：
+1. 本次以文档更新为主，不做新的模型功能开发
+2. 不新增 Stage 4 训练系统
+3. 不修改 Stage 3 物理实现，除非为了修正文档与代码不一致的明显小问题
+4. 不编造未跑过的实验
+5. 不把 Task3-8 变成“大规模 README 重构”
+
+建议输出风格：
+- experiment_log.md：按 issue/task 时间线记录
+- results_summary.md：按“当前已验证事实 / 当前不能得出的结论 / 已知限制”组织
+- design_notes.md：按“数据流 / 光学实现 / readout contract / provider hook / known issues”组织
+
+建议最小验收标准：
+1. 三个文档都被更新
+2. 文档内容与当前代码/实验结果一致
+3. 能让新对话或新协作者快速理解：
+   - Stage 3 做了什么
+   - 现在哪些点已经固定
+   - 还有哪些数值风险和结论边界
+4. 不夸大验证结果
+5. Task3-7 的 hook 只被记录为接口预留，而不是已进入 Stage 4
+
+输出要求：
+1. 先简短复述你理解到的 Task3-8 边界
+2. 列出准备修改的文档文件
+3. 再实施文档更新
+4. 最后给出：
+   - 各文档新增/更新了哪些部分
+   - 哪些 Stage 3 结论已被固定记录
+   - 哪些内容被刻意留到 Stage 4

--- a/docs/execution/design_notes.md
+++ b/docs/execution/design_notes.md
@@ -1,231 +1,223 @@
 # Design Notes
 
-记录当前实现中的重要设计决策与限制。
-这些内容不是 bug，但会影响未来模块开发。
+记录当前仓库中已经实现并确认的 Stage 3 optical module 边界。重点是当前 stable contract，而不是未来愿景。
 
----
+## 1. Stage 3 Stable Contract
 
-## Evaluation Pipeline
+当前 Stage 3 optical module 的稳定主链路为：
 
-### 1. Tensor shape ambiguity
+`phi_lr -> U0 -> U_out_full -> I_out_full -> I_out_roi -> loss/metrics`
 
-当前 evaluation pipeline 支持以下输入：
+对应职责拆分：
 
-- [H,W]
-- [C,H,W]
-- [N,C,H,W]
+- `phi_lr -> U0`
+  - 由 `forward_from_phase(...)` 和 `build_input_field(...)` 负责
+- `U0 -> U_out_full`
+  - 由 `PropagationOperator` + phase-mask modulation 负责
+- `U_out_full -> I_out_full`
+  - 由 `intensity_readout(...)` 负责
+- `I_out_full -> I_out_roi`
+  - 由 `center_crop_2d(...)` 负责
 
-对于三维输入：
+当前 freeze 边界：
 
+- full-grid forward + ROI supervision
+- `U_out_full` 和 `I_out_full` 必须保留
+- ROI crop 必须显式、确定性、可配置
+- optical module 只负责 direct optical readout，不包含 electrical decoder
 
-[N,H,W] / [C,H,W]
+## 2. Propagation Primitive
 
+当前实现位置：
+- `src/models/optics/propagation.py`
 
-由于维度本身不可区分，当前实现采用启发式规则：
+来源与方式：
+- 数学与数值思路来自 `external/sdn_upstream` 中值得复用的 optics primitive
+- 当前 repo 内已重写为纯 torch、config-driven 实现
 
+当前实际采用的 primitive：
 
-如果首维 ∈ {1,2,3,4}
-→ 视为 channel 维
+- centered FFT / IFFT
+  - `fft2_centered(...)`
+  - `ifft2_centered(...)`
+- Rayleigh-Sommerfeld transfer kernel
+  - `build_rayleigh_sommerfeld_transfer_kernel(...)`
+- 单次自由空间传播
+  - `PropagationOperator`
+- phase-only mask modulation
+  - `apply_phase_modulation(...)`
 
+当前明确去掉的内容：
 
-因此：
+- classification head
+- electrical decoder
+- Pet / OAM / LG / HG 任务耦合
+- 基于 `layer == 2` 或 `depth + 1` 的隐式 final propagation 逻辑
 
+## 3. L 与 Distance Schedule 语义
 
-(2,28,28)
+当前稳定定义：
 
+- `L` 表示 trainable diffractive phase masks 数量
+- final propagation to sensor plane 不计入 `L`
+- 当前 Stage 3 支持 `L in {1, 3, 5}`
 
-可能被解释为 2-channel image 而不是 batch=2。
+distance schedule 必须使用显式 schema：
 
-建议未来调用 evaluation API 时统一使用：
-
-
-[N,C,H,W]
-
-
-以避免歧义。
-
-### 2. Input range handling
-
-evaluation pipeline 假设输入图像范围为：
-
-
-[0,1]
-
-
-当前实现的容错策略：
-
-| 输入范围 | 行为 |
-|---|---|
-| [0,1] | 直接使用 |
-| [0,255] | 自动除以 255 |
-| 其它 | clip 到 [0,1] |
-
-这种策略方便工具脚本，但可能掩盖上游错误。
-
-未来正式实验建议：
-
-- 明确保证输入范围为 `[0,1]`
-- 或在 evaluation 中改为严格报错
-
-## Baseline
-
-### 1. Interpolation Baseline Design Notes
-
-当前 Stage1/2 中实现的 interpolation baseline 主要用于：
-
-- 验证数据链路是否正确
-- 验证统一评估 pipeline 是否可用
-- 提供最基础的性能参考下界
-
-该 baseline 属于 **sanity-check baseline**，并不代表最终论文对齐的实验协议。因此在当前实现中存在一些需要记录的设计约定与潜在限制。
-
----
-
-#### 2.1 HR / LR 构造协议（Stage1/2 版本）
-
-当前 baseline 默认使用：
-
+```yaml
+distance_schedule:
+  input_to_first: ...
+  inter_layer: [...]
+  last_to_sensor: ...
 ```
 
-hr_size = 96
-scale = 4
+对应语义：
 
+- `input_to_first`
+  - 输入面到第一层 trainable phase mask 的传播距离
+- `inter_layer`
+  - 相邻 trainable phase mask 之间的传播距离列表
+- `last_to_sensor`
+  - 最后一层 mask 到 sensor plane 的传播距离
+
+当前 decoder 会显式检查 `inter_layer` 长度是否与 `L` 匹配，避免旧 upstream 的隐式 special case。
+
+## 4. Grid / Padding / Readout / Crop
+
+当前 grid contract 位置：
+- `src/models/optics/diffractive_decoder.py`
+- `src/models/optics/readout.py`
+
+当前 grid 语义：
+
+- `input_pattern_hw`
+  - phase-domain 输入图样尺寸
+- `layer_hw`
+  - trainable diffractive phase mask 尺寸
+- `propagation_hw`
+  - optics propagation 使用的 full grid 尺寸
+
+padding 规则：
+
+- input pattern 和 phase mask 都会被 centered embed 到 `propagation_hw`
+- center embed 是显式逻辑，不通过脚本临时补零
+
+readout / crop 规则：
+
+- `I_out_full = |U_out_full|^2`
+- ROI 由 `ReadoutConfig.output_crop_hw` 控制
+- ROI crop 采用 deterministic center crop
+- crop 超出 full grid 时会显式报错
+
+当前验证脚本使用的最小协议示例：
+
+- `input_pattern_hw = (24, 24)`
+- `layer_hw = (32, 32)`
+- `propagation_hw = (48, 48)`
+- `output_crop_hw = (20, 20)`
+
+这些数值是 Stage 3 tiny validation setting，不应误读为 final paper-setting。
+
+## 5. Phase Parameterization
+
+当前 phase 相关实现位置：
+- `src/models/optics/phase_utils.py`
+- `src/models/optics/diffractive_decoder.py`
+
+当前明确约定：
+
+- 输入主线是 phase-only
+- 默认 amplitude 固定为 1
+- coherent field 使用 complex tensor 表示，不再沿用含混的 `amp/phase` 命名
+
+当前两类 phase 处理责任不同：
+
+- 输入 phase `phi_lr`
+  - 由调用方直接提供 phase-domain tensor
+  - decoder 在 `forward_from_phase(...)` 内部完成 `phase -> field`
+  - 当前输入路径默认使用 identity phase mapping，然后构造 `exp(j * phi)`
+- trainable phase masks
+  - 内部保存 raw parameter
+  - 通过 `map_phase(...)` 映射到物理 phase range
+  - 当前默认配置是 `tanh` 映射到 `[-pi, pi]`
+  - 当前默认初始化是 zero init
+
+## 6. Entry Points and Responsibility Boundary
+
+当前 decoder 的三个入口职责如下：
+
+| 入口 | 输入语义 | decoder 负责什么 | caller / provider 负责什么 |
+| --- | --- | --- | --- |
+| `forward_from_phase(phi_lr, ...)` | real-valued phase tensor `[B, 1, H, W]` | `phase -> U0 -> propagation -> readout -> crop` | 提供 phase tensor，保证 batch/channel/spatial 语义正确 |
+| `forward_from_field(U0, ...)` | complex coherent field `[B, 1, H, W]` | `propagation -> readout -> crop` | 提前构造好 complex field |
+| `forward_from_phase_provider(provider, upstream_input, ...)` | provider 输出 phase | 调用 provider 获取 phase，然后委托给 `forward_from_phase(...)` | 提供满足 contract 的 provider |
+
+额外说明：
+
+- `forward(...)` 当前仍然直接委托到 `forward_from_phase(...)`
+- 这样可以保持现有 Stage 3 Issue 3~6 脚本不需要改接口
+
+## 7. Phase-Provider Hook
+
+当前 hook 实现位置：
+- `src/models/optics/phase_provider.py`
+
+最小 contract：
+
+```python
+PhaseProvider(upstream_input: torch.Tensor) -> torch.Tensor
 ```
 
-构造流程为：
+返回值要求：
 
-```
+- real-valued tensor
+- shape 为 `[B, 1, H, W]`
+- batch 维允许存在
+- device / dtype 由 caller/provider 与 decoder 保持一致
 
-HR -> bicubic downsample -> LR -> interpolation -> SR
+当前 Stage 3 默认 provider：
 
-```
+- `DirectPhaseProvider`
+  - 直接把调用方给的 phase tensor 原样返回
 
-具体步骤：
+当前边界解释：
 
-1. 原始 EMNIST 图像首先被 resize 到 `hr_size`
-2. 使用 **bicubic 下采样**生成 LR 图像
-3. 再通过指定插值方法（bilinear / bicubic）上采样回 HR 尺寸
+- 这是 future Stage 4 integration hook
+- 它只定义“谁提供 phase”，不实现 encoder
+- 它不包含 dataset、loss、trainer 或 joint training 逻辑
 
-需要注意：
+## 8. Stable Contract vs Future Hook
 
-- 当前 HR 定义是 **Stage1/2 的工程壳设定**
-- 并不代表论文最终实验所使用的 HR/LR 数据构造协议
+当前已稳定的 Stage 3 contract：
 
-未来在进入 **paper-aligned experiments** 时，HR 定义可能会发生调整，因此当前 baseline 指标不应直接与论文结果进行对比。
+- `forward_from_phase(...)`
+- `forward_from_field(...)`
+- `phi_lr -> U0 -> U_out_full -> I_out_full -> I_out_roi`
+- `L` 的语义
+- explicit distance schedule
+- full-grid forward + ROI supervision
+- intensity readout + center crop
 
----
+当前只是为 future Stage 4 预留的 hook：
 
-#### 2.2 LR 退化模型假设
+- `PhaseProvider`
+- `DirectPhaseProvider`
+- `forward_from_phase_provider(...)`
 
-当前实现中，LR 图像由 **bicubic 下采样**生成：
+这些 hook 的作用仅仅是把 future encoder 接入点固定在 decoder 外部，而不是提前实现 Stage 4。
 
-```
+## 9. Known Issues and Current Limits
 
-LR = BicubicDownsample(HR)
+当前已知限制：
 
-```
+- Stage 3 主要完成了最小可运行与最小容量验证，不是 final paper reproduction
+- 当前 tiny protocol 使用小 grid、短步数和 synthetic target，重点是 sanity / capacity，不是正式 benchmark
+- 当前物理实现使用 float32 + centered FFT / RS kernel 的工程化版本，后续若进入更严格 paper alignment，仍需要继续核对参数与数值稳定性
+- 当前没有引入 efficiency term、quantization、misalignment 或 hardware robustness
+- 当前没有引入 encoder，也没有验证 Stage 4 闭环训练
 
-这意味着当前 baseline 默认假设：
+因此，当前 design notes 的定位是：
 
-```
-
-degradation model = bicubic
-
-```
-
-因此：
-
-- bilinear baseline 与 bicubic baseline 实际是在同一退化模型下进行比较
-- 不代表任意 LR 来源的通用性能下界
-
-这一设定符合常见 SR baseline 做法，但应在实验记录中明确说明。
-
-未来如果需要测试：
-
-- 不同退化模型
-- 更接近真实光学系统的 degradation
-
-则需要重新定义 LR 构造方式。
-
----
-
-#### 2.3 内部验证集（val split）
-
-当前实现中的 `val` split 并非官方数据集划分。
-
-如果 EMNIST 未提供明确的验证集，则脚本会：
-
-```
-
-从 train split 中按固定 seed 划分出 val
-
-```
-
-其目的仅为：
-
-- 在 Stage1/2 阶段进行 baseline 验证
-- 确认评估 pipeline 工作正常
-
-该 val split 不应被视为最终实验协议中的验证集。
-
----
-
-#### 2.4 插值导致的数值越界
-
-在某些情况下：
-
-```
-
-bicubic / bilinear interpolation
-
-```
-
-可能产生轻微数值越界，例如：
-
-```
-
-pixel < 0
-pixel > 1
-
-```
-
-当前 baseline 依赖统一评估 pipeline 对输入进行范围处理，使最终指标计算保持在 `[0,1]` 口径。
-
-该策略在工具脚本阶段是可接受的，但需要注意：
-
-- 评估模块当前包含一定的容错策略
-- 后续正式实验阶段应尽量保证输入范围严格符合 `[0,1]`
-
----
-
-#### 2.5 Baseline 的阶段性性质
-
-Interpolation baseline 的设计目标是：
-
-```
-
-提供任务的最基础性能参考下界
-
-```
-
-如果后续 **pure electronic baseline** 的性能没有明显优于 interpolation baseline，则需要重新检查：
-
-- 数据 pipeline
-- LR / HR 构造逻辑
-- 评估指标实现
-
-因此 interpolation baseline 的结果在当前项目中主要用于：
-
-```
-
-pipeline sanity check
-
-```
-
-而不是用于最终论文级性能对比。
-
-## Dataset Construction
-
-## Optical Propagation Implementation
-
-## Experiment Protocol 
+- 固化 Stage 3 已实现并确认的接口边界
+- 避免未来 Stage 4 误把 optical core 再次耦合回 encoder / trainer
+- 为后续接入 learned encoder 提供最小而清晰的 phase-provider hook

--- a/docs/execution/experiment_log.md
+++ b/docs/execution/experiment_log.md
@@ -1,94 +1,133 @@
 # Experiment Log
 
-记录阶段推进中的关键实验、排查和结论，保证后续能够追溯“改了什么、为什么改、结果如何”。
+记录 Stage 3 optical module verification 阶段的关键执行路径、最小验证结论和当前边界。
 
-## Exp-000
-- 日期: 2026-03-14
-- 阶段: Stage 1 / Stage 2
-- 类型: 排错 / 基线修复
-- 目标: 解释电子 baseline 在服务器上出现的异常现象，包括参数不生效、训练速度异常、`Recon` 全黑、单样本 overfit 失败
-- 配置:
-  - 旧版电子 baseline 训练脚本
-  - `outputs/electronic_baseline/fit_one_sample`
-  - `outputs/electronic_baseline/smallset_e10`
-- 代码版本 / 分支: 当前工作区
-- 修改内容:
-  - 修复 `scripts/train_electronic_baseline.py` 中 `CLI > config` 优先级错误
-  - 把 HR resize 从训练循环前移到 dataset transform
-  - 将 preview 图改为固定多样本网格，避免“每轮都像同一张图”
-  - 为真正的单样本拟合增加 `--overfit-single-sample`
-- 结果:
-  - 旧报告确认存在配置覆盖问题，命令行中的 `epochs=10, batch_size=32, lr=1e-3` 被 `configs/base.yaml` 覆盖成 `50, 8, 1e-4`
-  - 修复后，`summary.json` 能正确记录实际生效参数
-- 观察:
-  - 参数覆盖问题会直接污染实验结论，必须先修，否则无法判断模型本身是否有问题
-- 结论:
-  - 第一轮异常包含脚本实现问题，不能直接把旧 baseline 结果当成模型真实性能
-- 下一步:
-  - 在参数优先级修复后，继续检查模型是否仍存在训练动力学问题
+当前 Stage 3 冻结主链路：
 
-## Exp-001
-- 日期: 2026-03-14
-- 阶段: Stage 1 / Stage 2
-- 类型: 诊断实验 / 模型修复
-- 目标: 找到电子 baseline `Recon` 全黑的根因，并验证模型是否能通过单样本 overfit sanity check
-- 配置:
-  - 单样本 overfit
-  - `hr_size=96`
-  - `sr_factor=4`
-  - `latent_channels=1`
-  - `lr=1e-3`
-- 代码版本 / 分支: 当前工作区
-- 修改内容:
-  - 将 `src/models/electronic_baseline.py` 中的隐藏层激活从 `ReLU` 改为 `LeakyReLU(0.1)`
-  - 将输出映射从 `sigmoid` 改为 `atan(out) / pi + 0.5`
-- 结果:
-  - 旧模型在几十步内塌缩到全黑输出，梯度接近 0
-  - 新模型在本地单样本 overfit 40 epoch 下达到:
-    - `best_val_psnr = 22.51`
-    - `best_val_ssim = 0.8217`
-    - `final_val_l1 = 0.0333`
-- 观察:
-  - 旧问题不是“可视化保存错误”，而是真实的零输出塌缩
-  - 稀疏白字黑底任务中，`ReLU + sigmoid + L1` 组合容易在早期把输出压到全黑并进入饱和区
-- 结论:
-  - 电子 baseline 的致命问题来自输出路径的训练动力学，而非瓶颈语义或数据协议
-- 下一步:
-  - 在服务器上重新运行标准 overfit / smallset 命令，确认正式结果是否稳定
+`phi_lr -> U0 -> U_out_full -> I_out_full -> I_out_roi -> loss/metrics`
 
-## Exp-002
-- 日期: 2026-03-14
-- 阶段: Stage 1 / Stage 2
-- 类型: 正式 baseline 结果确认
-- 目标: 判断修复后的电子 baseline 是否达到“可信、可通过”的基线标准
-- 配置:
-  - 单样本 overfit:
-    - `outputs/electronic_baseline/fit_one_sample`
-    - `epochs=200, batch_size=1, lr=1e-3, num_samples=1, overfit_single_sample=true`
-  - 小数据集训练:
-    - `outputs/electronic_baseline/smallset_e10`
-    - `epochs=10, batch_size=32, lr=1e-3, num_samples=2000, val_ratio=0.1`
-- 代码版本 / 分支: 当前工作区
-- 修改内容:
-  - 无新增代码改动，分析服务器返回的正式 JSON 报告
-- 结果:
-  - `fit_one_sample/metrics.json`
-    - `best_epoch = 194`
-    - `best_val_psnr = 32.4633`
-    - `best_val_ssim = 0.9624`
-    - `final_val_psnr = 30.4862`
-    - `final_val_ssim = 0.9619`
-  - `smallset_e10/metrics.json`
-    - `best_epoch = 10`
-    - `best_val_psnr = 33.6274`
-    - `best_val_ssim = 0.9780`
-    - `final_val_l1 = 0.01042`
-- 观察:
-  - 单样本 overfit 已明显成功，说明模型和训练动力学已恢复正常
-  - 小数据集训练 10 个 epoch 内持续提升，没有再出现“第 1 轮后完全停滞”
-  - `summary.json` 中记录的训练参数与命令行一致，说明参数覆盖问题已解决
-- 结论:
-  - 当前电子 baseline 已达到 Stage 1 / Stage 2 可接受状态，可以作为后续 optical model 的纯电子参考基线
-- 下一步:
-  - 将当前 baseline 结果写入结果总结和排错文档
-  - 后续如果继续扩展，可在相同 bottleneck 约束下做更系统的数据量和训练轮数对比
+本文档只记录当前仓库中已经实现并运行过的 Stage 3 里程碑，不把最小 smoke 或 tiny protocol 包装成最终论文结果。
+
+## S3-02 Optical Propagation Core
+
+- 对应任务：Issue 2 `feat: extract paper-aligned propagation core from sdn_upstream`
+- 做了什么：
+  - 从 `external/sdn_upstream` 参考并重写了 centered FFT / IFFT、Rayleigh-Sommerfeld transfer kernel、phase-mask modulation。
+  - 在 `src/models/optics/propagation.py`、`src/models/optics/phase_utils.py`、`src/models/optics/diffractive_decoder.py` 内落地为当前 repo 的 clean optics core。
+  - 去掉了 classification head、electrical decoder、Pet / OAM / LG / HG 任务耦合，以及 `layer == 2` 这类隐式 final propagation 逻辑。
+- 为什么做：
+  - Stage 3 需要先验证 optical decoder skeleton 本身可运行、可检查、可被后续 readout / crop / fitting 复用。
+- 最小结论：
+  - optical core 已独立于 upstream 任务层。
+  - `L` 的语义已固定为 trainable diffractive phase masks 数量。
+  - distance schedule 已改为显式 `input_to_first / inter_layer / last_to_sensor`。
+
+## S3-03 Readout / Crop Contract
+
+- 对应任务：Issue 3 `feat: add output FOV crop and optical direct-readout contract`
+- 做了什么：
+  - 新增 `src/models/optics/readout.py`，把 `I_out_full = |U_out_full|^2` 和 deterministic center crop 从调用脚本中抽离出来。
+  - decoder 现在稳定返回 `U_out_full`、`I_out_full`、`I_out_roi`，不再把 full-grid 和 ROI 混在一起。
+  - `output_crop_hw` 变成显式配置，crop 越界会报错。
+- 为什么做：
+  - Stage 3 freeze 明确要求 full-grid forward + ROI supervision，且 crop 不能隐藏在脚本中。
+- 最小结论：
+  - `scripts/check_optical_readout.py` 已在当前仓库状态下通过。
+  - 当前重跑结果：
+    - `I_out_full` shape: `(1, 1, 48, 48)`
+    - `I_out_roi` shape: `(1, 1, 20, 20)`，改为 `(12, 12)` 时 ROI shape 正确变为 `(1, 1, 12, 12)`
+    - oversized crop 会显式报错
+    - 改变输入 phase 时，`full_delta = 1.748107e-03`，`roi_delta = 2.850121e-03`
+
+## S3-04 Forward Sanity for L=1/3/5
+
+- 对应任务：Issue 4 `feat: add Stage 3 forward sanity scripts for L=1/3/5`
+- 做了什么：
+  - 新增 `scripts/check_optical_forward_depths.py`，在一致的最小协议下检查 `L=1/3/5` 的 forward 行为。
+  - 检查项覆盖：forward 成功、输出 key 完整、`U_out_full` 为 complex、强度非负、ROI shape 一致、不同 depth 输出不完全相同、invalid distance schedule 会显式失败。
+- 为什么做：
+  - Stage 3 在进入 fitting 前必须先证明 optics forward 本身可信，不依赖 electrical decoder 才能“看懂”输出。
+- 最小结论：
+  - `scripts/check_optical_forward_depths.py` 已在当前仓库状态下通过。
+  - 当前重跑结果：
+    - 三个 depth 都返回 `['I_out_full', 'I_out_roi', 'U0', 'U_out_full']`
+    - `L=1/3/5` 的 full-grid shape 均为 `(1, 1, 48, 48)`，ROI shape 均为 `(1, 1, 20, 20)`
+    - pairwise ROI delta:
+      - `L1-L3 = 5.641614e-01`
+      - `L1-L5 = 7.738391e-01`
+      - `L3-L5 = 3.243636e-01`
+    - 错误的 `inter_layer` 长度会被显式拒绝，而不是依赖旧的 layer-index special case
+
+## S3-05 Decoder-Only Single-Sample Fitting
+
+- 对应任务：Issue 5 `feat: add decoder-only single-sample fitting runner`
+- 做了什么：
+  - 新增 `scripts/train_decoder_only_single_sample.py`
+  - 用 learnable input phase 直接驱动 optical decoder，不引入 encoder。
+  - 在 ROI 上使用 normalized MAE 进行最小拟合，并保存 target / initial / best / final ROI、loss curve 和 summary。
+- 为什么做：
+  - Stage 3 需要先隔离 encoder 影响，验证 optical decoder stack 是否有最小可优化容量。
+- 最小结论：
+  - `outputs/optics/decoder_only_single_sample_smoke/summary.json` 记录了一个 `L=3` 的可复跑 smoke：
+    - `initial_loss = 0.1463065892457962`
+    - `best_loss = 0.03812457248568535`
+    - `final_loss = 0.03893868252635002`
+    - `loss_decrease = 0.10818201676011086`
+    - `roi_change_mean_abs = 0.4759185314178467`
+  - 当前结论仅说明 decoder-only 单样本路径可学，不代表论文设置或最终系统性能已复现。
+
+## S3-06 Decoder-Only Small-Subset Depth Sweep
+
+- 对应任务：Issue 6 `feat: run small-subset optical capacity experiment across L=1/3/5`
+- 做了什么：
+  - 先新增 `scripts/train_decoder_only_small_subset.py`，再补齐 `scripts/train_decoder_only_small_subset_sweep.py`
+  - 对固定 deterministic subset、固定 ROI normalized MAE、固定步数预算和固定优化超参执行 `L=1/3/5` sweep
+  - 为每个 depth 输出独立目录，并生成统一 `sweep_summary.json` 与 `depth_comparison.csv`
+- 为什么做：
+  - 单样本下降不足以支持 Issue 6 关闭；Stage 3 freeze 要求至少在小子集上比较 `L=1/3/5`
+- 最小结论：
+  - 来源：`outputs/optics/decoder_only_small_subset_sweep_run1/sweep_summary.json`
+  - shared protocol：
+    - `subset_size = 4`
+    - `steps = 80`
+    - `seed = 42`
+    - `device = cpu`
+    - `lr_phase = 0.15`
+    - `lr_decoder = 0.03`
+    - `freeze_decoder = false`
+    - `loss = normalized_mae_roi`
+  - fixed-protocol 结果：
+    - `L=1`: `success_count = 4/4`, `mean_best_loss = 0.02864284673705697`, `mean_loss_decrease = 0.09716733871027827`
+    - `L=3`: `success_count = 4/4`, `mean_best_loss = 0.03225723281502724`, `mean_loss_decrease = 0.09978684224188328`
+    - `L=5`: `success_count = 4/4`, `mean_best_loss = 0.03135538613423705`, `mean_loss_decrease = 0.10351110668852925`
+  - 当前结论仅说明三种 depth 在 tiny protocol 下都具备可优化容量，不构成论文性能排序结论。
+
+## S3-07 Phase-Provider Hook
+
+- 对应任务：Task3-7 `feat: add clean phase-provider hook for future Stage 4 integration`
+- 做了什么：
+  - 新增 `src/models/optics/phase_provider.py`
+  - 明确 `PhaseProvider` callable contract：`upstream_input -> phase tensor`
+  - 新增 `DirectPhaseProvider` 作为当前 Stage 3 默认 stub
+  - 在 decoder 中稳定 `forward_from_phase(...)`、`forward_from_field(...)`，并补充 `forward_from_phase_provider(...)`
+- 为什么做：
+  - 让 optical core 与 future encoder 的实现方式解耦，同时不提前引入 Stage 4 trainer 或 joint model
+- 最小结论：
+  - 当前 hook 只负责接口边界，不负责任何训练或 encoder 实现
+  - 已做的 smoke 结论：
+    - `forward_from_phase(...)`、`forward_from_field(...)`、`forward_from_phase_provider(...)` 可运行
+    - 现有 Issue 5/6 脚本在加入 hook 后仍能运行
+
+## 当前 Stage 3 记录边界
+
+- 已固定：
+  - propagation primitive 的实现边界
+  - full-grid forward + ROI supervision contract
+  - `L=1/3/5` 的显式 layer semantics
+  - decoder-only single-sample / small-subset 的最小验证路径
+  - future Stage 4 的 phase-provider hook 入口
+- 尚未在 Stage 3 中解决：
+  - encoder / joint training
+  - paper full-setting reproduction
+  - hardware robustness / quantization / misalignment
+  - dataset-scale end-to-end optical experiments

--- a/docs/execution/results_summary.md
+++ b/docs/execution/results_summary.md
@@ -1,81 +1,126 @@
 # Results Summary
 
-阶段性结果总结，强调当前已确认的结论、可接受范围和后续工作重点。
+汇总当前 Stage 3 已经获得的事实性结果，并明确哪些结论已经可以说、哪些还不能说。
 
 ## 当前阶段
-- Stage 1 / Stage 2
-- 目标: 完成纯电子 baseline、数据协议检查、统一评估协议和最小可训练闭环验证
 
-## 已确认结果
+- Stage 3: Optical Module Verification
+- 当前定位：
+  - 验证 paper-aligned optical decoder skeleton 是否可运行、可检查、可做最小容量验证
+  - 不是最终 end-to-end SR system
+  - 不是 final joint training
+  - 不是 final paper full-setting reproduction
 
-### 1. 电子 baseline 已恢复正常训练
-- 模型: `ElectronicBottleneckAutoencoder`
-- 输入 / 输出: `[B,1,96,96] -> [B,1,24,24] latent -> [B,1,96,96]`
-- bottleneck:
-  - 空间尺寸: `24 x 24`
-  - 通道数: `1`
-- 评估入口: 复用 `src.eval.evaluator.evaluate_batch(...)`
+## 当前已验证的事实
 
-### 2. 单样本 overfit sanity check 通过
-来源: [fit_one_sample/metrics.json](d:\AI project\ONN research\sdn-for-super-resolution-reproduction\outputs\electronic_baseline\fit_one_sample\metrics.json)
+### 1. Stage 3 optical contract 已落地
 
-- `best_epoch = 194`
-- `best_val_psnr = 32.4633`
-- `best_val_ssim = 0.9624`
-- `final_val_psnr = 30.4862`
-- `final_val_ssim = 0.9619`
+- 当前主链路已经稳定到：
+  - `phi_lr -> U0 -> U_out_full -> I_out_full -> I_out_roi`
+- full-grid forward 与 ROI supervision 已显式分离
+- `U_out_full`、`I_out_full`、`I_out_roi` 都由 optical module 直接返回
 
-结论:
-- 模型已经能够在相同 bottleneck 约束下记住单样本
-- 这说明当前训练骨架、数据构造、loss 和输出映射已基本正确
+### 2. Readout / Crop 最小验证通过
 
-### 3. 小数据集训练结果正常
-来源: [smallset_e10/metrics.json](d:\AI project\ONN research\sdn-for-super-resolution-reproduction\outputs\electronic_baseline\smallset_e10\metrics.json)
+来源：
+- `scripts/check_optical_readout.py`
 
-- 训练集 / 验证集:
-  - `train_samples = 1800`
-  - `val_samples = 200`
-- 最终结果:
-  - `final_val_l1 = 0.01042`
-  - `final_val_psnr = 33.6274`
-  - `final_val_ssim = 0.9780`
-- history 趋势:
-  - epoch 1: `PSNR = 24.12`, `SSIM = 0.8305`
-  - epoch 5: `PSNR = 30.62`, `SSIM = 0.9619`
-  - epoch 10: `PSNR = 33.63`, `SSIM = 0.9780`
+当前重跑结果：
+- `U_out_full` 为 complex tensor
+- `I_out_full` 和 `I_out_roi` 为 real 且 nonnegative
+- `output_crop_hw=(20, 20)` 时 ROI shape 为 `(1, 1, 20, 20)`
+- `output_crop_hw=(12, 12)` 时 ROI shape 为 `(1, 1, 12, 12)`
+- oversized crop 会报显式错误
+- 改变输入 phase 会改变输出：
+  - `full_delta = 1.748107e-03`
+  - `roi_delta = 2.850121e-03`
 
-结论:
-- 训练过程平稳，指标持续提升
-- 没有再出现早期塌缩、全黑重建或 epoch 1 后停滞
+### 3. Forward sanity 已覆盖 L=1/3/5
 
-## 已解决问题
+来源：
+- `scripts/check_optical_forward_depths.py`
 
-### 问题 1: config 覆盖 CLI
-- 旧问题: `configs/base.yaml` 会覆盖命令行显式传入的训练参数
-- 影响: 训练速度、学习率、batch size、epoch 数全部可能失真
-- 当前状态: 已修复
+当前重跑结果：
+- `L=1/3/5` 都能 forward 成功
+- 三个 depth 的输出接口一致：
+  - `U0`
+  - `U_out_full`
+  - `I_out_full`
+  - `I_out_roi`
+- `U_out_full` 持续保持 complex
+- `I_out_full` 与 `I_out_roi` 持续保持 real 且 nonnegative
+- 错误的 `inter_layer` 长度会被显式拒绝
 
-### 问题 2: `ReLU + sigmoid` 导致全黑输出塌缩
-- 旧问题: 稀疏灰度图像任务中，模型会快速塌缩到零输出并丢失梯度
-- 当前修复:
-  - 隐层激活改为 `LeakyReLU(0.1)`
-  - 输出映射改为 `atan(out) / pi + 0.5`
-- 当前状态: 已修复
+### 4. Decoder-only single-sample fitting 已显示明确下降
 
-## 当前判断
-- 当前电子 baseline 结果正常
-- 当前电子 baseline 可以通过 Stage 1 / Stage 2 验收
-- 当前结果可以作为后续 optical model 的纯电子参考
+来源：
+- `outputs/optics/decoder_only_single_sample_smoke/summary.json`
 
-## 风险与边界
-- 当前结果仍是 Stage 1 / Stage 2 的最小 shell 数据设定，不代表已完成论文最终设定对齐
-- 当前结论只说明“同一 bottleneck 约束下，纯电子方案可学且训练流程正常”
-- 后续进入 optical model 时，仍需要重新检查:
-  - optical bottleneck 对齐方式
-  - 相同数据协议下的可学习性
-  - 评估协议是否保持一致
+当前 `L=3` smoke 结果：
 
-## 下一步建议
-1. 固定当前电子 baseline，作为后续对照组
-2. 在不改变评估协议的前提下推进 optical decoder 主线
-3. 后续所有光学实验都应至少和当前 `smallset_e10` 级别结果进行对比
+| depth | steps | initial_loss | best_loss | final_loss | loss_decrease |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| 3 | 120 | 0.1463065892457962 | 0.03812457248568535 | 0.03893868252635002 | 0.10818201676011086 |
+
+补充观察：
+- `roi_change_mean_abs = 0.4759185314178467`
+- `best_roi_std = 0.34699586033821106`
+
+这说明在不引入 encoder 的条件下，当前 optical decoder stack 至少能对一个目标做出可观下降。
+
+### 5. Fixed-protocol small-subset depth sweep 已覆盖 L=1/3/5
+
+来源：
+- `outputs/optics/decoder_only_small_subset_sweep_run1/sweep_summary.json`
+- `outputs/optics/decoder_only_small_subset_sweep_run1/depth_comparison.csv`
+
+shared protocol：
+- `subset_size = 4`
+- `steps = 80`
+- `seed = 42`
+- `device = cpu`
+- `lr_phase = 0.15`
+- `lr_decoder = 0.03`
+- `freeze_decoder = false`
+- `loss = normalized_mae_roi`
+
+结果摘要：
+
+| depth | success_count | total_count | success_rate | mean_initial_loss | mean_best_loss | mean_loss_decrease |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 4 | 4 | 1.0 | 0.12581018544733524 | 0.02864284673705697 | 0.09716733871027827 |
+| 3 | 4 | 4 | 1.0 | 0.13204407505691051 | 0.03225723281502724 | 0.09978684224188328 |
+| 5 | 4 | 4 | 1.0 | 0.1348664928227663 | 0.03135538613423705 | 0.10351110668852925 |
+
+最小事实结论：
+- 三种 depth 在同一 tiny protocol 下都能在多个样本上下降
+- Issue 6 需要的 fixed-protocol `L=1/3/5` 容量 sweep 已补齐
+
+## 当前可以说的结论
+
+- 当前 Stage 3 optical decoder skeleton 是可运行的，且 optical/readout/crop contract 已稳定。
+- 在当前 tiny synthetic protocol 下，`L=1/3/5` 三种 depth 都表现出可优化的 decoder-only capacity。
+- 当前结果已经足以支撑：
+  - 进入未来 Stage 4 时不必重新设计 optical core
+  - future encoder 只需要对接 phase-provider / `forward_from_phase(...)` contract
+
+## 当前不能说的结论
+
+- 不能说论文性能已经复现。
+- 不能说 `L=5` 或任何更深 depth 已经被严格证明更优。
+- 不能说当前 tiny synthetic subset 结果可直接外推到真实数据集或自然图像。
+- 不能说当前 optical module 已经完成 final paper-setting alignment。
+- 不能说 Stage 4 end-to-end training 已经就绪到可以跳过进一步调试。
+
+## 已知限制与风险
+
+- 当前验证协议使用的是 Stage 3 工程化 tiny setting，不是 final paper full-setting。
+- 当前子集目标是 deterministic synthetic ROI targets，主要用于 capacity sanity，不是正式 benchmark。
+- 当前 sweep 在 CPU 上完成，默认使用 float32 计算与较小 grid。
+- propagation primitive 来自 upstream optics 思路的重写版本，当前已做 forward / fitting sanity，但尚未扩展到硬件鲁棒性或更严格物理对照。
+- current depth comparison 只说明“在相同预算下都能下降”，不说明更深层必然更好。
+
+## 后续阶段边界
+
+- Stage 4 才进入 encoder 接入与最小闭环训练。
+- Stage 5/6 才进入 paper-final setting alignment、更多数据协议和系统化实验。


### PR DESCRIPTION
record the landed Stage 3 optical implementation, validation path, fixed-protocol fitting results, stable contracts, and known limits so the current decoder/readout/capacity decisions are traceable without overstating paper reproduction status

ref: #24