### PR TITLE
feat: add Stage 4 minimal dataset path and ROI target adapter

### DIFF
--- a/docs/ai/CodexFeedback/stage4/feedback_stage4-3.md
+++ b/docs/ai/CodexFeedback/stage4/feedback_stage4-3.md
@@ -1,0 +1,44 @@
+4.3 的边界已按要求收住：这次只补了最小真实 EMNIST 数据路径和显式 `target_hr -> target_roi` adapter，用来服务后续 closed-loop training；没有实现 trainer、loss loop，也没有改 optical core 或 wrapper 核心职责。
+
+变更文件：
+- [src/datasets/stage4_emnist.py](d:/AI%20project/ONN%20research/sdn-for-super-resolution-reproduction/src/datasets/stage4_emnist.py)
+- [src/datasets/target_adapter.py](d:/AI%20project/ONN%20research/sdn-for-super-resolution-reproduction/src/datasets/target_adapter.py)
+- [src/datasets/__init__.py](d:/AI%20project/ONN%20research/sdn-for-super-resolution-reproduction/src/datasets/__init__.py)
+
+变更总结：
+- 新增 `Stage4EMNISTDataset`，复用可信 EMNIST 路径，产出显式字段 `x_hr / target_hr / label / dataset_index`
+- 新增 `build_stage4_train_val_datasets(...)`，沿用 baseline 风格做最小 train/val split 和 single-sample overfit 入口
+- 新增 `Stage4RoiTargetAdapter`，把 `target_hr -> target_roi` 的 resize/clamp 逻辑从脚本里抽出来
+- 新增 `save_stage4_input_target_preview(...)`，保存 `x_hr / target_roi / target_roi(upsampled)` 预览
+- 没有修改现有 optical module、minimal phase encoder、minimal hybrid wrapper
+
+Stage 4 当前 `x_hr / target_roi` 定义：
+- `x_hr`：来自 `torchvision.datasets.EMNIST` 的真实单通道图像，经 bicubic resize 到当前 Stage 4 最小 HR 尺寸，当前 smoke 使用 `96x96`
+- `x_hr` 形状：`[B, 1, H_hr, W_hr]`，当前验证为 `[B, 1, 96, 96]`
+- `x_hr` 数值：`float32`，并在数据侧显式 clamp 到 `[0, 1]`
+- `target_hr`：当前最小协议里与 `x_hr` 指向同一张真实 HR 图像内容，用于后续显式 target adaptation；这是 Stage 4 minimal learnability 选择，不是 paper-final protocol
+- `target_roi`：由 `Stage4RoiTargetAdapter` 显式从 `target_hr` 生成，当前实现是 resize 到 optical `output_crop_hw` 后再 clamp 到 `[0, 1]`
+- `target_roi` 形状：`[B, 1, H_roi, W_roi]`，并要求与 `I_out_roi` 完全一致；当前 smoke 为 `[B, 1, 20, 20]`
+
+preview 保存位置与内容：
+- 预览文件已保存到 [outputs/stage4/data_preview_smoke/pair_preview.png](d:/AI%20project/ONN%20research/sdn-for-super-resolution-reproduction/outputs/stage4/data_preview_smoke/pair_preview.png)
+- 内容包含三列：`x_hr`、`target_roi`、`target_roi (upsampled)`
+- 我已实际查看这张图，字形可解释，没有明显空白或错位
+
+batch / shape 自检结果：
+- 已用真实 EMNIST batch 跑通最小 smoke check
+- 数据构造：`num_samples=16`，得到 `train=12, val=4`
+- batch 成功加载
+- `x_hr.shape = (4, 1, 96, 96)`
+- `target_hr.shape = (4, 1, 96, 96)`
+- `target_roi.shape = (4, 1, 20, 20)`
+- 现有 wrapper 在同批 `x_hr` 上 forward 成功，`I_out_roi.shape = (4, 1, 20, 20)`
+- 已检查 `x_hr / target_hr / target_roi / phi_lr / I_out_roi` 无 `NaN/Inf`
+
+下一步建议：
+- 进入最小 Stage 4 训练脚本 issue
+- 训练脚本直接复用这三个接口：
+  - `batch["x_hr"]`
+  - `Stage4RoiTargetAdapter(batch["target_hr"])`
+  - `MinimalHybridWrapper(x_hr) -> I_out_roi`
+- 先做单样本 overfit，再做小子集 closed-loop run，不要回头再改 wrapper

--- a/docs/ai/prompt/stage4/prompt_stage4-3.md
+++ b/docs/ai/prompt/stage4/prompt_stage4-3.md
@@ -1,0 +1,115 @@
+你正在当前仓库中实现：
+
+Issue 4.3 — Build Stage-4 minimal dataset path and target adapter
+
+当前状态：
+- Stage 3 optical contract 已冻结：
+  phi_lr -> U0 -> U_out_full -> I_out_full -> I_out_roi
+- minimal phase encoder 已完成
+- Stage 4 minimal hybrid wrapper 已完成，并可在 fake batch 上跑通：
+  x_hr -> encoder -> phi_lr -> decoder.forward_from_phase(...) -> I_out_roi
+- 当前缺口不是 optical core，也不是 wrapper，而是：
+  1) 最小真实数据路径
+  2) ROI-aligned supervision target adapter
+
+你必须严格遵循：
+- docs/ai/PROJECT_CONTEXT.md
+- docs/plan/plan_overview.md
+- docs/plan/stage3_contract_freeze.md
+- docs/paper/paper_notes.md
+- 当前仓库内已落地的:
+  - Stage 3 optical module
+  - minimal phase encoder
+  - minimal hybrid wrapper
+  - trusted EMNIST path / baseline path
+- 不重新设计 optical core
+- 不提前做 trainer / loss loop / Stage 5 paper alignment
+- 保持 protocol 最小、真实、可调试，并明确 non-paper-final
+
+本次任务目标：
+构建 Stage 4 的最小真实数据路径，并定义 target adapter，
+让后续 closed-loop training 能监督 wrapper 输出的 I_out_roi。
+
+本次需要回答的核心问题：
+1. Stage 4 的 HR input tensor 到底长什么样？
+2. target_roi 如何从真实图像目标中得到？
+3. target 的 shape 和语义如何与 optical I_out_roi 对齐？
+4. 能否保存少量 preview，确认 input/target 配对是可解释的？
+
+你要完成的核心工作：
+
+A. 复用可信 EMNIST 数据路径
+要求：
+1. 尽量复用当前 trusted EMNIST path，而不是重新发明 dataset
+2. 只做最小 Stage 4 数据壳
+3. 明确 Stage 4 当前使用的输入图像语义：
+   - x_hr 是什么
+   - target_roi 是什么
+4. 不把数据模块写成 paper-final pipeline
+
+B. 定义 Stage 4 HR input format
+要求：
+1. 明确 x_hr 的 shape 约定，例如 [B, 1, H_hr, W_hr]
+2. 明确其数值范围 / dtype / device 约束
+3. 明确是否需要 resize / pad / normalize
+4. 写清当前协议只是 Stage 4 minimal learnability check，不是论文最终 HR protocol
+
+C. 实现 ROI target adapter
+要求：
+1. 给定真实 target 图像，导出可与 I_out_roi 对齐的 supervision target
+2. target shape 必须匹配 optical ROI readout shape
+3. crop / resize / normalization 的逻辑必须显式，不允许隐藏在脚本散代码里
+4. 命名清楚，建议有单独 adapter/helper，而不是把切片逻辑散落在训练脚本中
+5. 要和 Stage 3 已冻结的 ROI contract 一致：
+   - I_out_full 保留用于诊断
+   - 主要监督对象是 I_out_roi
+
+D. 保存 preview artifacts
+至少保存：
+1. input x_hr preview
+2. target_roi preview
+3. 如方便，可保存 input/target pair preview grid
+目标是人工能快速判断：
+- 数据是不是读对了
+- target adapter 有没有明显错位
+- shape/语义是否可解释
+
+推荐落地文件（按需最小化）：
+- src/datasets/stage4_emnist.py
+- src/datasets/target_adapter.py
+- 或等价的小型模块化落点
+- 如确有必要，可加一个很小的 preview script
+不要大规模重构 repo。
+
+必须遵守的边界：
+1. 不实现 trainer
+2. 不实现完整 loss loop
+3. 不改 optical core
+4. 不改 minimal hybrid wrapper 的核心职责
+5. 不把 4.3 做成 paper-final data pipeline
+6. 不把 target adapter 写成隐式、分散、难追踪的脚本逻辑
+7. 不编造 preview 或 batch 结果；跑不通就诚实说明
+
+建议最小验收检查：
+1. 一个 batch 能加载成功
+2. x_hr shape 符合 wrapper 预期
+3. target_roi shape 与 I_out_roi shape 一致
+4. saved previews visually interpretable
+5. target adapter 逻辑可被后续训练脚本直接复用
+
+实现风格要求：
+- small, local, readable changes
+- clear naming
+- 把“真实最小数据路径”和“论文最终数据协议”明确区分
+- 注释里写清楚当前 target adapter 的责任边界
+
+输出要求：
+1. 先简短复述你理解到的 4.3 边界
+2. 列出准备新增/修改的文件
+3. 再实施代码修改
+4. 最后给出：
+   - 变更总结
+   - Stage 4 x_hr / target_roi 的当前定义
+   - preview 保存位置与内容
+   - batch / shape 自检结果
+   - 下一步建议（应指向最小训练脚本，而不是回头再改 wrapper）

--- a/src/datasets/__init__.py
+++ b/src/datasets/__init__.py
@@ -1,0 +1,21 @@
+"""Dataset helpers for the repo's staged reproduction workflow."""
+
+from src.datasets.stage4_emnist import (
+    DEFAULT_STAGE4_DATASET_ROOT,
+    Stage4EMNISTDataset,
+    build_stage4_train_val_datasets,
+    resolve_stage4_dataset_root,
+)
+from src.datasets.target_adapter import (
+    Stage4RoiTargetAdapter,
+    save_stage4_input_target_preview,
+)
+
+__all__ = [
+    "DEFAULT_STAGE4_DATASET_ROOT",
+    "Stage4EMNISTDataset",
+    "Stage4RoiTargetAdapter",
+    "build_stage4_train_val_datasets",
+    "resolve_stage4_dataset_root",
+    "save_stage4_input_target_preview",
+]

--- a/src/datasets/stage4_emnist.py
+++ b/src/datasets/stage4_emnist.py
@@ -1,0 +1,235 @@
+"""Stage 4 minimal EMNIST dataset path.
+
+This module reuses the trusted EMNIST path from the electronic baseline and
+defines the Stage 4 minimal data-side contract:
+
+- `x_hr`: the single-channel HR tensor consumed by the minimal encoder
+- `target_hr`: the real-image supervision source later adapted into `target_roi`
+
+This is intentionally a small, debuggable Stage 4 data shell. It is not the
+paper-final data protocol.
+"""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import torch
+from torch.utils.data import Dataset, Subset
+from torchvision import transforms
+from torchvision.datasets import EMNIST
+from torchvision.transforms import InterpolationMode
+
+
+DEFAULT_STAGE4_DATASET_ROOT = Path("data/raw/emnist")
+
+
+def _normalize_hw(hw: int | Sequence[int], *, name: str) -> tuple[int, int]:
+    if isinstance(hw, int):
+        if hw < 1:
+            raise ValueError(f"{name} must be >= 1, got {hw}.")
+        return (hw, hw)
+
+    if not isinstance(hw, Sequence) or isinstance(hw, (str, bytes)) or len(hw) != 2:
+        raise TypeError(f"{name} must be an int or a length-2 sequence, got {hw!r}.")
+
+    height = int(hw[0])
+    width = int(hw[1])
+    if height < 1 or width < 1:
+        raise ValueError(f"{name} values must be >= 1, got {(height, width)}.")
+    return (height, width)
+
+
+def resolve_stage4_dataset_root(
+    dataset_root: str | Path | None = None,
+    *,
+    config_root: str | Path | None = None,
+) -> Path:
+    """Resolve the minimal Stage 4 EMNIST root without assuming a paper-final config."""
+    if dataset_root is not None:
+        return Path(dataset_root)
+
+    if config_root is not None:
+        cfg_root = Path(config_root)
+        cfg_root_str = str(cfg_root).lower()
+        looks_like_emnist_root = (
+            "emnist" in cfg_root_str
+            or (cfg_root / "EMNIST").exists()
+            or (cfg_root / "raw").exists()
+        )
+        if looks_like_emnist_root:
+            return cfg_root
+
+    return DEFAULT_STAGE4_DATASET_ROOT
+
+
+def _prepare_hr_tensor(
+    image: torch.Tensor,
+    *,
+    expected_hw: tuple[int, int],
+) -> torch.Tensor:
+    if not isinstance(image, torch.Tensor):
+        raise TypeError(f"Expected EMNIST transform to return a tensor, got {type(image)!r}.")
+
+    x_hr = image.detach().clone().float()
+    if x_hr.ndim == 2:
+        x_hr = x_hr.unsqueeze(0)
+    if x_hr.ndim != 3:
+        raise ValueError(
+            "Stage 4 dataset expects CHW image tensors, "
+            f"got shape {tuple(x_hr.shape)}."
+        )
+    if x_hr.shape[0] != 1:
+        raise ValueError(
+            "Stage 4 minimal protocol expects single-channel HR input, "
+            f"got shape {tuple(x_hr.shape)}."
+        )
+    if tuple(x_hr.shape[-2:]) != expected_hw:
+        raise ValueError(
+            "Unexpected HR shape after dataset transform, "
+            f"got {tuple(x_hr.shape[-2:])}, expected {expected_hw}."
+        )
+
+    return torch.clamp(x_hr, 0.0, 1.0).contiguous()
+
+
+class Stage4EMNISTDataset(Dataset[dict[str, Any]]):
+    """Minimal Stage 4 dataset that yields real EMNIST HR tensors.
+
+    Returned sample fields:
+    - `x_hr`: `[1, H_hr, W_hr]`, float32, clamped to `[0, 1]`
+    - `target_hr`: same image content as `x_hr`, reserved for explicit
+      `target_hr -> target_roi` adaptation
+    - `label`: EMNIST label for trace/debug only
+    - `dataset_index`: source index inside the underlying EMNIST split
+
+    This first Stage 4 version deliberately uses the same real image as both
+    encoder input and supervision source. Later paper-aligned protocols may
+    refine that contract, but this module does not assume them.
+    """
+
+    def __init__(
+        self,
+        *,
+        dataset_root: str | Path | None = None,
+        emnist_split: str = "letters",
+        hr_hw: int | Sequence[int] = 96,
+        train: bool = True,
+        download: bool = False,
+    ) -> None:
+        super().__init__()
+        self.dataset_root = resolve_stage4_dataset_root(dataset_root)
+        self.emnist_split = emnist_split
+        self.hr_hw = _normalize_hw(hr_hw, name="hr_hw")
+        self.train = bool(train)
+        self.download = bool(download)
+
+        resize_to_hr = transforms.Compose(
+            [
+                transforms.Resize(
+                    self.hr_hw,
+                    interpolation=InterpolationMode.BICUBIC,
+                    antialias=True,
+                ),
+                transforms.ToTensor(),
+            ]
+        )
+        self.base_dataset = EMNIST(
+            root=str(self.dataset_root),
+            split=self.emnist_split,
+            train=self.train,
+            transform=resize_to_hr,
+            download=self.download,
+        )
+
+    def __len__(self) -> int:
+        return len(self.base_dataset)
+
+    def __getitem__(self, index: int) -> dict[str, Any]:
+        image_hr, label = self.base_dataset[index]
+        x_hr = _prepare_hr_tensor(image_hr, expected_hw=self.hr_hw)
+        return {
+            "x_hr": x_hr,
+            "target_hr": x_hr.clone(),
+            "label": int(label),
+            "dataset_index": int(index),
+        }
+
+
+def build_stage4_train_val_datasets(
+    *,
+    dataset_root: str | Path | None = None,
+    config_root: str | Path | None = None,
+    emnist_split: str = "letters",
+    hr_hw: int | Sequence[int] = 96,
+    num_samples: int = 2000,
+    val_ratio: float = 0.1,
+    seed: int = 42,
+    download: bool = False,
+    overfit_single_sample: bool = False,
+) -> tuple[Dataset[Any], Dataset[Any], dict[str, int | str | list[int]]]:
+    """Build minimal Stage 4 train/val datasets from the trusted EMNIST path."""
+    dataset = Stage4EMNISTDataset(
+        dataset_root=resolve_stage4_dataset_root(dataset_root, config_root=config_root),
+        emnist_split=emnist_split,
+        hr_hw=hr_hw,
+        train=True,
+        download=download,
+    )
+
+    all_indices = list(range(len(dataset)))
+    rng = random.Random(seed)
+    rng.shuffle(all_indices)
+
+    if num_samples > 0:
+        use_count = min(num_samples, len(all_indices))
+        active_indices = all_indices[:use_count]
+    else:
+        active_indices = all_indices
+
+    if not active_indices:
+        raise ValueError("Need at least one Stage 4 sample from EMNIST.")
+
+    if overfit_single_sample:
+        overfit_index = active_indices[0]
+        train_ds = Subset(dataset, [overfit_index])
+        val_ds = Subset(dataset, [overfit_index])
+        return train_ds, val_ds, {
+            "train": 1,
+            "val": 1,
+            "total": 1,
+            "hr_hw": list(dataset.hr_hw),
+            "dataset_root": str(dataset.dataset_root),
+        }
+
+    if len(active_indices) < 2:
+        raise ValueError("Need at least 2 samples to build Stage 4 train/val splits.")
+    if not 0.0 < val_ratio < 1.0:
+        raise ValueError(f"val_ratio must be in (0,1), got {val_ratio}.")
+
+    val_count = max(1, int(len(active_indices) * val_ratio))
+    if val_count >= len(active_indices):
+        val_count = len(active_indices) - 1
+
+    val_indices = active_indices[:val_count]
+    train_indices = active_indices[val_count:]
+    train_ds = Subset(dataset, train_indices)
+    val_ds = Subset(dataset, val_indices)
+    return train_ds, val_ds, {
+        "train": len(train_ds),
+        "val": len(val_ds),
+        "total": len(active_indices),
+        "hr_hw": list(dataset.hr_hw),
+        "dataset_root": str(dataset.dataset_root),
+    }
+
+
+__all__ = [
+    "DEFAULT_STAGE4_DATASET_ROOT",
+    "Stage4EMNISTDataset",
+    "build_stage4_train_val_datasets",
+    "resolve_stage4_dataset_root",
+]

--- a/src/datasets/target_adapter.py
+++ b/src/datasets/target_adapter.py
@@ -1,0 +1,188 @@
+"""Stage 4 minimal ROI target adapter.
+
+This module makes the `target_hr -> target_roi` logic explicit so the Stage 4
+training path can supervise `I_out_roi` without hiding resize/crop logic in a
+training script.
+
+The current adapter is deliberately minimal and non-paper-final:
+
+- input is a real HR target tensor
+- output is a real ROI-aligned supervision tensor
+- adaptation is explicit resize + clamp, not an implicit or learned head
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from src.models.optics.readout import ReadoutConfig
+
+
+def _normalize_hw(hw: int | Sequence[int], *, name: str) -> tuple[int, int]:
+    if isinstance(hw, int):
+        if hw < 1:
+            raise ValueError(f"{name} must be >= 1, got {hw}.")
+        return (hw, hw)
+
+    if not isinstance(hw, Sequence) or isinstance(hw, (str, bytes)) or len(hw) != 2:
+        raise TypeError(f"{name} must be an int or a length-2 sequence, got {hw!r}.")
+
+    height = int(hw[0])
+    width = int(hw[1])
+    if height < 1 or width < 1:
+        raise ValueError(f"{name} values must be >= 1, got {(height, width)}.")
+    return (height, width)
+
+
+def _to_gray_numpy(image: torch.Tensor) -> np.ndarray:
+    tensor = image.detach().cpu().float()
+    if tensor.ndim == 2:
+        return tensor.numpy()
+    if tensor.ndim == 3 and tensor.shape[0] == 1:
+        return tensor[0].numpy()
+    raise ValueError(f"Expected grayscale image tensor, got shape {tuple(tensor.shape)}.")
+
+
+class Stage4RoiTargetAdapter:
+    """Adapt real HR targets into ROI-aligned supervision tensors.
+
+    The Stage 3 optical decoder already owns:
+    `phi_lr -> U0 -> U_out_full -> I_out_full -> I_out_roi`
+
+    This adapter only defines how a real target image is mapped into a
+    supervision tensor aligned with `I_out_roi`. It does not change the optical
+    contract and it does not implement a loss.
+    """
+
+    def __init__(
+        self,
+        *,
+        output_crop_hw: int | Sequence[int] | ReadoutConfig,
+        resize_mode: str = "bicubic",
+        align_corners: bool = False,
+        clamp_range: tuple[float, float] = (0.0, 1.0),
+    ) -> None:
+        if isinstance(output_crop_hw, ReadoutConfig):
+            self.output_crop_hw = output_crop_hw.output_crop_hw
+        else:
+            self.output_crop_hw = _normalize_hw(output_crop_hw, name="output_crop_hw")
+
+        clamp_min = float(clamp_range[0])
+        clamp_max = float(clamp_range[1])
+        if not clamp_min <= clamp_max:
+            raise ValueError(f"clamp_range must be increasing, got {clamp_range}.")
+
+        self.resize_mode = resize_mode
+        self.align_corners = bool(align_corners)
+        self.clamp_range = (clamp_min, clamp_max)
+
+    def _validate_target_hr(self, target_hr: torch.Tensor) -> None:
+        if not isinstance(target_hr, torch.Tensor):
+            raise TypeError(f"target_hr must be a torch.Tensor, got {type(target_hr)!r}.")
+        if target_hr.ndim != 4:
+            raise ValueError(
+                "target_hr must have shape [B, 1, H, W], "
+                f"got {tuple(target_hr.shape)}."
+            )
+        if target_hr.shape[1] != 1:
+            raise ValueError(
+                "Stage 4 minimal target adapter expects single-channel targets, "
+                f"got {tuple(target_hr.shape)}."
+            )
+
+    def __call__(self, target_hr: torch.Tensor) -> torch.Tensor:
+        self._validate_target_hr(target_hr)
+        target_float = target_hr.float()
+
+        resize_kwargs: dict[str, object] = {
+            "size": self.output_crop_hw,
+            "mode": self.resize_mode,
+        }
+        if self.resize_mode in {"linear", "bilinear", "bicubic", "trilinear"}:
+            resize_kwargs["align_corners"] = self.align_corners
+        if self.resize_mode in {"bilinear", "bicubic"}:
+            resize_kwargs["antialias"] = True
+
+        target_roi = F.interpolate(target_float, **resize_kwargs)
+        clamp_min, clamp_max = self.clamp_range
+        return torch.clamp(target_roi, min=clamp_min, max=clamp_max).contiguous()
+
+    def extra_repr(self) -> str:
+        return (
+            f"output_crop_hw={self.output_crop_hw}, "
+            f"resize_mode='{self.resize_mode}', "
+            f"clamp_range={self.clamp_range}"
+        )
+
+
+@torch.no_grad()
+def save_stage4_input_target_preview(
+    output_path: str | Path,
+    *,
+    x_hr: torch.Tensor,
+    target_roi: torch.Tensor,
+    max_rows: int = 4,
+) -> Path:
+    """Save a small preview grid for Stage 4 input/target sanity inspection."""
+    if x_hr.ndim != 4 or x_hr.shape[1] != 1:
+        raise ValueError(f"x_hr must have shape [B,1,H,W], got {tuple(x_hr.shape)}.")
+    if target_roi.ndim != 4 or target_roi.shape[1] != 1:
+        raise ValueError(
+            f"target_roi must have shape [B,1,H,W], got {tuple(target_roi.shape)}."
+        )
+    if x_hr.shape[0] != target_roi.shape[0]:
+        raise ValueError(
+            "x_hr and target_roi batch sizes must match, "
+            f"got {x_hr.shape[0]} vs {target_roi.shape[0]}."
+        )
+
+    row_count = min(max_rows, x_hr.shape[0])
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    target_roi_up = F.interpolate(
+        target_roi[:row_count],
+        size=tuple(x_hr.shape[-2:]),
+        mode="nearest",
+    )
+
+    fig, axes = plt.subplots(row_count, 3, figsize=(9, max(3.0, 3.0 * row_count)))
+    if row_count == 1:
+        axes = np.expand_dims(axes, axis=0)
+
+    titles = ("x_hr", "target_roi", "target_roi (upsampled)")
+    for row_idx in range(row_count):
+        panels = (
+            _to_gray_numpy(x_hr[row_idx]),
+            _to_gray_numpy(target_roi[row_idx]),
+            _to_gray_numpy(target_roi_up[row_idx]),
+        )
+        ranges = (
+            (0.0, 1.0),
+            (0.0, 1.0),
+            (0.0, 1.0),
+        )
+        for col_idx, ax in enumerate(axes[row_idx]):
+            vmin, vmax = ranges[col_idx]
+            ax.imshow(panels[col_idx], cmap="gray", vmin=vmin, vmax=vmax)
+            if row_idx == 0:
+                ax.set_title(titles[col_idx])
+            ax.axis("off")
+        axes[row_idx, 0].set_ylabel(f"sample {row_idx + 1}", rotation=90, labelpad=10)
+
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=180, bbox_inches="tight")
+    plt.close(fig)
+    return output_path
+
+
+__all__ = [
+    "Stage4RoiTargetAdapter",
+    "save_stage4_input_target_preview",
+]


### PR DESCRIPTION
Why:
Stage 4 needs a minimal but real data path that supervises I_out_roi with non-synthetic image targets, so the closed-loop training path can reuse the trusted EMNIST source while keeping the protocol small, explicit, and non-paper-final.

What:
Add a Stage 4 dataset module that reuses the current EMNIST path, defines the HR input format for x_hr, and add an explicit ROI target adapter that derives target_roi with clear resize/crop semantics matching the optical ROI readout shape.

Validation:
Verify that a real batch loads successfully, x_hr matches the wrapper input contract, target_roi matches the optical I_out_roi shape, and preview artifacts for input/target pairs are saved and visually interpretable for sanity inspection.

ref: #38 