### PR TITLE
docs: consolidate Stage 4 outcomes and Stage 5 go/no-go decision

### DIFF
--- a/docs/ai/PROJECT_CONTEXT.md
+++ b/docs/ai/PROJECT_CONTEXT.md
@@ -9,7 +9,7 @@ Optical Neural Network Super-Resolution Reproduction
 Reproduce the paper *Super-resolution image display using diffractive decoders* with a traceable engineering workflow.
 
 **Current Stage:**  
-The project is entering **Stage 4: minimal closed-loop training**.
+Stage 4 learnability gate has **passed**. The project is now ready to enter **Stage 5: paper-alignment** (GO decision pending implementation).
 
 **Important Stage-4 Principle:**  
 The goal is **not** to chase the paper's final metric yet.  
@@ -34,12 +34,16 @@ The goal is to answer one question:
 - Stage 3 optical forward sanity checks
 - Stage 3 decoder-only single-sample fitting
 - Stage 3 decoder-only small-subset capacity checks
+- Stage 4 minimal encoder + hybrid wrapper + dataset path
+- Stage 4 minimal trainer with artifact saving
+- Stage 4 single-sample closed-loop acceptance: PASS
+- Stage 4 small-subset closed-loop acceptance: PASS (with caveats)
 
 ### Current focus
 
-- build the first **encoder + optical decoder** minimal closed loop
-- keep the setup small, debuggable, and explicitly non-paper-final
-- verify learnability before any Stage 5 paper-alignment work
+- consolidate Stage 4 evidence and documentation
+- make a clear Stage 5 GO decision
+- prepare for Stage 5 paper-alignment work without over-claiming quality
 
 ---
 
@@ -106,10 +110,8 @@ They are useful for optical learnability verification, but they are **not yet** 
 
 The repo does **not yet** have:
 
-- a real Stage 4 general trainer
-- a real Stage 4 eval runner
-- Stage 4 optics configs
-- a clean dataset module under `src/datasets/`
+- a general Stage 4 eval runner
+- Stage 5 paper-aligned configs
 - a `tests/` directory for systematic automated checks
 
 At the time of this update:
@@ -118,7 +120,8 @@ At the time of this update:
 - `scripts/eval.py` is empty
 - `scripts/visualize.py` is empty
 
-So any Stage 4 plan must honestly treat these as pending work.
+Stage 4 has a **minimal** trainer + dataset path for acceptance runs, but it is not
+a full general training/eval framework.
 
 ---
 
@@ -165,23 +168,14 @@ This ordering exists because some older background/context docs may lag behind t
 
 ---
 
-## 7. Immediate Stage-4 Engineering Gaps
+## 7. Immediate Stage-5 Engineering Gaps
 
-The most likely Stage 4 work items are:
+The most likely Stage 5 work items are:
 
-1. define the minimal encoder output contract
-2. connect encoder output to `phi_lr`
-3. decide the first Stage 4 training scale
-   - stay toy first
-   - or move partially toward the paper setup
-4. build a real Stage 4 trainer script
-5. build Stage 4 config files
-6. define artifact saving rules
-7. define Stage 4 acceptance checks
-   - loss decreases
-   - single-sample overfit works
-   - gradients reach encoder and optics
-   - intermediate outputs are interpretable
+1. align optics/encoder configs with paper settings
+2. scale data protocol beyond minimal EMNIST setup
+3. define Stage 5 training schedule and evaluation pipeline
+4. keep Stage 4 artifacts as traceable baseline for regressions
 
 ---
 

--- a/docs/execution/experiment_log.md
+++ b/docs/execution/experiment_log.md
@@ -131,3 +131,45 @@
   - paper full-setting reproduction
   - hardware robustness / quantization / misalignment
   - dataset-scale end-to-end optical experiments
+
+---
+
+# Stage 4 Minimal Closed-Loop Acceptance
+
+## S4-01 Single-Sample Closed-Loop Acceptance (Issue 4.6)
+
+- 任务：使用最小 Stage 4 trainer 执行单样本 overfit，并形成验收报告
+- 运行配置（cuda）：
+  - `steps = 100` 与 `steps = 300`
+  - `dataset_root = data/raw/emnist`
+  - `hr_size = 96`
+  - optics grid: `24 / 32 / 48 / 20`
+- 工件目录：
+  - `outputs/stage4/minimal_trainer/issue4_6_single_sample_100/`
+  - `outputs/stage4/minimal_trainer/issue4_6_single_sample_300/`
+- 关键结果：
+  - loss 明确下降
+  - encoder / optics 梯度持续可观测
+  - 无 NaN / Inf
+  - 读出逐步接近目标结构
+- 结论：**PASS**
+
+## S4-02 Small-Subset Closed-Loop Acceptance (Issue 4.7)
+
+- 任务：验证 learnability 是否能扩展到小子集（非单样本）
+- 运行配置（cuda）：
+  - `subset_size = 16`
+  - `batch_size = 4`
+  - `steps = 200` 与 `steps = 400`
+  - `dataset_root = data/raw/emnist`
+  - optics grid: `24 / 32 / 48 / 20`
+- 工件目录：
+  - `outputs/stage4/minimal_trainer/issue4_7_small_subset_16_s200/`
+  - `outputs/stage4/minimal_trainer/issue4_7_small_subset_16_s400/`
+- 关键结果：
+  - loss 在小子集上仍能下降但趋于平台
+  - encoder / optics 梯度持续可观测
+  - 输出对输入有响应，无明显 collapse
+  - 无 NaN / Inf
+  - 读出仍偏模糊，PSNR/SSIM 偏低
+- 结论：**PASS（带保留项）**

--- a/docs/execution/results_summary.md
+++ b/docs/execution/results_summary.md
@@ -4,12 +4,12 @@
 
 ## å½“å‰é˜¶æ®µ
 
-- Stage 3: Optical Module Verification
+- Stage 4: Minimal Closed-Loop Learnability (**PASS**)
 - å½“å‰å®šä½ï¼š
-  - éªŒè¯ paper-aligned optical decoder skeleton æ˜¯å¦å¯è¿è¡Œã€å¯æ£€æŸ¥ã€å¯åšæœ€å°å®¹é‡éªŒè¯
-  - ä¸æ˜¯æœ€ç»ˆ end-to-end SR system
-  - ä¸æ˜¯ final joint training
-  - ä¸æ˜¯ final paper full-setting reproduction
+  - å·²å®Œæˆ Stage 4 å•æ ·æœ¬ overfit éªŒæ”¶ï¼ˆPASSï¼‰
+  - å·²å®Œæˆ Stage 4 å°å­é›†éªŒæ”¶ï¼ˆPASSï¼Œå¸¦ä¿ç•™é¡¹ï¼‰
+  - ä¸‹ä¸€é˜¶æ®µä¸º Stage 5 paper-aligned setting alignmentï¼ˆGOï¼‰
+  - ä¸ä»£è¡¨è®ºæ–‡æŒ‡æ ‡å·²è¾¾æˆ
 
 ## å½“å‰å·²éªŒè¯çš„äº‹å®
 
@@ -124,3 +124,30 @@ shared protocolï¼š
 
 - Stage 4 æ‰è¿›å…¥ encoder æ¥å…¥ä¸æœ€å°é—­ç¯è®­ç»ƒã€‚
 - Stage 5/6 æ‰è¿›å…¥ paper-final setting alignmentã€æ›´å¤šæ•°æ®åè®®å’Œç³»ç»ŸåŒ–å®éªŒã€‚
+
+---
+
+## Stage 4 Closed-Loop Learnability Summary
+
+### ÒÑ½¨Á¢µÄÊÂÊµ
+
+- µ¥Ñù±¾±Õ»· loss Ã÷È·ÏÂ½µ£¬encoder Óë optics Ìİ¶È¿É¹Û²â£¬ÎŞ NaN/Inf
+- Ğ¡×Ó¼¯±Õ»· loss ÈÔÄÜÏÂ½µ£¬Êä³ö¶ÔÊäÈëÓĞÏìÓ¦£¬ÎŞÃ÷ÏÔ collapse
+- Stage 4 learnability gate ³ÉÁ¢£¨PASS£©
+
+### ÉĞÎ´½¨Á¢µÄÊÂÊµ
+
+- ÂÛÎÄ¼¶¶Á³öÖÊÁ¿ÓëÖ¸±ê£¨PSNR/SSIM ÈÔÆ«µÍ£©
+- paper-final setting alignment
+- ´ó¹æÄ£ÑµÁ·»òÏµÍ³»¯ÏûÈÚ
+
+### Ö÷Òª±£ÁôÏî
+
+- Ğ¡×Ó¼¯¶Á³öÈÔÆ«Ä£ºı¡¢blob-like
+- normalized MAE ÏÂ loss Æ½Ì¨Öµ½Ï¸ß
+- ¿ÉÄÜÔ­Òò°üÀ¨×îĞ¡ encoder ÈİÁ¿¡¢toy optics grid¡¢Ä¿±ê¹éÒ»»¯·½Ê½µÈ£¨Ğè Stage 5 ½øÒ»²½ÑéÖ¤£©
+
+### Stage 5 ¾ö²ß
+
+- ½áÂÛ£º**GO**
+- ÀíÓÉ£ºStage 4 learnability gate ÒÑÍ¨¹ı£¬µ«¶Á³öÖÊÁ¿Î´´ïÂÛÎÄÉè¶¨£¬Stage 5 ¶ÔÆëÈÔÊÇ±ØÒª²½Öè

--- a/docs/execution/stage4_small_subset_report.md
+++ b/docs/execution/stage4_small_subset_report.md
@@ -1,0 +1,110 @@
+# Stage 4 Small-Subset Report
+
+## 1. 任务边界
+
+- 本次只验证 Stage 4 小子集 closed-loop learnability
+- 不重写 optical core
+- 不重写 dataset / adapter / wrapper / trainer
+- 不进入 Stage 5 paper-aligned settings
+
+## 2. 运行命令
+
+实际运行（根据 `config_snapshot.json` 还原的参数）：
+
+```bash
+python scripts/train_stage4_minimal.py \
+  --subset-size 16 \
+  --batch-size 4 \
+  --steps 200 \
+  --preview-limit 4 \
+  --device cuda \
+  --dataset-root data/raw/emnist \
+  --run-name issue4_7_small_subset_16_s200
+```
+
+补充运行（更强验证，仍基于同一子集与配置）：
+
+```bash
+python scripts/train_stage4_minimal.py \
+  --subset-size 16 \
+  --batch-size 4 \
+  --steps 400 \
+  --preview-limit 4 \
+  --device cuda \
+  --dataset-root data/raw/emnist \
+  --run-name issue4_7_small_subset_16_s400
+```
+
+## 3. 设备与工件目录
+
+- 设备：`cuda`
+- 工件目录：
+  - `outputs/stage4/minimal_trainer/issue4_7_small_subset_16_s200/`
+  - `outputs/stage4/minimal_trainer/issue4_7_small_subset_16_s400/`
+
+## 4. Core Scalar Results
+
+### 200 steps
+
+- initial loss: `0.217708`
+- best loss: `0.149736` @ step 171
+- final loss: `0.180445`
+- val loss: `0.192186`
+- val PSNR / SSIM: `8.3882` / `0.0557`
+
+### 400 steps
+
+- initial loss: `0.217708`
+- best loss: `0.144116` @ step 360
+- final loss: `0.171176`
+- val loss: `0.190612`
+- val PSNR / SSIM: `8.3843` / `0.0556`
+
+### 趋势结论
+
+- train loss 明确下降，但波动较大（小子集 + mini-batch 导致）
+- val loss 从 `0.2286` 降到约 `0.19` 后趋于平台
+- 与 single-sample 不同，小子集 loss 不会接近 0，是可预期现象
+
+## 5. Preview / Artifact Inspection Findings
+
+- 多个输入是否不同：是（预览行对应不同 EMNIST 字符）
+- 多个输出是否随输入变化：是，但变化主要体现在亮斑位置 / 形状的偏移，细节与 `target_roi` 仍不匹配
+- 是否出现明显 collapse 到单一亮斑 / 单一模式：否，输出仍受输入影响，但整体偏“模糊亮斑”
+
+## 6. Gradient Findings
+
+- encoder gradients：全程观测到非零梯度（200/200、400/400 steps）
+- optics gradients：全程观测到非零梯度（200/200、400/400 steps）
+
+## 7. Stability Findings
+
+- NaN / Inf：未发现（`run_summary.json` 显示 `initial_preview_finite=true`、`final_preview_finite=true`）
+- 是否存在明显数值不稳定：未见明显不稳定或爆炸
+
+## 8. Verdict
+
+**PASS（带保留项）**
+
+理由：
+
+- loss 在小子集上有明确下降，且无数值异常
+- encoder / optics 梯度持续可观测
+- 输出对输入有响应，没有明显 collapse
+
+保留项：
+
+- 预测仍以模糊亮斑为主，细节不足，val PSNR/SSIM 偏低
+- 说明最小闭环“可学”成立，但距离 paper-final 读出质量仍有差距
+
+## 9. 非阻塞未决项
+
+- loss 平台值较高，可能与最小 encoder 容量、toy optics grid、normalized MAE 的 per-sample 归一化有关
+- 需要在 Stage 4 总结中明确为“可学习性成立、质量尚不达标”
+
+## 10. 下一步
+
+进入 Stage 4 总结与 Stage 5 GO/NO-GO 决策整理，明确：
+
+- 单样本与小子集均通过可学习性验收
+- 小子集仍存在输出模糊与指标偏低的现象（非阻塞）


### PR DESCRIPTION
Why:
Stage 4 acceptance has completed (single-sample PASS, small-subset PASS with caveats), so the repo needs a consolidated, evidence-based record and an explicit Stage 5 GO decision without overstating paper-level quality.

What:
Update PROJECT_CONTEXT and execution logs/summaries to reflect Stage 4 pass evidence, remaining quality gaps, and a Stage 5 GO call, and add the Stage 4 small-subset acceptance report.