### PR TITLE
docs(docs/ | stage 4-6&4-7): add Stage 4 acceptance reports for single-sample and small-subset

### DIFF
--- a/docs/ai/CodexFeedback/stage4/feedback_stage4-6.md
+++ b/docs/ai/CodexFeedback/stage4/feedback_stage4-6.md
@@ -1,0 +1,143 @@
+## Issue 4.6 Feedback
+
+### 任务边界
+
+本次只执行 Stage 4 的正式 single-sample overfit 验收，不改 optical core，不改 dataset / adapter / wrapper，不扩展成 Stage 5 或通用训练框架。分析对象仅限已有 trainer `scripts/train_stage4_minimal.py` 生成的单样本运行工件。
+
+### 使用命令
+
+首轮正式验收运行：
+
+```bash
+python scripts/train_stage4_minimal.py \
+  --single-sample \
+  --steps 100 \
+  --device cuda \
+  --dataset-root data/raw/emnist \
+  --download \
+  --run-name issue4_6_single_sample_100
+```
+
+由于首轮已经清楚下降，但为确认 learnability 趋势又补跑了更强的单样本版本：
+
+```bash
+python scripts/train_stage4_minimal.py \
+  --single-sample \
+  --steps 300 \
+  --device cuda \
+  --dataset-root data/raw/emnist \
+  --run-name issue4_6_single_sample_300
+```
+
+### 设备与工件目录
+
+- 设备：`cuda`
+- 本地回传工件目录：
+  - `outputs/stage4/minimal_trainer/issue4_6_single_sample_100/`
+  - `outputs/stage4/minimal_trainer/issue4_6_single_sample_300/`
+
+两次运行都包含：
+
+- `config_snapshot.json`
+- `history.json`
+- `run_summary.json`
+- `loss_curve.png`
+- `preview_step0.png`
+- `preview_best.png`
+- `preview_final.png`
+- `phi_preview_step0.png`
+- `phi_preview_best.png`
+- `phi_preview_final.png`
+- `grad_stats.json`
+- `checkpoints/checkpoint_best.pt`
+- `checkpoints/checkpoint_latest.pt`
+
+### 核心结果摘要
+
+| run | steps | initial loss | best loss | final loss | encoder grad | optics grad | NaN/Inf |
+|---|---:|---:|---:|---:|---|---|---|
+| `issue4_6_single_sample_100` | 100 | 0.213564 | 0.164205 | 0.164152 | observed | observed | none |
+| `issue4_6_single_sample_300` | 300 | 0.213564 | 0.117267 | 0.116939 | observed | observed | none |
+
+补充指标：
+
+- 100-step final val metrics:
+  - `val_loss = 0.164152`
+  - `val_psnr = 12.1184`
+  - `val_ssim = 0.3732`
+- 300-step final val metrics:
+  - `val_loss = 0.116939`
+  - `val_psnr = 10.8155`
+  - `val_ssim = 0.2243`
+
+### 工件检查结论
+
+#### 1. Loss 是否清楚下降
+
+是。
+
+- 100-step 的 train / val loss 基本同步、平滑下降，末端仍在下降，没有数值爆炸或停滞。
+- 300-step 继续把 normalized MAE 从 `0.213564` 压到 `0.116939`，说明当前最小闭环在单样本上存在持续可学习性。
+
+#### 2. 输出 ROI 是否更接近 target
+
+是，但要带上一个重要限定：
+
+- `preview_step0.png` 中的 `pred I_out_roi` 主要是扩散的大块亮斑，和 `target_roi` 的字符结构不对齐。
+- 到 100-step 时，预测已经从“泛化亮斑”收缩成可辨认的字符拓扑，`|pred-target|` 也从大面积高误差变成更集中在笔画附近。
+- 到 300-step 时，预测的空间结构进一步贴近 target 的主轮廓，背景明显更暗，误差图主要集中在字符边缘和局部笔画残差。
+
+限定项：
+
+- 当前预览图展示的是 raw `I_out_roi`，而训练目标是 ROI-level normalized MAE，内部存在按样本重标定的 `sigma`。
+- 因此 raw 读出预览、PSNR/SSIM 与训练主损失并不完全同向。300-step 上 loss 明显更低，但 raw `val_psnr/val_ssim` 反而低于 100-step，这更像是“训练目标与 raw 强度可视化不完全一致”，而不是 learnability 消失。
+
+#### 3. Encoder 与 optics 梯度是否非零
+
+是。
+
+- 100-step：`encoder_nonzero_steps = 100 / 100`，`optics_nonzero_steps = 100 / 100`
+- 300-step：`encoder_nonzero_steps = 300 / 300`，`optics_nonzero_steps = 300 / 300`
+
+这说明当前单样本闭环训练中，encoder 和 optics 参数都持续收到了有效梯度。
+
+#### 4. 是否出现 NaN / Inf 或明显数值异常
+
+没有。
+
+- `run_summary.json` 中 `initial_preview_finite = true`、`final_preview_finite = true`
+- loss curve 连续，没有出现爆炸或异常跳变
+- `phi_preview_final.png` 显示相位图已经形成结构化模式，并覆盖接近完整的相位范围，但没有数值崩溃迹象
+
+### Verdict
+
+**PASS**
+
+理由：
+
+1. 单样本 closed-loop loss 明确下降，且 100-step 已足以构成正式验收证据。
+2. 预测 ROI 从初始扩散亮斑演化到与目标字符轮廓更接近的结构。
+3. encoder 与 optics 梯度在整个训练过程中均被持续观测到。
+4. 没有 NaN / Inf 或明显数值不稳定。
+
+保留说明：
+
+- 300-step 的 raw PSNR/SSIM 回落，不应被忽略，但在当前 Stage 4 最小协议下，它更像是“当前 normalized-MAE 训练目标与 raw ROI 可视化指标不完全一致”的现象，而不是 Issue 4.6 的验收失败。
+- 因此本次 PASS 是“最小单样本 learnability 已成立”的 PASS，不是“paper-final 读出质量已经理想”的 PASS。
+
+### 最可能的后续关注点
+
+当前最窄的下一步，不是重写 trainer，也不是跳到 Stage 5，而是继续做下一个最小验收任务：
+
+- 进入 Stage 4 的 **small-subset acceptance run**
+- 继续使用同一 trainer、同一 dataset path、同一 wrapper
+- 重点检查：
+  - 小子集下 loss 是否仍能稳定下降
+  - 梯度可观测性是否保持
+  - 预览图是否从单样本记忆延伸到“少量真实样本上的持续可学”
+
+如果后续需要更细地解释 300-step 的 PSNR/SSIM 回落，最窄的调试目标应是：
+
+- 在分析侧额外区分 raw `I_out_roi` 与 loss 内部 `sigma` 重标定后的读出
+
+这属于验收解释增强，不构成当前 Issue 4.6 的阻塞。

--- a/docs/ai/CodexFeedback/stage4/feedback_stage4-7.md
+++ b/docs/ai/CodexFeedback/stage4/feedback_stage4-7.md
@@ -1,0 +1,110 @@
+# Stage 4 Small-Subset Report
+
+## 1. 任务边界
+
+- 本次只验证 Stage 4 小子集 closed-loop learnability
+- 不重写 optical core
+- 不重写 dataset / adapter / wrapper / trainer
+- 不进入 Stage 5 paper-aligned settings
+
+## 2. 运行命令
+
+实际运行（根据 `config_snapshot.json` 还原的参数）：
+
+```bash
+python scripts/train_stage4_minimal.py \
+  --subset-size 16 \
+  --batch-size 4 \
+  --steps 200 \
+  --preview-limit 4 \
+  --device cuda \
+  --dataset-root data/raw/emnist \
+  --run-name issue4_7_small_subset_16_s200
+```
+
+补充运行（更强验证，仍基于同一子集与配置）：
+
+```bash
+python scripts/train_stage4_minimal.py \
+  --subset-size 16 \
+  --batch-size 4 \
+  --steps 400 \
+  --preview-limit 4 \
+  --device cuda \
+  --dataset-root data/raw/emnist \
+  --run-name issue4_7_small_subset_16_s400
+```
+
+## 3. 设备与工件目录
+
+- 设备：`cuda`
+- 工件目录：
+  - `outputs/stage4/minimal_trainer/issue4_7_small_subset_16_s200/`
+  - `outputs/stage4/minimal_trainer/issue4_7_small_subset_16_s400/`
+
+## 4. Core Scalar Results
+
+### 200 steps
+
+- initial loss: `0.217708`
+- best loss: `0.149736` @ step 171
+- final loss: `0.180445`
+- val loss: `0.192186`
+- val PSNR / SSIM: `8.3882` / `0.0557`
+
+### 400 steps
+
+- initial loss: `0.217708`
+- best loss: `0.144116` @ step 360
+- final loss: `0.171176`
+- val loss: `0.190612`
+- val PSNR / SSIM: `8.3843` / `0.0556`
+
+### 趋势结论
+
+- train loss 明确下降，但波动较大（小子集 + mini-batch 导致）。
+- val loss 从 `0.2286` 降到约 `0.19` 后趋于平台。
+- 与 single-sample 不同，小子集下 loss 不会接近 0，是可预期现象。
+
+## 5. Preview / Artifact Inspection Findings
+
+- 多个输入是否不同：是（预览行对应不同 EMNIST 字符）。
+- 多个输出是否随输入变化：是，但变化主要体现在亮斑位置 / 形状的偏移，细节与 target_roi 仍不匹配。
+- 是否出现明显 collapse 到单一亮斑 / 单一模式：否。预测输出仍受输入影响，但整体仍偏“模糊亮斑”。
+
+## 6. Gradient Findings
+
+- encoder gradients：全程观测到非零梯度（200/200、400/400 steps）。
+- optics gradients：全程观测到非零梯度（200/200、400/400 steps）。
+
+## 7. Stability Findings
+
+- NaN / Inf：未发现（`run_summary.json` 显示 `initial_preview_finite=true`、`final_preview_finite=true`）。
+- 是否存在明显数值不稳定：未见明显不稳定或爆炸。
+
+## 8. Verdict
+
+**PASS（带保留项）**
+
+理由：
+
+1. loss 在小子集上有明确下降，且无数值异常。
+2. encoder / optics 梯度持续可观测。
+3. 输出对输入有响应，没有明显 collapse 到单一模式。
+
+保留项：
+
+- 预测仍以模糊亮斑为主，细节不足；val PSNR/SSIM 偏低。
+- 这说明当前最小闭环“可学”成立，但距离 paper-final 读出质量仍有明显差距。
+
+## 9. 非阻塞未决项
+
+- loss 降到的平台值较高，可能与最小 encoder 容量、toy optics grid、normalized MAE 目标的 per-sample 归一化有关。
+- 这不是阻塞项，但需要在 Stage 4 总结中明确为“最小可学习性成立、质量尚不达标”。
+
+## 10. 下一步
+
+进入 Stage 4 的 first summary / execution logging 整理，明确：
+
+- 单样本与小子集均通过可学习性验收
+- 小子集仍存在输出模糊与指标偏低的现象（非阻塞）

--- a/docs/ai/prompt/stage4/prompt_stage4-6.md
+++ b/docs/ai/prompt/stage4/prompt_stage4-6.md
@@ -1,0 +1,77 @@
+You are working on Stage 4 of the repo. Execute Issue 4.6 only.
+
+Goal:
+Use the existing Stage 4 minimal closed-loop trainer to run the formal single-sample overfit acceptance experiment and write an honest acceptance report.
+
+Critical boundaries:
+- DO NOT rewrite the optical core.
+- DO NOT rewrite dataset / adapter / wrapper.
+- DO NOT expand into Stage 5 or a general training framework.
+- DO NOT redesign the Stage 4 trainer unless a tiny bugfix is strictly required to complete the acceptance run.
+- Reuse the existing script: scripts/train_stage4_minimal.py
+- This issue is an execution + inspection + reporting issue, not a new architecture issue.
+
+Context from Issue 4.5:
+- The minimal trainer already exists and runs.
+- It supports --single-sample and --subset-size.
+- It already saves history, summaries, previews, checkpoints, loss curves, and grad stats.
+- CPU smoke already showed:
+  - single-sample loss decreased slightly
+  - encoder gradients observed
+  - optics gradients observed
+- Therefore, for Issue 4.6, the task is to run a stronger single-sample acceptance experiment and document the result honestly.
+
+What to do:
+1. Inspect scripts/train_stage4_minimal.py and confirm the proper CLI usage for a formal single-sample run.
+2. Run a formal single-sample overfit experiment with a stronger step count than smoke.
+   - Start with a reasonable acceptance setting such as:
+     python scripts/train_stage4_minimal.py --single-sample --steps 100
+   - If the result is still ambiguous and the script is stable, extend to a stronger run such as 300 or 500 steps.
+   - Prefer GPU if available; otherwise run on CPU and state the limitation honestly.
+3. Collect and inspect all artifacts:
+   - config_snapshot.json
+   - history.json
+   - run_summary.json
+   - loss_curve.png
+   - preview_step0.png
+   - preview_best.png
+   - preview_final.png
+   - phi previews
+   - checkpoints
+   - grad_stats.json
+4. Evaluate acceptance against the issue intent:
+   - Does loss decrease clearly?
+   - Does output ROI move closer to target?
+   - Are encoder and optical gradients non-zero?
+   - Are there any NaN/Inf or numerical issues?
+5. Write a concise but honest report at:
+   docs/execution/stage4_single_sample_report.md
+
+Report requirements:
+- State exact command(s) used
+- State device used
+- State output artifact directory
+- Summarize initial loss, best loss, final loss
+- Summarize whether encoder and optics gradients were observed
+- Summarize preview observations
+- Give a clear PASS / FAIL / BORDERLINE verdict
+- If FAIL or BORDERLINE, explain the most likely reason without overclaiming
+- Include a short “next step” section:
+  - if pass: recommend proceeding to the next minimal Stage 4 acceptance task
+  - if fail: recommend the narrowest next debugging target, not a broad redesign
+
+Implementation style:
+- Minimal changes only.
+- If a tiny bugfix is necessary to complete the acceptance run, keep it surgical and explain it clearly.
+- Do not hide failure.
+- Do not artificially relax acceptance wording to force a pass.
+
+Deliverables:
+- completed acceptance run artifacts
+- docs/execution/stage4_single_sample_report.md
+
+At the end, provide:
+1. a short summary of what was run,
+2. verdict (PASS / FAIL / BORDERLINE),
+3. files changed,
+4. exact next recommendation.

--- a/docs/ai/prompt/stage4/prompt_stage4-7.md
+++ b/docs/ai/prompt/stage4/prompt_stage4-7.md
@@ -1,0 +1,230 @@
+You are working in a research engineering repository for reproducing
+“Super-resolution image display using diffractive decoders”.
+
+Your task is to complete GitHub Issue 4.7:
+
+Issue title:
+Run small-subset closed-loop training and produce first Stage-4 summary
+
+This issue starts only after Issue 4.6 has already passed.
+Do NOT re-open or re-implement the single-sample acceptance work.
+Use the existing Stage 4 training stack as-is unless a tiny run-blocking fix is strictly necessary.
+
+==================================================
+0. MUST-READ CONTEXT FIRST
+==================================================
+
+Before doing anything, you MUST read and follow these:
+
+- stage4_issue_plan.md
+- stage4_plan.md
+- stage4_protocol_freeze.md
+- feedback_stage4-6.md
+
+Also inspect the current repo implementation that Issue 4.7 depends on, especially:
+- `scripts/train_stage4_minimal.py`
+- the current Stage 4 encoder / wrapper / dataset path / trainer-related files already used in Issue 4.6
+- any report/output conventions used by the repo
+
+Important context from Issue 4.6:
+- single-sample closed-loop acceptance already PASSed
+- encoder gradients were observed
+- optics gradients were observed
+- no NaN/Inf
+- the next narrow step is the small-subset acceptance run
+Do not turn this issue into a redesign of trainer / loss / optics / dataset. :contentReference[oaicite:6]{index=6}
+
+==================================================
+1. ISSUE 4.7 GOAL
+==================================================
+
+Run the first small-subset Stage 4 closed-loop training acceptance experiment and summarize whether the learnability observed in single-sample overfit extends beyond one sample.
+
+This issue is about acceptance evidence, not architectural expansion.
+
+You must answer, with real run artifacts:
+
+1. Does loss still decrease on a small real subset?
+2. Do encoder and optics gradients remain observable?
+3. Are outputs input-dependent across samples?
+4. Is there any obvious collapse to a single pattern?
+5. Does the evidence support a PASS or FAIL judgment for small-subset Stage 4 acceptance?
+
+==================================================
+2. NON-GOALS — DO NOT DRIFT
+==================================================
+
+Do NOT do any of the following unless absolutely required by a run-blocking bug:
+
+- do not redesign the optical core
+- do not redesign the dataset / adapter / wrapper
+- do not introduce Stage 5 paper-aligned settings
+- do not add large-scale training
+- do not rewrite the trainer into a general framework
+- do not perform L=1/3/5 sweeps
+- do not introduce quantization / robustness / misalignment studies
+- do not “improve” Issue 4.6 retroactively
+- do not create stage-based source directories
+
+==================================================
+3. BRANCH / WORKTREE EXPECTATION
+==================================================
+
+This issue belongs to the training / acceptance path.
+
+Preferred working branch:
+- `feat/train`
+
+If `feat/train` is no longer clean or has diverged too much from latest `dev`,
+create a clean branch from latest `dev` such as:
+- `feat/train-stage4`
+
+Do NOT work on `docs/*` branches.
+
+Before coding/running, verify the current branch and working tree are appropriate.
+
+==================================================
+4. WHAT TO RUN
+==================================================
+
+Use the existing Stage 4 trainer and run a small-subset closed-loop acceptance experiment.
+
+Stay close to the existing single-sample pipeline from Issue 4.6.
+Reuse:
+- same trainer
+- same dataset path style
+- same model stack
+- same artifact conventions
+
+Select a small real subset size appropriate for Stage 4 acceptance.
+A reasonable target is something like:
+- 8 / 16 / 32 samples
+
+Choose a small subset size that is:
+- non-trivial
+- computationally manageable
+- sufficient to expose whether the model collapses or remains input-dependent
+
+Do not silently choose a huge run.
+
+==================================================
+5. REQUIRED ARTIFACTS
+==================================================
+
+The run output directory should contain the usual Stage 4 trainer artifacts, including as applicable:
+
+- config snapshot
+- history
+- run summary
+- loss curve
+- representative previews
+- phase previews
+- gradient statistics
+- checkpoints
+
+In addition, for this issue you MUST ensure there is enough evidence to inspect:
+- multiple different inputs
+- their corresponding outputs
+- whether outputs differ across inputs
+- whether there is obvious collapse
+
+If the current trainer already saves suitable multi-sample previews, use that.
+If it does not, add only the smallest necessary artifact/reporting enhancement to support this issue.
+
+Do NOT turn this into a visualization framework overhaul.
+
+==================================================
+6. REQUIRED ANALYSIS
+==================================================
+
+You must inspect and summarize at least:
+
+### A. Loss behavior
+- initial vs best vs final loss
+- whether train/val loss decrease meaningfully on the subset
+
+### B. Gradient observability
+- whether encoder gradients are non-zero across training
+- whether optics gradients are non-zero across training
+
+### C. Output diversity / anti-collapse check
+- whether outputs differ across different inputs
+- whether the model collapses to a single generic bright blob / generic pattern
+- whether the learned behavior remains input-dependent
+
+### D. Numerical stability
+- NaN / Inf presence or absence
+- obvious instability or not
+
+### E. Honest verdict
+Give a clear PASS / FAIL judgment for Issue 4.7 specifically.
+
+==================================================
+7. REPORT DELIVERABLE
+==================================================
+
+Create or update the concise report:
+
+- `docs/execution/stage4_small_subset_report.md`
+
+The report must include:
+
+1. Task boundary
+2. Run command(s)
+3. Device and artifact directory
+4. Core scalar results
+5. Preview / artifact inspection findings
+6. Gradient findings
+7. Stability findings
+8. PASS / FAIL verdict
+9. If PASS, what remains unresolved but non-blocking
+10. The most natural next step after Issue 4.7
+
+The tone must be honest and engineering-oriented.
+Do not exaggerate success.
+Do not pretend Stage 5 quality has been reached.
+
+==================================================
+8. ALLOWED CODE CHANGES
+==================================================
+
+Preferred path:
+- run the existing trainer with no code change if possible
+
+If a small-subset acceptance run reveals that one tiny change is strictly required to:
+- select a small subset
+- save representative multi-sample previews
+- report gradients / summaries cleanly
+
+then make only the narrowest necessary change.
+
+Do NOT do unrelated refactors.
+
+==================================================
+9. ACCEPTANCE CRITERIA
+==================================================
+
+Issue 4.7 is complete only if:
+
+1. A real small-subset closed-loop run has been executed
+2. Loss decreases meaningfully on the subset
+3. Encoder gradients remain observable
+4. Optics gradients remain observable
+5. There is evidence that outputs are input-dependent
+6. There is no obvious collapse to a single pattern
+7. `docs/execution/stage4_small_subset_report.md` gives an honest PASS / FAIL judgment
+8. The issue remains Stage-4-scoped and does not drift into Stage 5
+
+==================================================
+10. FINAL RESPONSE FORMAT
+==================================================
+
+After finishing, respond with:
+
+- short summary of what was run / changed
+- exact files changed
+- exact run command(s)
+- artifact output path(s)
+- core results summary
+- PASS / FAIL verdict for Issue 4.7
+- any remaining non-blocking caveats

--- a/docs/plan/stage_plan/stage5/stage5_issue_plan.md
+++ b/docs/plan/stage_plan/stage5/stage5_issue_plan.md
@@ -1,0 +1,615 @@
+﻿**GPT-5.4**
+
+下面给出一份 **Stage 5 详细工程推进计划**，用于直接拆成 GitHub issues 执行。内容基于当前仓库与既有文档：`plan_overview.md`、`stage4_protocol_freeze.md`、`paper_notes.md` 和 execution logs。
+
+Stage 5 的核心不是“系统化消融”，而是 **把论文主设定落地成可运行、可复盘的工程协议**。系统化 sweep、量化、鲁棒性和大规模对比应后置到 Stage 6。
+
+前置条件提醒：
+
+- Stage 4 单样本 overfit 与小子集闭环必须已经通过
+- 若单样本闭环报告缺失，建议先补齐，再进入 Stage 5
+
+---
+
+# 一、Stage 5 的工程目标重述
+
+一句话版本：
+
+> **把论文的完整设定（96×96 数据协议、200/400 光学网格、L=1/3/5、phase-only encoder、loss/效率项、训练超参、评估口径）落地为可复现 pipeline，并产出首个 paper-aligned 训练结果。**
+
+---
+
+# 二、Stage 5 拆解为 10 个 GitHub Issues
+
+建议命名方式：
+
+- Milestone: `Stage 5 — Paper-Aligned Settings`
+- Issue 编号：`5.1 ~ 5.10`
+
+---
+
+# Issue 5.1 — Freeze Stage-5 paper-aligned protocol and unresolved-parameters ledger
+
+## 这个 issue 要解决什么
+
+先把 Stage 5 的协议冻住，不然所有实现都会漂。
+
+要明确：数据构造、光学 grid、distance schedule、encoder 输出尺寸、loss 公式、训练超参与评估协议，并把未决项列成清单。
+
+## 输入
+
+- `docs/plan/plan_overview.md`
+- `docs/plan/stage_plan/stage4/stage4_protocol_freeze.md`
+- `docs/paper/paper_notes.md`
+- `docs/execution/results_summary.md`
+
+## 产物
+
+- `docs/plan/stage_plan/stage5/stage5_protocol_freeze.md`
+
+## 验收标准
+
+- 文档明确 Stage 5 与 Stage 6 的边界
+- 论文设定中的关键参数都写清楚
+- 所有不确定项以“待确认”列出
+
+## 风险点
+
+最大风险是把 Stage 5 写成 Stage 6 的消融计划。
+
+## GitHub issue 正文建议
+
+Title:
+`Freeze Stage 5 paper-aligned protocol and unresolved-parameters ledger`
+
+Body:
+```md
+## Background
+Stage 5 should align the repo to the paper's full settings. Without a frozen protocol, implementations will drift and become untraceable.
+
+## Goal
+Write and freeze a Stage-5 protocol document that defines:
+- paper-aligned data protocol
+- optics grid/padding/distances
+- encoder output contract
+- loss and efficiency term
+- training hyperparameters
+- evaluation protocol
+- explicit unresolved items
+
+## Tasks
+- Review plan_overview, Stage-4 protocol freeze, and paper_notes
+- Define the Stage 5 dataflow and tensor contract
+- Freeze optics grid and distance schedule mapping
+- Freeze loss definition and efficiency term defaults
+- Record all unresolved items explicitly
+
+## Deliverable
+- `docs/plan/stage_plan/stage5/stage5_protocol_freeze.md`
+
+## Acceptance
+The document makes Stage 5 scope explicit and prevents confusion with Stage 6.
+```
+
+---
+
+# Issue 5.2 — Build paper-aligned EMNIST 96×96 display dataset + augmentation
+
+## 这个 issue 要解决什么
+
+实现论文的 display dataset 构造：28×28 letters → 32×32 → 96×96 拼图，并对齐 train/val/test 划分与样本分布。
+
+## 设计要点
+
+- train/val 含 1~4 letters
+- test 含 6~9 letters
+- 记录 tile 规则与随机种子
+- 加入 rotation / flip / contrast augmentation
+
+## 产物
+
+- 新数据模块（建议 `src/data/stage5_emnist_display.py`）
+- 可视化样本预览
+- config 入口（不把参数写死）
+
+## 验收标准
+
+- 可生成 96×96 图像 batch
+- train/val/test 分布符合论文描述
+- 保存预览图可解释
+
+## 风险点
+
+tile 规则若不透明，后续结果无法对齐论文。
+
+## GitHub issue 正文建议
+
+Title:
+`Build paper-aligned 96×96 EMNIST display dataset with augmentation`
+
+Body:
+```md
+## Background
+Paper-aligned training requires the 96×96 EMNIST display dataset with specific train/val/test composition rules.
+
+## Goal
+Implement a dataset pipeline that reproduces the paper's 96×96 display protocol, including augmentation.
+
+## Tasks
+- Construct 96×96 samples from EMNIST letters (28→32, then tile)
+- Enforce train/val/test size and letter-count distribution
+- Add rotation/flip/contrast augmentation options
+- Save a small preview grid of generated samples
+- Keep all rules configurable
+
+## Deliverable
+- Dataset module under `src/data/`
+- Preview artifacts for sanity checks
+- Config entries for dataset construction
+
+## Acceptance
+- A batch loads successfully with correct shapes
+- Train/val/test splits match the paper's distribution
+- Previews are visually interpretable and logged
+```
+
+---
+
+# Issue 5.3 — Add paper-aligned optics configs for L=1/3/5 (200/400 grid + distances)
+
+## 这个 issue 要解决什么
+
+把论文的 optical geometry 变成可复用的 config，并确保 L=1/3/5 都可 forward。
+
+## 关键要点
+
+- layer grid 200×200
+- propagation grid 400×400（zero padding）
+- input/output FOV 96×96
+- 距离 schedule 必须显式映射到 `input_to_first / inter_layer / last_to_sensor`
+
+## 产物
+
+- optics config（建议 `configs/optics/paper_l1.yaml`、`paper_l3.yaml`、`paper_l5.yaml`）
+- smoke check 脚本或更新现有 sanity script
+
+## 验收标准
+
+- L=1/3/5 forward 成功
+- 输出 shape 与 ROI 对齐
+- distances mapping 清楚且可追溯
+
+## 风险点
+
+距离映射不清会导致“跑得通但不对齐”。
+
+## GitHub issue 正文建议
+
+Title:
+`Add paper-aligned optics configs for L=1/3/5 (200/400 grid + distances)`
+
+Body:
+```md
+## Background
+Stage 5 requires paper-aligned optics geometry: 200×200 layer grid, 400×400 propagation grid, and explicit distance schedules.
+
+## Goal
+Create reusable optics configs for L=1/3/5 that match the paper settings and pass forward sanity checks.
+
+## Tasks
+- Define paper-aligned grid/padding settings in config files
+- Map paper distances to input_to_first / inter_layer / last_to_sensor
+- Add or reuse a sanity script to validate shapes and forward stability
+
+## Deliverable
+- Optics config files under `configs/optics/`
+- Forward sanity evidence for L=1/3/5
+
+## Acceptance
+- L=1/3/5 forward works with correct shapes
+- Distance mapping is explicit and documented
+```
+
+---
+
+# Issue 5.4 — Implement paper-aligned phase-only encoder (v1)
+
+## 这个 issue 要解决什么
+
+实现论文主线 encoder，把 96×96 HR 输入映射为低分辨率 phase-only `phi_lr`。
+
+## 设计要点
+
+- 输出 shape 对齐 paper LR pattern（默认 32×32，但需在协议中确认）
+- 显式相位范围映射（例如 `[-π, π]`）
+- 不改 optical core
+
+## 产物
+
+- `src/models/encoder/paper_encoder_v1.py`
+- 对应 config 入口
+
+## 验收标准
+
+- forward 输出 shape 正确
+- phase 范围受控
+- 可接入 `forward_from_phase(...)`
+
+## 风险点
+
+输出尺寸或相位范围不明确会导致全链路偏差。
+
+## GitHub issue 正文建议
+
+Title:
+`Implement paper-aligned phase-only encoder for Stage 5`
+
+Body:
+```md
+## Background
+Stage 5 requires a paper-aligned encoder that outputs a low-resolution phase-only pattern compatible with the frozen optical contract.
+
+## Goal
+Add a paper-aligned encoder module that maps 96×96 HR input to a phase-only `phi_lr` tensor.
+
+## Tasks
+- Implement `paper_encoder_v1.py` under `src/models/encoder/`
+- Ensure output spatial size matches the paper LR pattern size
+- Apply explicit phase-range mapping
+- Keep the optical core untouched
+
+## Deliverable
+- Paper-aligned encoder module
+- Config options for encoder size and phase mapping
+
+## Acceptance
+- Output shape and range are correct
+- Forward integrates with the current diffractive decoder
+```
+
+---
+
+# Issue 5.5 — Implement paper-aligned loss with efficiency penalty
+
+## 这个 issue 要解决什么
+
+把论文的 normalized MAE + efficiency term 落地为可配置损失。
+
+## 设计要点
+
+- σ 归一化项按论文公式实现
+- efficiency term 可开关
+- γ 对 L=1/3/5 可配置
+
+## 产物
+
+- loss 实现（建议 `src/losses/paper_sr_loss.py`）
+- config 入口
+- 最小 unit check（前向数值稳定）
+
+## 验收标准
+
+- loss 数值稳定（无 NaN/Inf）
+- γ 与开关可配置
+
+## 风险点
+
+若 σ 归一化实现偏差，会导致训练曲线不可对齐。
+
+## GitHub issue 正文建议
+
+Title:
+`Add paper-aligned SR loss with efficiency penalty`
+
+Body:
+```md
+## Background
+The paper uses normalized MAE plus an efficiency term. Stage 5 must align this loss exactly and keep it configurable.
+
+## Goal
+Implement the paper-aligned loss function with a switchable efficiency term and configurable gamma values.
+
+## Tasks
+- Implement normalized MAE with sigma normalization
+- Add the efficiency penalty term
+- Make gamma and on/off flags configurable per depth
+- Add a small sanity check for numerical stability
+
+## Deliverable
+- Loss implementation under `src/losses/`
+- Config options for gamma and efficiency toggle
+
+## Acceptance
+- Loss runs stably on a fake batch
+- Gamma values and toggles are configurable and logged
+```
+
+---
+
+# Issue 5.6 — Build Stage-5 paper-aligned trainer + configs
+
+## 这个 issue 要解决什么
+
+实现 Stage 5 主线训练脚本，能跑 paper-aligned 设置并保存完整工件。
+
+## 设计要点
+
+- 支持 encoder / decoder 参数分组（不同 LR）
+- 支持长训与 resume
+- 保存 config snapshot / summary / metrics / checkpoints / sample previews
+
+## 产物
+
+- `scripts/train_stage5_paper.py`
+- 训练 config 模板（dataset / optics / loss / optimizer）
+
+## 验收标准
+
+- 能完成短 smoke 训练
+- 产物齐全且可追溯
+
+## 风险点
+
+trainer 过度泛化会把 Stage 6 需求提前塞进来。
+
+## GitHub issue 正文建议
+
+Title:
+`Implement Stage 5 paper-aligned trainer and configs`
+
+Body:
+```md
+## Background
+Stage 5 needs a dedicated trainer that runs the paper-aligned pipeline with correct configs and artifacts.
+
+## Goal
+Create a paper-aligned training script with clear configs, artifact saving, and resume support.
+
+## Tasks
+- Add `scripts/train_stage5_paper.py`
+- Support separate LR for encoder and decoder
+- Save config snapshots, summary, metrics, checkpoints, and previews
+- Keep the script minimal and paper-focused
+
+## Deliverable
+- Stage 5 trainer script
+- Config templates under `configs/`
+
+## Acceptance
+- A short run completes successfully
+- All expected artifacts are generated and logged
+```
+
+---
+
+# Issue 5.7 — Add evaluation runner + bicubic baseline + line-pair test
+
+## 这个 issue 要解决什么
+
+实现 paper-aligned 评估：PSNR/SSIM、bicubic baseline、blind line-pair test。
+
+## 产物
+
+- `scripts/eval_stage5_paper.py`
+- bicubic baseline 生成逻辑
+- line-pair / resolution target 生成与评估入口
+
+## 验收标准
+
+- 可以对 val/test 集输出 PSNR/SSIM
+- baseline 结果可复盘
+- line-pair 测试可运行
+
+## 风险点
+
+评估口径不一致会导致结果不可比较。
+
+## GitHub issue 正文建议
+
+Title:
+`Add Stage 5 evaluation runner with bicubic baseline and line-pair test`
+
+Body:
+```md
+## Background
+Paper alignment requires consistent evaluation: PSNR/SSIM, bicubic baseline, and blind line-pair tests.
+
+## Goal
+Provide a unified evaluation runner that reproduces paper-aligned metrics and baselines.
+
+## Tasks
+- Implement `scripts/eval_stage5_paper.py`
+- Add bicubic baseline generation (with anti-aliasing)
+- Add line-pair / resolution target generator and eval hook
+- Log metric outputs in a reproducible format
+
+## Deliverable
+- Evaluation script
+- Baseline and line-pair utilities
+
+## Acceptance
+- PSNR/SSIM can be computed on val/test
+- Bicubic baseline is reproducible
+- Line-pair tests can be executed and logged
+```
+
+---
+
+# Issue 5.8 — Run paper-aligned smoke training and write report
+
+## 这个 issue 要解决什么
+
+用 paper-aligned 配置做一次短训 smoke，验证 pipeline 稳定。
+
+## 产物
+
+- `outputs/stage5/paper_smoke/...`
+- `docs/execution/stage5_smoke_report.md`
+
+## 验收标准
+
+- 无 NaN/Inf
+- loss 有下降趋势
+- 训练产物齐全
+
+## 风险点
+
+若 smoke 不通过，应先修 pipeline，不进入主线大训。
+
+## GitHub issue 正文建议
+
+Title:
+`Run paper-aligned smoke training and write Stage 5 smoke report`
+
+Body:
+```md
+## Background
+Before launching long runs, we need a paper-aligned smoke run to validate the pipeline end-to-end.
+
+## Goal
+Run a short paper-aligned training and record stability and artifacts.
+
+## Tasks
+- Run a short smoke training with paper configs
+- Save checkpoints and preview outputs
+- Record loss trends and stability findings
+- Write a concise smoke report
+
+## Deliverable
+- Smoke run outputs under `outputs/stage5/`
+- `docs/execution/stage5_smoke_report.md`
+
+## Acceptance
+- Training completes without NaN/Inf
+- Loss decreases at least modestly
+- Artifacts and logs are complete
+```
+
+---
+
+# Issue 5.9 — Run paper-aligned main training (phase-only, L=5) + report
+
+## 这个 issue 要解决什么
+
+执行 paper-aligned 主线训练（建议 L=5 phase-only），并记录结果。
+
+## 产物
+
+- `outputs/stage5/paper_main_l5/...`
+- `docs/execution/stage5_main_run_report.md`
+
+## 验收标准
+
+- 训练完成并生成完整工件
+- PSNR/SSIM 与 baseline 可对比
+- 未决项在报告中被明确记录
+
+## 风险点
+
+训练成本高，需提前评估算力与时间预算。
+
+## GitHub issue 正文建议
+
+Title:
+`Run paper-aligned main training (phase-only, L=5) and write report`
+
+Body:
+```md
+## Background
+Stage 5 should produce at least one paper-aligned main run to anchor the reproduction results.
+
+## Goal
+Run the paper-aligned main training for phase-only L=5 and document the results.
+
+## Tasks
+- Train with the paper-aligned L=5 config
+- Run evaluation on val/test
+- Compare against bicubic baseline
+- Write a main-run report with assumptions and gaps
+
+## Deliverable
+- Main run outputs under `outputs/stage5/`
+- `docs/execution/stage5_main_run_report.md`
+
+## Acceptance
+- Training completes with full artifacts
+- Evaluation metrics are recorded and comparable
+- Report clearly states assumptions and remaining gaps
+```
+
+---
+
+# Issue 5.10 — Consolidate Stage-5 docs and make Stage-6 go/no-go decision
+
+## 这个 issue 要解决什么
+
+把 Stage 5 执行结果收口，更新文档，并明确是否进入 Stage 6。
+
+## 产物
+
+- 更新 `docs/execution/experiment_log.md`
+- 更新 `docs/execution/results_summary.md`
+- 更新 `docs/plan/reproduction_plan.md`
+
+## 验收标准
+
+- Stage 5 结果与假设被清楚记录
+- Stage 6 进入条件被明确判定
+
+## GitHub issue 正文建议
+
+Title:
+`Consolidate Stage 5 results and make Stage-6 go/no-go decision`
+
+Body:
+```md
+## Background
+Stage 5 is only useful if its results are consolidated and used to decide Stage 6 entry.
+
+## Goal
+Summarize Stage 5 execution, update docs, and make an explicit Stage-6 decision.
+
+## Tasks
+- Update experiment log and results summary
+- Record all paper-aligned assumptions and unresolved items
+- Summarize smoke and main-run outcomes
+- Make a clear go/no-go call for Stage 6
+
+## Deliverable
+- Updated docs with a clear Stage 6 decision
+
+## Acceptance
+The repo states clearly whether Stage 5 passed and whether Stage 6 may start.
+```
+
+---
+
+# 三、推荐执行顺序（依赖优先）
+
+1. Issue 5.1
+2. Issue 5.2 + 5.3
+3. Issue 5.4 + 5.5
+4. Issue 5.6
+5. Issue 5.7
+6. Issue 5.8
+7. Issue 5.9
+8. Issue 5.10
+
+---
+
+# 四、Milestone 建议
+
+Milestone：`Stage 5 — Paper-Aligned Settings`
+
+Issues：
+
+- 5.1 Freeze Stage 5 paper-aligned protocol and unresolved-parameters ledger
+- 5.2 Build paper-aligned 96×96 EMNIST display dataset with augmentation
+- 5.3 Add paper-aligned optics configs for L=1/3/5 (200/400 grid + distances)
+- 5.4 Implement paper-aligned phase-only encoder for Stage 5
+- 5.5 Add paper-aligned SR loss with efficiency penalty
+- 5.6 Implement Stage 5 paper-aligned trainer and configs
+- 5.7 Add Stage 5 evaluation runner with bicubic baseline and line-pair test
+- 5.8 Run paper-aligned smoke training and write Stage 5 smoke report
+- 5.9 Run paper-aligned main training (phase-only, L=5) and write report
+- 5.10 Consolidate Stage 5 results and make Stage-6 go/no-go decision

--- a/docs/plan/stage_plan/stage5/stage5_plan.md
+++ b/docs/plan/stage_plan/stage5/stage5_plan.md
@@ -1,0 +1,244 @@
+﻿**GPT-5.4**
+
+---
+
+# 第五阶段具体规划（Stage 5 — 论文设定对齐）
+
+---
+
+# 1. 文档定位
+
+本文档定义本仓库 **Stage 5（论文设定对齐）** 的工程规划与验收边界。
+
+Stage 5 的任务不是做系统化消融，而是把论文主设定（数据、光学几何、encoder、loss、训练超参、评估协议）落实成 **可运行、可复盘、可追踪** 的工程协议。
+
+系统化消融、量化 sweep、鲁棒性与大规模对比实验属于 Stage 6。
+
+参考优先级（与现有文档一致）：
+
+1. `docs/plan/plan_overview.md`
+2. `docs/plan/stage3_contract_freeze.md`
+3. `docs/plan/stage_plan/stage4/stage4_protocol_freeze.md`
+4. 当前 `src/` 与 `scripts/`
+5. `docs/paper/paper_notes.md`
+6. `docs/execution/results_summary.md`
+7. `docs/execution/experiment_log.md`
+
+---
+
+# 2. Stage 5 核心目标
+
+1. **数据协议对齐**：实现论文中的 96×96 EMNIST display 数据构造与 train/val/test 划分。
+2. **光学几何对齐**：实现 paper-aligned 的 grid 尺寸、zero padding、距离 schedule 与初始化策略。
+3. **encoder 对齐**：实现论文主线的 phase-only encoder 输出与 `phi_lr` contract。
+4. **损失与训练超参对齐**：实现 normalized MAE + efficiency term，匹配 Adam + LR + batch + epoch 设定。
+5. **评估协议对齐**：落实 PSNR / SSIM 口径、bicubic baseline、blind line-pair test。
+6. **可复现工程化**：用 configs 与日志把上述设置固化，输出可追踪工件与文档。
+
+---
+
+# 3. Stage 5 非目标
+
+以下内容 **不属于 Stage 5**，应明确后置到 Stage 6：
+
+- 系统化 L=1/3/5 sweep 与完整消融矩阵
+- efficiency penalty 的系统化 ablation
+- quantization sweep（16/8/6/4/2 bit）
+- misalignment / robustness / hardware-aware 训练
+- 复杂调制（complex-valued / amplitude-only）系统化对比
+- 大规模参数调参或框架级重构
+
+---
+
+# 4. 进入 Stage 5 的前置条件
+
+进入 Stage 5 前，需满足 Stage 4 通过条件（见 `docs/plan/stage_plan/stage4/stage4_protocol_freeze.md`）：
+
+- 单样本 overfit 闭环通过
+- 小子集闭环训练通过
+- encoder / optics 梯度可观测且非零
+
+当前仓库已存在：
+
+- `docs/execution/stage4_small_subset_report.md`（已通过）
+
+仍需确认：
+
+- 是否已有单样本闭环报告（建议路径：`docs/execution/stage4_single_sample_report.md`）
+
+若单样本证据缺失，应先补齐再进入 Stage 5。
+
+---
+
+# 5. 当前工程状态与 Stage 5 缺口
+
+## 已有基础
+
+- Stage 3 optical contract 已冻结：`phi_lr -> U0 -> U_out_full -> I_out_full -> I_out_roi`
+- Stage 4 已建立最小闭环训练路径（非论文设定）
+- PSNR / SSIM 评估工具与电子 baseline 已通过 Stage 1/2 验证
+
+## Stage 5 缺口
+
+- paper-aligned dataset（96×96 display）
+- paper-aligned optics config（200/400 grid + distances）
+- paper-aligned encoder（phase-only）
+- paper loss + efficiency term
+- paper-aligned trainer 与 config
+- paper-aligned eval + bicubic baseline + line-pair test
+
+---
+
+# 6. 论文设定对齐目标（paper-aligned v1）
+
+## 6.1 数据协议
+
+- 数据源：EMNIST letters
+- 原始 28×28 → bicubic 插值到 32×32
+- 96×96 display 由 32×32 patch 组合构成
+- 数据量：train 60,000 / val 6,000 / test 6,000
+- 内容分布：train/val 含 1~4 个字母；test 含 6~9 个字母
+- 增强：随机旋转（0/90/180/270）、随机翻转、随机对比度
+
+## 6.2 光学几何与网格
+
+- diffractive neuron sampling：0.533 λ
+- layer size：200×200 pixels
+- input/output FOV：96×96 pixels
+- zero padding：400×400
+- depth：L = 1 / 3 / 5
+- 初始化：phase masks = 0
+
+距离（来自 `paper_notes.md`，需显式映射到代码的 distance schedule）：
+
+- L=1：d1 = 6.667λ，d3 = 173.333λ
+- L=3：d1 = 4λ，d2 = 53.334λ，d3 = 53.334λ
+- L=5：d1 = 2.667λ，d2 = 66.667λ，d3 = 80λ
+
+> 注：论文未明确说明这些距离与 `input_to_first / inter_layer / last_to_sensor` 的一一对应，需要在 Stage 5 protocol 中明确映射。
+
+## 6.3 Encoder 与相位约束
+
+- 输入：96×96 HR target image
+- 输出：低分辨率 phase-only pattern `phi_lr`
+- `phi_lr` 空间尺寸预期为 32×32（与 3× SR factor 对齐），但需在 Stage 5 协议中显式确认
+- 相位范围映射需显式（例如 `[0, 2π)` 或 `[-π, π]`），不能隐式藏在 optical core 中
+
+## 6.4 Loss 与效率项
+
+主损失：normalized MAE
+
+\[
+\mathcal L = \frac{1}{N}\sum_i |y_i - \sigma \hat y_i| + \gamma e^{-\eta}
+\]
+
+其中：
+
+\[
+\sigma = \frac{\sum_i y_i}{\sum_i \hat y_i + \epsilon}
+\]
+
+\[
+\eta = 100 \times \frac{P_o}{P_i}
+\]
+
+论文建议：
+
+- γ = 0.005 for L=1
+- γ = 0.015 for L=3
+- 其它情况 γ = 0（需明确是否对 L=5 也为 0）
+
+## 6.5 训练设定
+
+- optimizer：Adam
+- 学习率：decoder 0.001 / encoder 0.0005
+- batch size：40
+- epochs：500
+- 训练需支持 encoder / decoder 参数分组
+
+## 6.6 评估协议
+
+- PSNR / SSIM
+- bicubic baseline（需 anti-aliasing）
+- blind line-pair / resolution target 测试
+- train/val/test 口径与输出 crop 对齐必须在 config 中显式记录
+
+## 6.7 工程化输出
+
+- configs：可复现、可 diff
+- summary.json / metrics.json / checkpoints / sample previews
+- 运行命令与 config snapshot 必须落地
+
+---
+
+# 7. 待确认与假设清单（Stage 5 必须显式记录）
+
+1. `phi_lr` 的精确尺寸是否固定为 32×32（默认假设为 96/3）。
+2. 96×96 display 的具体 tile 规则（布局、放置策略、随机性、空位处理）。
+3. distance schedule 与代码中 `input_to_first / inter_layer / last_to_sensor` 的映射关系。
+4. efficiency penalty 是否对 L=5 也为 0。
+5. phase mapping 使用 `[0, 2π)` 还是 `[-π, π]`（以及初始分布）。
+6. σ 的归一化在 batch 维的 exact 计算方式（逐样本还是逐 batch）。
+7. output FOV 与 full-grid 的 crop 对齐是否有额外 margin / padding 处理。
+
+这些条目必须被写入 Stage 5 protocol freeze 文档，不能隐性处理。
+
+---
+
+# 8. Stage 5 任务拆解（建议）
+
+- **Stage 5A — 协议冻结**：写出 paper-aligned protocol freeze，并冻结未决项处理方式。
+- **Stage 5B — 数据协议落地**：实现 96×96 EMNIST display 数据构造与增强。
+- **Stage 5C — 光学配置对齐**：加入 paper grid/padding/distances 的 optics config（L=1/3/5）。
+- **Stage 5D — Encoder 对齐**：实现 paper-aligned phase-only encoder。
+- **Stage 5E — 损失函数对齐**：normalized MAE + efficiency penalty 可配置化。
+- **Stage 5F — 训练骨架对齐**：Stage 5 trainer + configs，支持长训与 resume。
+- **Stage 5G — 评估协议对齐**：PSNR/SSIM + bicubic baseline + line-pair test。
+- **Stage 5H — paper-aligned smoke**：短跑验证 pipeline 稳定。
+- **Stage 5I — paper-aligned main run**：主线训练与评估结果记录。
+- **Stage 5J — 文档收口**：更新执行日志、结果摘要，给出 Stage 6 入口结论。
+
+---
+
+# 9. Stage 5 验收标准
+
+Stage 5 至少需要满足以下可验证标准：
+
+1. 96×96 display 数据集可稳定生成，预览样本可解释。
+2. paper-aligned optics config 能在 L=1/3/5 下 forward 成功且 shape 正确。
+3. paper-aligned loss / efficiency term 可开关，并在 config 中可追溯。
+4. paper-aligned trainer 可完成 smoke 训练且无 NaN/Inf。
+5. 至少完成一次 paper-aligned 主线训练（建议 L=5 phase-only）。
+6. PSNR/SSIM 与 bicubic baseline 结果可复盘、可对比。
+7. blind line-pair 测试可生成并在 eval 中复用。
+8. 所有关键假设已在 protocol freeze 与 summary 中明确记录。
+
+---
+
+# 10. 风险与排错优先级
+
+1. **显存/内存压力**：400×400 propagation grid 显著增加显存。
+   - 方案：先跑 CPU/小 batch smoke，再转 GPU；必要时引入 gradient checkpointing，但需明确记录。
+2. **数据协议偏差**：96×96 tile 规则若偏差，将导致结果不可对齐。
+   - 方案：保存可视化样本并在文档中记录 tile 规则。
+3. **距离映射歧义**：论文距离参数映射不清会导致物理设置偏差。
+   - 方案：在 protocol freeze 中显式写出 mapping 与理由。
+4. **训练不稳定**：长训 + efficiency term 可能引入数值不稳。
+   - 方案：先关闭 efficiency term 做 smoke；再按 L=1/3 的 γ 值逐步启用。
+
+---
+
+# 11. 文档同步建议
+
+完成 Stage 5 后应更新：
+
+- `docs/execution/experiment_log.md`
+- `docs/execution/results_summary.md`
+- `docs/plan/reproduction_plan.md`
+- `docs/paper/paper_notes.md`（补充明确化的未决参数）
+
+---
+
+# 12. Stage 6 入口条件（简述）
+
+只有当 Stage 5 完成 **paper-aligned pipeline + 至少一次主线训练**，并明确记录所有假设后，才进入 Stage 6 的系统化消融与扩展实验。

--- a/docs/run_order.md
+++ b/docs/run_order.md
@@ -95,6 +95,121 @@ python scripts/train_electronic_baseline.py \
 If data has already been downloaded, you can change `--download` to `--no-download` and
 optionally add `--dataset-root <your_emnist_root>`.
 
+### 4) Stage 4 minimal closed-loop: formal single-sample acceptance
+
+Issue 4.6 is an execution/reporting task, not a new trainer design task. Use the existing
+`scripts/train_stage4_minimal.py` as-is and run the formal single-sample overfit acceptance
+experiment on the Linux server. Start with 100 steps. Only extend to a stronger run if the
+100-step result is still ambiguous.
+
+Recommended first acceptance run:
+
+```bash
+python scripts/train_stage4_minimal.py \
+  --single-sample \
+  --steps 100 \
+  --device cuda \
+  --dataset-root data/raw/emnist \
+  --download \
+  --run-name issue4_6_single_sample_100
+```
+
+If the 100-step result is still borderline but numerically stable, extend to 300 steps:
+
+```bash
+python scripts/train_stage4_minimal.py \
+  --single-sample \
+  --steps 300 \
+  --device cuda \
+  --dataset-root data/raw/emnist \
+  --run-name issue4_6_single_sample_300
+```
+
+After the run finishes, collect at least these files from the output directory:
+
+- `config_snapshot.json`
+- `history.json`
+- `run_summary.json`
+- `loss_curve.png`
+- `preview_step0.png`
+- `preview_best.png`
+- `preview_final.png`
+- `phi_preview_step0.png`
+- `phi_preview_best.png`
+- `phi_preview_final.png`
+- `grad_stats.json`
+- `checkpoints/checkpoint_best.pt`
+- `checkpoints/checkpoint_latest.pt`
+
+Expected output roots:
+
+- `outputs/stage4/minimal_trainer/issue4_6_single_sample_100/`
+- `outputs/stage4/minimal_trainer/issue4_6_single_sample_300/`
+
+### 5) Stage 4 minimal closed-loop: formal small-subset acceptance
+
+Issue 4.7 starts only after Issue 4.6 has already passed. Reuse the same
+`scripts/train_stage4_minimal.py` stack and do not redesign the trainer,
+optics, dataset path, or wrapper. The goal is to check whether the learnability
+seen in single-sample overfit extends to a small real subset without obvious
+collapse.
+
+Recommended first acceptance run:
+
+```bash
+python scripts/train_stage4_minimal.py \
+  --subset-size 16 \
+  --batch-size 4 \
+  --steps 200 \
+  --preview-limit 4 \
+  --device cuda \
+  --dataset-root data/raw/emnist \
+  --download \
+  --run-name issue4_7_small_subset_16_s200
+```
+
+If the 200-step result is still ambiguous but numerically stable, extend to 400
+steps with the same subset size:
+
+```bash
+python scripts/train_stage4_minimal.py \
+  --subset-size 16 \
+  --batch-size 4 \
+  --steps 400 \
+  --preview-limit 4 \
+  --device cuda \
+  --dataset-root data/raw/emnist \
+  --run-name issue4_7_small_subset_16_s400
+```
+
+After the run finishes, collect at least these files from the output directory:
+
+- `config_snapshot.json`
+- `history.json`
+- `run_summary.json`
+- `loss_curve.png`
+- `preview_step0.png`
+- `preview_best.png`
+- `preview_final.png`
+- `phi_preview_step0.png`
+- `phi_preview_best.png`
+- `phi_preview_final.png`
+- `grad_stats.json`
+- `checkpoints/checkpoint_best.pt`
+- `checkpoints/checkpoint_latest.pt`
+
+For Issue 4.7 specifically, the previews must be kept because they are the main
+evidence for:
+
+- multiple different inputs
+- corresponding different outputs
+- whether there is obvious collapse to one generic pattern
+
+Expected output roots:
+
+- `outputs/stage4/minimal_trainer/issue4_7_small_subset_16_s200/`
+- `outputs/stage4/minimal_trainer/issue4_7_small_subset_16_s400/`
+
 ## Notes
 
 - `scripts/train_electronic_baseline.py` now treats explicit CLI arguments as higher priority


### PR DESCRIPTION
Why:
Stage 4 requires formal acceptance evidence for both single-sample overfit (Issue 4.6) and small-subset learnability (Issue 4.7), so we need a single consolidated documentation update that captures commands, artifacts, metrics, and honest pass/fail judgments.

What:
Add the Stage 4 single-sample acceptance report and the small-subset acceptance report, plus update run-order notes with the corresponding Linux run commands and artifact expectations.