### PR TITLE
docs(plan | stage5-1): freeze stage5 paper protocol

### DIFF
--- a/docs/ai/CodexFeedback/stage5/feedback_stage5-1.md
+++ b/docs/ai/CodexFeedback/stage5/feedback_stage5-1.md
@@ -1,0 +1,23 @@
+新增了 Stage 5 的协议冻结文档，把范围边界、继承 contract、paper-aligned 默认值、未决参数 ledger，以及后续 issue 的拍板权限都固定下来，便于后续实现 prompt 直接引用。
+
+精确变更文件：
+- [stage5_protocol_freeze.md](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/docs/plan/stage_plan/stage5/stage5_protocol_freeze.md)
+
+新文档之外的 consistency edit：
+- 无
+
+最重要的冻结决策：
+- Stage 5 明确继承并冻结 optical contract：`phi_lr -> U0 -> U_out_full -> I_out_full -> I_out_roi`
+- Stage 4 learnability gate 已通过，Stage 4 artifacts 只作为 regression baseline，不在 Stage 5 重开
+- Stage 5 是第一次对齐论文完整主设定的阶段；Stage 6 仍负责 quantization、misalignment/robustness、系统化 `L=1/3/5` ablation、complex/amplitude-only 对比
+- Stage 5 当前默认目标已写清：EMNIST `96×96` protocol、`200/400` optics grid、phase-only encoder、paper loss、Adam/LR/batch/epoch targets、PSNR/SSIM + bicubic + blind line-pair eval path
+- 每个未决项都绑定了唯一 owner issue，并明确哪些后续 issue 不得静默拍板
+
+最重要的刻意保留未决项：
+- `phi_lr` size：当前默认 `32×32`，由 `5.4` 最终拍板，之前必须保持可配置
+- `96×96` tiling rule：由 `5.2` 最终拍板
+- distance mapping 与 output crop/FOV alignment：由 `5.3` 最终拍板
+- `L=5` gamma policy 与 sigma granularity：由 `5.5` 最终拍板
+- phase mapping range：当前默认 `[0, 2π)`，由 `5.4` 最终拍板
+
+这是文档任务，未运行测试。

--- a/docs/ai/PROJECT_CONTEXT.md
+++ b/docs/ai/PROJECT_CONTEXT.md
@@ -37,13 +37,14 @@ The goal is to answer one question:
 - Stage 4 minimal encoder + hybrid wrapper + dataset path
 - Stage 4 minimal trainer with artifact saving
 - Stage 4 single-sample closed-loop acceptance: PASS
+  - summarized in `docs/execution/stage4_single_sample_report.md`
 - Stage 4 small-subset closed-loop acceptance: PASS (with caveats)
 
 ### Current focus
 
-- consolidate Stage 4 evidence and documentation
-- make a clear Stage 5 GO decision
-- prepare for Stage 5 paper-alignment work without over-claiming quality
+- keep Stage 4 evidence as the regression baseline
+- use Stage 5 planning docs as the main paper-alignment entry point
+- avoid sending large, lagging execution docs to helper agents unless a specific claim needs tracing
 
 ---
 
@@ -76,9 +77,9 @@ The Stage 3 optical path is already defined as:
 
 `phi_lr -> U0 -> U_out_full -> I_out_full -> I_out_roi`
 
-Any Stage 4 plan must build on that contract rather than redesigning the optical core.
+Any Stage 5 planning or implementation work must build on that contract rather than redesigning the optical core.
 
-### 4.2 The optical core already exposes Stage-4 hooks
+### 4.2 The optical core already exposes the integration hooks we need
 
 The current optical decoder already supports:
 
@@ -86,7 +87,7 @@ The current optical decoder already supports:
 - `forward_from_field(...)`
 - `forward_from_phase_provider(...)`
 
-This means Stage 4 should primarily solve the **upstream encoder / trainer / protocol** problem, not rewrite optics first.
+This means Stage 5 should primarily solve the **paper-aligned encoder / config / loss / eval** problem, not rewrite optics first.
 
 ### 4.3 Electronic baseline is already trusted
 
@@ -104,7 +105,7 @@ The Stage 3 decoder-only scripts currently use:
 - synthetic target patterns
 - toy grid sizes such as `24 / 32 / 48 / 20`
 
-They are useful for optical learnability verification, but they are **not yet** the Stage 4 end-to-end data pipeline.
+They are useful for optical learnability verification, but they are **not** the Stage 5 paper-aligned pipeline.
 
 ### 4.5 Some infrastructure is still missing
 
@@ -120,8 +121,7 @@ At the time of this update:
 - `scripts/eval.py` is empty
 - `scripts/visualize.py` is empty
 
-Stage 4 has a **minimal** trainer + dataset path for acceptance runs, but it is not
-a full general training/eval framework.
+Stage 4 has a **minimal** trainer + dataset path for acceptance runs, but it is not a full paper-aligned training/eval framework.
 
 ---
 
@@ -152,23 +152,49 @@ a full general training/eval framework.
 
 ---
 
-## 6. Current Documentation Sources Of Truth
+## 6. Stage-5 Review Facts A Helper Agent Should Assume
 
-When different documents disagree, a new assistant should prioritize them in this order:
+If a helper agent is asked to review or generate prompts for Stage 5, it should assume the following unless newer code disproves it:
 
-1. `docs/plan/plan_overview.md`
-2. `docs/plan/stage3_contract_freeze.md`
-3. `docs/integration/stage3_unresolved_params.md`
-4. current code in `src/` and `scripts/`
-5. `docs/paper/paper_notes.md`
-6. `docs/execution/results_summary.md`
-7. `docs/execution/experiment_log.md`
-
-This ordering exists because some older background/context docs may lag behind the repo's actual progress.
+1. Stage 4 learnability gate has passed, but quality is still far from paper-final.
+2. Stage 5 is the first phase that should align to the paper's full settings.
+3. The optical core contract remains:
+   `phi_lr -> U0 -> U_out_full -> I_out_full -> I_out_roi`
+4. Stage 5 must not silently pull Stage 6 scope forward:
+   - no quantization sweep
+   - no robustness / misalignment study
+   - no large ablation matrix
+5. The canonical Stage 4 acceptance evidence lives in:
+   - `docs/execution/stage4_single_sample_report.md`
+   - `docs/execution/stage4_small_subset_report.md`
 
 ---
 
-## 7. Immediate Stage-5 Engineering Gaps
+## 7. Current Documentation Sources Of Truth
+
+For Stage 5 review or prompt-generation tasks, prioritize documents in this order:
+
+1. `AGENTS.md`
+2. `docs/ai/PROJECT_CONTEXT.md`
+3. `docs/paper/paper_notes.md`
+4. `docs/plan/stage_plan/stage5/stage5_plan.md`
+5. `docs/plan/stage_plan/stage5/stage5_issue_plan.md`
+6. current code in `src/` and `scripts/`
+
+Only pull in the following if a specific claim must be verified:
+
+- `docs/plan/plan_overview.md`
+- `docs/plan/stage_plan/stage4/stage4_protocol_freeze.md`
+- `docs/execution/stage4_single_sample_report.md`
+- `docs/execution/stage4_small_subset_report.md`
+- `docs/execution/results_summary.md`
+- `docs/execution/experiment_log.md`
+
+This ordering is intentional: the execution logs are useful, but they are verbose, partially redundant, and more likely to lag than the curated context + Stage 5 planning docs.
+
+---
+
+## 8. Immediate Stage-5 Engineering Gaps
 
 The most likely Stage 5 work items are:
 
@@ -179,7 +205,7 @@ The most likely Stage 5 work items are:
 
 ---
 
-## 8. Known Risks
+## 9. Known Risks
 
 The main current risks are:
 
@@ -191,29 +217,30 @@ The main current risks are:
 
 ---
 
-## 9. Recommended Minimal File Package For A New Chat
+## 10. Recommended Minimal File Package For Stage-5 Review / Prompting
 
-If a user wants another assistant to plan Stage 4, the minimal useful package is:
+If a user wants another assistant to review Stage 5 plans or generate prompts for Codex, the default minimal package should be only these 5 files:
 
+- `AGENTS.md`
 - `docs/ai/PROJECT_CONTEXT.md`
-- `docs/plan/plan_overview.md`
-- `docs/plan/stage3_contract_freeze.md`
 - `docs/paper/paper_notes.md`
-- `src/models/optics/diffractive_decoder.py`
-- `scripts/train_electronic_baseline.py`
-- `scripts/train_decoder_only_small_subset.py`
+- `docs/plan/stage_plan/stage5/stage5_plan.md`
+- `docs/plan/stage_plan/stage5/stage5_issue_plan.md`
+
+Add these only when the task explicitly needs them:
+
+- `docs/plan/plan_overview.md`
+- `docs/plan/stage_plan/stage4/stage4_protocol_freeze.md`
+- `docs/execution/stage4_single_sample_report.md`
+- `docs/execution/stage4_small_subset_report.md`
+- `docs/execution/experiment_log.md`
 - `docs/execution/results_summary.md`
 
-If the user can provide a bit more context, add:
-
-- `docs/integration/stage3_unresolved_params.md`
-- `docs/integration/sdn_optics_contract.md`
-- `docs/execution/experiment_log.md`
-- `outputs/optics/decoder_only_small_subset_sweep_run1/depth_comparison.csv`
+Do **not** send large execution logs by default just because they exist. Send them only when the helper agent needs to verify a factual claim, a run result, or a documentation gap.
 
 ---
 
-## 10. One-Screen Summary
+## 11. One-Screen Summary
 
 This is a long-running reproduction project for a hybrid
 `encoder -> diffractive optical decoder` super-resolution paper.
@@ -222,12 +249,13 @@ The repo has already passed:
 
 - Stage 1 / 2 baseline and evaluation groundwork
 - Stage 3 optical module verification
+- Stage 4 minimal closed-loop learnability acceptance
 
-The repo is now entering Stage 4:
+The repo is now preparing Stage 5:
 
-- connect a minimal encoder
-- reuse the frozen optical contract
-- run the first end-to-end minimal closed loop
-- prove the system can learn
+- align the system to the paper's data / optics / loss / eval settings
+- keep Stage 4 as the trusted learnability baseline
+- avoid drifting into Stage 6 ablations too early
 
-The biggest missing piece is **not optics core**, but the **Stage 4 training pipeline around it**.
+For prompt-writing or review tasks, the most efficient context package is:
+`AGENTS.md` + `PROJECT_CONTEXT.md` + `paper_notes.md` + `stage5_plan.md` + `stage5_issue_plan.md`.

--- a/docs/ai/prompt/stage5/prompt_stage5-1.md
+++ b/docs/ai/prompt/stage5/prompt_stage5-1.md
@@ -1,0 +1,223 @@
+You are working in a research-engineering repository for reproducing
+"Super-resolution image display using diffractive decoders".
+
+Your task is to complete GitHub Issue 5.1:
+
+Issue title:
+Freeze Stage 5 paper-aligned protocol and unresolved-parameters ledger
+
+This is a Stage-5-scoped documentation task.
+Do not write model code, training code, dataset code, or evaluation code in this issue.
+
+==================================================
+0. MUST-READ CONTEXT FIRST
+==================================================
+
+Before doing anything, you MUST read and follow these files in order:
+
+1. `AGENTS.md`
+2. `docs/ai/PROJECT_CONTEXT.md`
+3. `docs/paper/paper_notes.md`
+4. `docs/plan/stage_plan/stage4/stage4_protocol_freeze.md`
+5. `docs/plan/stage_plan/stage5/stage5_plan.md`
+6. `docs/plan/stage_plan/stage5/stage5_issue_plan.md`
+
+You may read `docs/plan/plan_overview.md` only if needed for a wording or boundary cross-check.
+Do not pull in large execution logs unless you need to verify one concrete claim.
+
+Important scope rule:
+- If `paper_notes.md` records a wider reproduction roadmap than the current Stage 5 schedule,
+  follow `stage5_plan.md` and `stage5_issue_plan.md` for stage scope.
+
+==================================================
+1. ISSUE 5.1 GOAL
+==================================================
+
+Write the Stage 5 protocol freeze document:
+
+- `docs/plan/stage_plan/stage5/stage5_protocol_freeze.md`
+
+This document must freeze the Stage 5 paper-aligned implementation boundary so later
+implementation prompts can be narrow, non-drifting, and auditable.
+
+The document must define:
+
+1. what Stage 5 is trying to align
+2. what Stage 5 explicitly does not include
+3. what Stage 3 / Stage 4 facts are inherited and frozen
+4. what paper-aligned defaults are selected for Stage 5
+5. what remains unresolved
+6. which later issue is allowed to finalize each unresolved item
+
+==================================================
+2. NON-GOALS — DO NOT DRIFT
+==================================================
+
+Do NOT do any of the following:
+
+- do not implement dataset code
+- do not implement optics configs
+- do not implement encoder / loss / trainer / eval code
+- do not rewrite Stage 4 history
+- do not promote Stage 6 work into Stage 5
+- do not silently resolve paper ambiguities as settled fact
+- do not create a broad design manifesto unrelated to later issue execution
+
+This issue is successful only if it produces a sharp protocol freeze for later work.
+
+==================================================
+3. BRANCH EXPECTATION
+==================================================
+
+Suggested branch:
+- `docs/update`
+
+Stay on a docs-oriented branch.
+Do not use this issue to modify feature branches such as `feat/train`, `feat/model`, or `feat/optics`.
+
+==================================================
+4. REQUIRED INHERITANCE
+==================================================
+
+The Stage 5 protocol freeze must explicitly inherit these facts:
+
+1. Frozen optical contract:
+   `phi_lr -> U0 -> U_out_full -> I_out_full -> I_out_roi`
+2. Stage 4 learnability gate has already passed.
+3. Stage 4 artifacts are the regression baseline, not work to redo.
+4. Stage 5 is the first stage that aligns to the paper's full settings.
+5. Stage 6 remains the home for:
+   - quantization sweep
+   - misalignment / robustness
+   - systematic L=1/3/5 ablations
+   - complex-valued / amplitude-only comparisons
+
+==================================================
+5. WHAT THE DOCUMENT MUST CONTAIN
+==================================================
+
+The document should be structured so that later implementation issues can use it directly.
+
+At minimum, include:
+
+### A. Document purpose
+- what this freeze is for
+- what kinds of later issues it constrains
+
+### B. Scope boundary
+- in-scope Stage 5 items
+- out-of-scope Stage 6 items
+- explicit conflict-resolution rule:
+  Stage 5 planning docs override wider paper-roadmap phrasing when stage scope differs
+
+### C. Inherited frozen contracts
+- optical contract
+- Stage 4 regression baseline role
+- no optical-core redesign
+
+### D. Paper-aligned target protocol
+- dataset protocol
+- optics geometry targets
+- encoder / phase representation target
+- loss / gamma policy
+- training hyperparameter targets
+- eval target protocol
+
+### E. Unresolved parameters ledger
+For each unresolved item, specify:
+- current default handling
+- what is still unknown
+- which later issue may finalize it
+- what later issues must not silently finalize it
+
+### F. Issue constraints
+Add short constraints for later issue families:
+- dataset
+- optics config
+- encoder
+- loss
+- trainer
+- eval
+- smoke / main run
+
+### G. Acceptance / exit criteria
+- what must exist before Stage 5 is considered engineering-complete
+- what stronger evidence is resource-dependent
+
+==================================================
+6. UNRESOLVED ITEMS THAT MUST BE HANDLED CAREFULLY
+==================================================
+
+You must explicitly address at least these unresolved items:
+
+1. `phi_lr` size
+2. 96x96 display tiling rule
+3. distance mapping into `input_to_first / inter_layer / last_to_sensor`
+4. L=5 gamma policy
+5. phase mapping range
+6. sigma normalization granularity
+7. output crop / FOV alignment details
+
+For each one:
+- do not pretend it is fully settled if it is not
+- assign ownership to a later issue
+- make clear whether later implementation must keep it configurable
+
+==================================================
+7. STYLE REQUIREMENTS
+==================================================
+
+The document should be:
+
+- concise but concrete
+- implementation-oriented
+- explicit about assumptions
+- explicit about forbidden drift
+- useful for future Codex prompts
+
+Avoid:
+
+- generic research prose
+- repeating the paper at length
+- long background sections that do not constrain implementation
+
+==================================================
+8. ALLOWED FILE CHANGES
+==================================================
+
+Primary target:
+- `docs/plan/stage_plan/stage5/stage5_protocol_freeze.md`
+
+Optional small companion edits are allowed only if strictly helpful for consistency:
+- `docs/plan/stage_plan/stage5/stage5_plan.md`
+- `docs/plan/stage_plan/stage5/stage5_issue_plan.md`
+
+But do not expand the task into broader doc refactoring unless a tiny consistency fix is necessary.
+
+==================================================
+9. ACCEPTANCE CRITERIA
+==================================================
+
+Issue 5.1 is complete only if:
+
+1. `stage5_protocol_freeze.md` is created
+2. The document clearly separates Stage 5 from Stage 6
+3. The document explicitly inherits the frozen optical contract
+4. The document records all major unresolved items honestly
+5. Each unresolved item is mapped to a later issue owner
+6. The document is specific enough that later implementation prompts can say:
+   - what this issue may finalize
+   - what this issue must keep configurable
+   - what this issue must not touch
+
+==================================================
+10. FINAL RESPONSE FORMAT
+==================================================
+
+After finishing, respond with:
+
+- short summary of what was added or updated
+- exact files changed
+- whether any consistency edits were made outside the new freeze doc
+- the most important frozen decisions introduced
+- the most important unresolved items left intentionally open

--- a/docs/ai/prompt/stage5/prompt_stage5_review_minimal.md
+++ b/docs/ai/prompt/stage5/prompt_stage5_review_minimal.md
@@ -1,0 +1,112 @@
+You are assisting a research-engineering repository for reproducing
+"Super-resolution image display using diffractive decoders".
+
+Your task is not to write code. Your task is to review the current Stage 5 planning
+documents so that a later Codex prompt can be sharper, narrower, and more executable.
+
+==================================================
+0. READ ONLY THESE 5 FILES FIRST
+==================================================
+
+Before doing anything, read these files in order:
+
+1. `AGENTS.md`
+2. `docs/ai/PROJECT_CONTEXT.md`
+3. `docs/paper/paper_notes.md`
+4. `docs/plan/stage_plan/stage5/stage5_plan.md`
+5. `docs/plan/stage_plan/stage5/stage5_issue_plan.md`
+
+Do not assume any extra context by default.
+
+If you think some claim cannot be verified from these 5 files alone, say:
+- `needs extra evidence`
+
+Do not invent missing facts.
+
+==================================================
+1. REVIEW GOAL
+==================================================
+
+Review these two target documents:
+
+- `docs/plan/stage_plan/stage5/stage5_plan.md`
+- `docs/plan/stage_plan/stage5/stage5_issue_plan.md`
+
+Your goal is to evaluate whether they are good enough to support future
+high-quality Codex implementation prompts for Stage 5 work.
+
+This is an engineering-review task plus prompt-quality-review task.
+It is not a writing-style review.
+
+==================================================
+2. WHAT TO CHECK
+==================================================
+
+Focus on these questions:
+
+1. Is the Stage 5 boundary clear?
+2. Does Stage 5 stay aligned with the paper rather than drifting into Stage 6?
+3. Does it correctly inherit the frozen optical contract and Stage 4 learnability baseline?
+4. Are the issue breakdown and dependency order executable?
+5. Are Goal / Tasks / Deliverable / Acceptance specific enough for future Codex prompts?
+6. Are important assumptions and unresolved items recorded explicitly?
+7. Are the suggested branches coherent with the repo's branch conventions?
+8. What prompt-critical context is still missing if we later want Codex to implement one Stage 5 issue?
+
+==================================================
+3. IMPORTANT RULES
+==================================================
+
+- Do not ask for extra documents unless they are truly required to verify a specific claim.
+- Do not restate the entire documents.
+- Do not rewrite Stage 5 from scratch.
+- Do not treat Stage 6 work as a Stage 5 requirement.
+- Do not present paper details as certain if the documents still mark them as unresolved.
+- If a point is acceptable but still slightly risky for future prompting, call it out clearly.
+
+==================================================
+4. REQUIRED OUTPUT FORMAT
+==================================================
+
+Use exactly this structure:
+
+A. Findings
+- Put problems first
+- Order by severity: High / Medium / Low
+- Cite the target document when possible
+- Focus on issues that would make future Codex prompts drift, overreach, or become underspecified
+- If no serious issues exist, explicitly say `No critical findings`
+
+B. Strengths
+- State what these Stage 5 docs already do well
+- Explain why those strengths help future Codex prompts
+
+C. Gaps For Prompting Codex
+- Split into:
+  - `Must add before implementation prompts`
+  - `Helpful but optional`
+- Only include context gaps that matter for implementable prompts
+
+D. Prompt-Readiness Verdict
+- Choose one:
+  - `Ready`
+  - `Ready with gaps`
+  - `Not ready`
+- Explain the decision in 3 to 6 sentences
+
+E. Next Prompt Package
+- List the smallest file bundle you would attach to the next Codex implementation prompt
+- If one extra file is needed beyond the original 5, explain why
+
+F. One Better Meta-Prompt
+- Describe the minimum fields that any future Stage 5 implementation prompt to Codex should contain
+- Keep it practical and implementation-oriented
+
+==================================================
+5. REVIEW STYLE
+==================================================
+
+- Be direct and engineering-oriented
+- Prefer concrete criticism over vague praise
+- Keep the review concise but specific
+- If a claim needs extra evidence, say so plainly

--- a/docs/execution/experiment_log.md
+++ b/docs/execution/experiment_log.md
@@ -1,175 +1,196 @@
 # Experiment Log
 
-记录 Stage 3 optical module verification 阶段的关键执行路径、最小验证结论和当前边界。
+本文档按时间顺序记录当前仓库中已经实现并运行过的关键里程碑。
 
-当前 Stage 3 冻结主链路：
+记录范围：
 
-`phi_lr -> U0 -> U_out_full -> I_out_full -> I_out_roi -> loss/metrics`
+- Stage 3 optical module verification
+- Stage 4 minimal closed-loop acceptance
 
-本文档只记录当前仓库中已经实现并运行过的 Stage 3 里程碑，不把最小 smoke 或 tiny protocol 包装成最终论文结果。
+不记录内容：
+
+- 尚未执行的 Stage 5 paper-aligned implementation
+- 计划文档中的未来任务
+- 仅存在于讨论中、没有运行证据的结论
+
+---
 
 ## S3-02 Optical Propagation Core
 
 - 对应任务：Issue 2 `feat: extract paper-aligned propagation core from sdn_upstream`
 - 做了什么：
-  - 从 `external/sdn_upstream` 参考并重写了 centered FFT / IFFT、Rayleigh-Sommerfeld transfer kernel、phase-mask modulation。
-  - 在 `src/models/optics/propagation.py`、`src/models/optics/phase_utils.py`、`src/models/optics/diffractive_decoder.py` 内落地为当前 repo 的 clean optics core。
-  - 去掉了 classification head、electrical decoder、Pet / OAM / LG / HG 任务耦合，以及 `layer == 2` 这类隐式 final propagation 逻辑。
-- 为什么做：
-  - Stage 3 需要先验证 optical decoder skeleton 本身可运行、可检查、可被后续 readout / crop / fitting 复用。
+  - 从 `external/sdn_upstream` 参考并重写 centered FFT / IFFT、Rayleigh-Sommerfeld transfer kernel、phase-mask modulation。
+  - 在 `src/models/optics/propagation.py`、`src/models/optics/phase_utils.py`、`src/models/optics/diffractive_decoder.py` 中落地为当前 repo 的 clean optics core。
+  - 去掉 classification head、electrical decoder 以及上游任务耦合逻辑。
 - 最小结论：
-  - optical core 已独立于 upstream 任务层。
-  - `L` 的语义已固定为 trainable diffractive phase masks 数量。
-  - distance schedule 已改为显式 `input_to_first / inter_layer / last_to_sensor`。
+  - optical core 已与 upstream 任务层解耦。
+  - `L` 的语义固定为 trainable diffractive phase masks 数量。
+  - distance schedule 已显式区分 `input_to_first / inter_layer / last_to_sensor`。
 
 ## S3-03 Readout / Crop Contract
 
 - 对应任务：Issue 3 `feat: add output FOV crop and optical direct-readout contract`
 - 做了什么：
-  - 新增 `src/models/optics/readout.py`，把 `I_out_full = |U_out_full|^2` 和 deterministic center crop 从调用脚本中抽离出来。
-  - decoder 现在稳定返回 `U_out_full`、`I_out_full`、`I_out_roi`，不再把 full-grid 和 ROI 混在一起。
-  - `output_crop_hw` 变成显式配置，crop 越界会报错。
-- 为什么做：
-  - Stage 3 freeze 明确要求 full-grid forward + ROI supervision，且 crop 不能隐藏在脚本中。
+  - 新增 `src/models/optics/readout.py`，把 `I_out_full = |U_out_full|^2` 和 deterministic center crop 从脚本中抽离。
+  - decoder 稳定返回 `U_out_full`、`I_out_full`、`I_out_roi`。
+  - `output_crop_hw` 成为显式配置，crop 越界会报错。
+- 运行证据：
+  - `scripts/check_optical_readout.py`
 - 最小结论：
-  - `scripts/check_optical_readout.py` 已在当前仓库状态下通过。
-  - 当前重跑结果：
-    - `I_out_full` shape: `(1, 1, 48, 48)`
-    - `I_out_roi` shape: `(1, 1, 20, 20)`，改为 `(12, 12)` 时 ROI shape 正确变为 `(1, 1, 12, 12)`
-    - oversized crop 会显式报错
-    - 改变输入 phase 时，`full_delta = 1.748107e-03`，`roi_delta = 2.850121e-03`
+  - full-grid 与 ROI readout 的职责已稳定。
+  - crop contract 已进入模块层，不再隐藏在脚本里。
 
-## S3-04 Forward Sanity for L=1/3/5
+## S3-04 Forward Sanity For L=1/3/5
 
 - 对应任务：Issue 4 `feat: add Stage 3 forward sanity scripts for L=1/3/5`
 - 做了什么：
-  - 新增 `scripts/check_optical_forward_depths.py`，在一致的最小协议下检查 `L=1/3/5` 的 forward 行为。
-  - 检查项覆盖：forward 成功、输出 key 完整、`U_out_full` 为 complex、强度非负、ROI shape 一致、不同 depth 输出不完全相同、invalid distance schedule 会显式失败。
-- 为什么做：
-  - Stage 3 在进入 fitting 前必须先证明 optics forward 本身可信，不依赖 electrical decoder 才能“看懂”输出。
+  - 新增 `scripts/check_optical_forward_depths.py`
+  - 在同一最小协议下检查 `L=1/3/5` 的 forward 行为
+- 运行证据：
+  - `scripts/check_optical_forward_depths.py`
 - 最小结论：
-  - `scripts/check_optical_forward_depths.py` 已在当前仓库状态下通过。
-  - 当前重跑结果：
-    - 三个 depth 都返回 `['I_out_full', 'I_out_roi', 'U0', 'U_out_full']`
-    - `L=1/3/5` 的 full-grid shape 均为 `(1, 1, 48, 48)`，ROI shape 均为 `(1, 1, 20, 20)`
-    - pairwise ROI delta:
-      - `L1-L3 = 5.641614e-01`
-      - `L1-L5 = 7.738391e-01`
-      - `L3-L5 = 3.243636e-01`
-    - 错误的 `inter_layer` 长度会被显式拒绝，而不是依赖旧的 layer-index special case
+  - `L=1/3/5` 都能成功 forward
+  - 输出接口一致，invalid distance schedule 会显式失败
 
 ## S3-05 Decoder-Only Single-Sample Fitting
 
 - 对应任务：Issue 5 `feat: add decoder-only single-sample fitting runner`
 - 做了什么：
   - 新增 `scripts/train_decoder_only_single_sample.py`
-  - 用 learnable input phase 直接驱动 optical decoder，不引入 encoder。
-  - 在 ROI 上使用 normalized MAE 进行最小拟合，并保存 target / initial / best / final ROI、loss curve 和 summary。
-- 为什么做：
-  - Stage 3 需要先隔离 encoder 影响，验证 optical decoder stack 是否有最小可优化容量。
+  - 直接优化 learnable input phase，不引入 encoder
+  - 在 ROI 上使用 normalized MAE 拟合单个 synthetic target
+- 运行证据：
+  - `outputs/optics/decoder_only_single_sample_smoke/summary.json`
 - 最小结论：
-  - `outputs/optics/decoder_only_single_sample_smoke/summary.json` 记录了一个 `L=3` 的可复跑 smoke：
-    - `initial_loss = 0.1463065892457962`
-    - `best_loss = 0.03812457248568535`
-    - `final_loss = 0.03893868252635002`
-    - `loss_decrease = 0.10818201676011086`
-    - `roi_change_mean_abs = 0.4759185314178467`
-  - 当前结论仅说明 decoder-only 单样本路径可学，不代表论文设置或最终系统性能已复现。
+  - decoder-only 单样本路径可学
+  - 这只说明 optical decoder 有容量，不等价于 end-to-end 结果
 
 ## S3-06 Decoder-Only Small-Subset Depth Sweep
 
 - 对应任务：Issue 6 `feat: run small-subset optical capacity experiment across L=1/3/5`
 - 做了什么：
-  - 先新增 `scripts/train_decoder_only_small_subset.py`，再补齐 `scripts/train_decoder_only_small_subset_sweep.py`
-  - 对固定 deterministic subset、固定 ROI normalized MAE、固定步数预算和固定优化超参执行 `L=1/3/5` sweep
-  - 为每个 depth 输出独立目录，并生成统一 `sweep_summary.json` 与 `depth_comparison.csv`
-- 为什么做：
-  - 单样本下降不足以支持 Issue 6 关闭；Stage 3 freeze 要求至少在小子集上比较 `L=1/3/5`
+  - 新增 `scripts/train_decoder_only_small_subset.py`
+  - 新增 `scripts/train_decoder_only_small_subset_sweep.py`
+  - 对固定 deterministic subset 执行 `L=1/3/5` sweep
+- 运行证据：
+  - `outputs/optics/decoder_only_small_subset_sweep_run1/sweep_summary.json`
+  - `outputs/optics/decoder_only_small_subset_sweep_run1/depth_comparison.csv`
 - 最小结论：
-  - 来源：`outputs/optics/decoder_only_small_subset_sweep_run1/sweep_summary.json`
-  - shared protocol：
-    - `subset_size = 4`
-    - `steps = 80`
-    - `seed = 42`
-    - `device = cpu`
-    - `lr_phase = 0.15`
-    - `lr_decoder = 0.03`
-    - `freeze_decoder = false`
-    - `loss = normalized_mae_roi`
-  - fixed-protocol 结果：
-    - `L=1`: `success_count = 4/4`, `mean_best_loss = 0.02864284673705697`, `mean_loss_decrease = 0.09716733871027827`
-    - `L=3`: `success_count = 4/4`, `mean_best_loss = 0.03225723281502724`, `mean_loss_decrease = 0.09978684224188328`
-    - `L=5`: `success_count = 4/4`, `mean_best_loss = 0.03135538613423705`, `mean_loss_decrease = 0.10351110668852925`
-  - 当前结论仅说明三种 depth 在 tiny protocol 下都具备可优化容量，不构成论文性能排序结论。
+  - 三种 depth 在同一 tiny protocol 下都能下降
+  - 当前结果不构成 paper performance 排序结论
 
 ## S3-07 Phase-Provider Hook
 
 - 对应任务：Task3-7 `feat: add clean phase-provider hook for future Stage 4 integration`
 - 做了什么：
   - 新增 `src/models/optics/phase_provider.py`
-  - 明确 `PhaseProvider` callable contract：`upstream_input -> phase tensor`
-  - 新增 `DirectPhaseProvider` 作为当前 Stage 3 默认 stub
-  - 在 decoder 中稳定 `forward_from_phase(...)`、`forward_from_field(...)`，并补充 `forward_from_phase_provider(...)`
-- 为什么做：
-  - 让 optical core 与 future encoder 的实现方式解耦，同时不提前引入 Stage 4 trainer 或 joint model
+  - 明确 `PhaseProvider` contract：`upstream_input -> phase tensor`
+  - 在 decoder 中稳定 `forward_from_phase(...)`、`forward_from_field(...)`、`forward_from_phase_provider(...)`
 - 最小结论：
-  - 当前 hook 只负责接口边界，不负责任何训练或 encoder 实现
-  - 已做的 smoke 结论：
-    - `forward_from_phase(...)`、`forward_from_field(...)`、`forward_from_phase_provider(...)` 可运行
-    - 现有 Issue 5/6 脚本在加入 hook 后仍能运行
-
-## 当前 Stage 3 记录边界
-
-- 已固定：
-  - propagation primitive 的实现边界
-  - full-grid forward + ROI supervision contract
-  - `L=1/3/5` 的显式 layer semantics
-  - decoder-only single-sample / small-subset 的最小验证路径
-  - future Stage 4 的 phase-provider hook 入口
-- 尚未在 Stage 3 中解决：
-  - encoder / joint training
-  - paper full-setting reproduction
-  - hardware robustness / quantization / misalignment
-  - dataset-scale end-to-end optical experiments
+  - future encoder 接入点已冻结
+  - Stage 4 不需要重新设计 optical core 接口
 
 ---
 
-# Stage 4 Minimal Closed-Loop Acceptance
+## S4-01 Single-Sample Closed-Loop Acceptance
 
-## S4-01 Single-Sample Closed-Loop Acceptance (Issue 4.6)
+- 对应任务：Issue 4.6 `Run Stage 4 single-sample overfit sanity and write acceptance report`
+- 做了什么：
+  - 使用现有 `scripts/train_stage4_minimal.py` 执行正式单样本 overfit 验收
+  - 未重写 optical core、dataset path、wrapper 或 trainer
+- 运行命令：
 
-- ����ʹ����С Stage 4 trainer ִ�е����� overfit�����γ����ձ���
-- �������ã�cuda����
-  - `steps = 100` �� `steps = 300`
-  - `dataset_root = data/raw/emnist`
-  - `hr_size = 96`
-  - optics grid: `24 / 32 / 48 / 20`
-- ����Ŀ¼��
+```bash
+python scripts/train_stage4_minimal.py \
+  --single-sample \
+  --steps 100 \
+  --device cuda \
+  --dataset-root data/raw/emnist \
+  --download \
+  --run-name issue4_6_single_sample_100
+```
+
+```bash
+python scripts/train_stage4_minimal.py \
+  --single-sample \
+  --steps 300 \
+  --device cuda \
+  --dataset-root data/raw/emnist \
+  --run-name issue4_6_single_sample_300
+```
+
+- 工件目录：
   - `outputs/stage4/minimal_trainer/issue4_6_single_sample_100/`
   - `outputs/stage4/minimal_trainer/issue4_6_single_sample_300/`
-- �ؼ������
-  - loss ��ȷ�½�
-  - encoder / optics �ݶȳ����ɹ۲�
-  - �� NaN / Inf
-  - �����𲽽ӽ�Ŀ��ṹ
-- ���ۣ�**PASS**
+- 结果摘要：
 
-## S4-02 Small-Subset Closed-Loop Acceptance (Issue 4.7)
+| run | steps | initial_loss | best_loss | final_loss | verdict |
+| --- | ---: | ---: | ---: | ---: | --- |
+| `issue4_6_single_sample_100` | 100 | 0.213564 | 0.164205 | 0.164152 | PASS |
+| `issue4_6_single_sample_300` | 300 | 0.213564 | 0.117267 | 0.116939 | PASS |
 
-- ������֤ learnability �Ƿ�����չ��С�Ӽ����ǵ�������
-- �������ã�cuda����
-  - `subset_size = 16`
-  - `batch_size = 4`
-  - `steps = 200` �� `steps = 400`
-  - `dataset_root = data/raw/emnist`
-  - optics grid: `24 / 32 / 48 / 20`
-- ����Ŀ¼��
+- 最小结论：
+  - loss 明确下降
+  - encoder / optics 梯度持续可观测
+  - 无 NaN / Inf
+  - 单样本 closed-loop learnability 成立
+- 详细报告：
+  - `docs/execution/stage4_single_sample_report.md`
+
+## S4-02 Small-Subset Closed-Loop Acceptance
+
+- 对应任务：Issue 4.7 `Run Stage 4 small-subset closed-loop training and summarize learnability`
+- 做了什么：
+  - 使用同一 Stage 4 最小训练栈运行真实小子集闭环训练
+  - 保持 Stage 4 范围，不扩展到 Stage 5 paper settings
+- 运行命令：
+
+```bash
+python scripts/train_stage4_minimal.py \
+  --subset-size 16 \
+  --batch-size 4 \
+  --steps 200 \
+  --preview-limit 4 \
+  --device cuda \
+  --dataset-root data/raw/emnist \
+  --run-name issue4_7_small_subset_16_s200
+```
+
+```bash
+python scripts/train_stage4_minimal.py \
+  --subset-size 16 \
+  --batch-size 4 \
+  --steps 400 \
+  --preview-limit 4 \
+  --device cuda \
+  --dataset-root data/raw/emnist \
+  --run-name issue4_7_small_subset_16_s400
+```
+
+- 工件目录：
   - `outputs/stage4/minimal_trainer/issue4_7_small_subset_16_s200/`
   - `outputs/stage4/minimal_trainer/issue4_7_small_subset_16_s400/`
-- �ؼ������
-  - loss ��С�Ӽ��������½�������ƽ̨
-  - encoder / optics �ݶȳ����ɹ۲�
-  - �������������Ӧ�������� collapse
-  - �� NaN / Inf
-  - ������ƫģ����PSNR/SSIM ƫ��
-- ���ۣ�**PASS���������**
+- 结果摘要：
+
+| run | steps | initial_loss | best_loss | final_loss | val_loss | verdict |
+| --- | ---: | ---: | ---: | ---: | ---: | --- |
+| `issue4_7_small_subset_16_s200` | 200 | 0.217708 | 0.149736 | 0.180445 | 0.192186 | PASS |
+| `issue4_7_small_subset_16_s400` | 400 | 0.217708 | 0.144116 | 0.171176 | 0.190612 | PASS |
+
+- 最小结论：
+  - 小子集上 loss 下降
+  - encoder / optics 梯度持续可观测
+  - 输出随输入变化，没有明显 collapse
+  - 输出质量仍偏模糊，PSNR / SSIM 偏低
+- 详细报告：
+  - `docs/execution/stage4_small_subset_report.md`
+
+---
+
+## 当前日志边界
+
+- 本文档当前记录到 Stage 4 learnability acceptance 为止。
+- Stage 5 目前只有 planning docs：
+  - `docs/plan/stage_plan/stage5/stage5_plan.md`
+  - `docs/plan/stage_plan/stage5/stage5_issue_plan.md`
+- 在尚未出现 paper-aligned 真实运行证据前，不应在本日志中提前写入 Stage 5 结果结论。

--- a/docs/execution/results_summary.md
+++ b/docs/execution/results_summary.md
@@ -1,153 +1,149 @@
 # Results Summary
 
-汇总当前 Stage 3 已经获得的事实性结果，并明确哪些结论已经可以说、哪些还不能说。
+本文档汇总当前仓库已经获得的事实性结果，用于回答两个问题：
 
-## 当前阶段
+1. 现在已经被验证的工程结论是什么。
+2. 现在还不能声称已经完成了什么。
 
-- Stage 4: Minimal Closed-Loop Learnability (**PASS**)
-- 当前定位：
-  - 已完成 Stage 4 单样本 overfit 验收（PASS）
-  - 已完成 Stage 4 小子集验收（PASS，带保留项）
-  - 下一阶段为 Stage 5 paper-aligned setting alignment（GO）
-  - 不代表论文指标已达成
-
-## 当前已验证的事实
-
-### 1. Stage 3 optical contract 已落地
-
-- 当前主链路已经稳定到：
-  - `phi_lr -> U0 -> U_out_full -> I_out_full -> I_out_roi`
-- full-grid forward 与 ROI supervision 已显式分离
-- `U_out_full`、`I_out_full`、`I_out_roi` 都由 optical module 直接返回
-
-### 2. Readout / Crop 最小验证通过
-
-来源：
-- `scripts/check_optical_readout.py`
-
-当前重跑结果：
-- `U_out_full` 为 complex tensor
-- `I_out_full` 和 `I_out_roi` 为 real 且 nonnegative
-- `output_crop_hw=(20, 20)` 时 ROI shape 为 `(1, 1, 20, 20)`
-- `output_crop_hw=(12, 12)` 时 ROI shape 为 `(1, 1, 12, 12)`
-- oversized crop 会报显式错误
-- 改变输入 phase 会改变输出：
-  - `full_delta = 1.748107e-03`
-  - `roi_delta = 2.850121e-03`
-
-### 3. Forward sanity 已覆盖 L=1/3/5
-
-来源：
-- `scripts/check_optical_forward_depths.py`
-
-当前重跑结果：
-- `L=1/3/5` 都能 forward 成功
-- 三个 depth 的输出接口一致：
-  - `U0`
-  - `U_out_full`
-  - `I_out_full`
-  - `I_out_roi`
-- `U_out_full` 持续保持 complex
-- `I_out_full` 与 `I_out_roi` 持续保持 real 且 nonnegative
-- 错误的 `inter_layer` 长度会被显式拒绝
-
-### 4. Decoder-only single-sample fitting 已显示明确下降
-
-来源：
-- `outputs/optics/decoder_only_single_sample_smoke/summary.json`
-
-当前 `L=3` smoke 结果：
-
-| depth | steps | initial_loss | best_loss | final_loss | loss_decrease |
-| --- | ---: | ---: | ---: | ---: | ---: |
-| 3 | 120 | 0.1463065892457962 | 0.03812457248568535 | 0.03893868252635002 | 0.10818201676011086 |
-
-补充观察：
-- `roi_change_mean_abs = 0.4759185314178467`
-- `best_roi_std = 0.34699586033821106`
-
-这说明在不引入 encoder 的条件下，当前 optical decoder stack 至少能对一个目标做出可观下降。
-
-### 5. Fixed-protocol small-subset depth sweep 已覆盖 L=1/3/5
-
-来源：
-- `outputs/optics/decoder_only_small_subset_sweep_run1/sweep_summary.json`
-- `outputs/optics/decoder_only_small_subset_sweep_run1/depth_comparison.csv`
-
-shared protocol：
-- `subset_size = 4`
-- `steps = 80`
-- `seed = 42`
-- `device = cpu`
-- `lr_phase = 0.15`
-- `lr_decoder = 0.03`
-- `freeze_decoder = false`
-- `loss = normalized_mae_roi`
-
-结果摘要：
-
-| depth | success_count | total_count | success_rate | mean_initial_loss | mean_best_loss | mean_loss_decrease |
-| --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| 1 | 4 | 4 | 1.0 | 0.12581018544733524 | 0.02864284673705697 | 0.09716733871027827 |
-| 3 | 4 | 4 | 1.0 | 0.13204407505691051 | 0.03225723281502724 | 0.09978684224188328 |
-| 5 | 4 | 4 | 1.0 | 0.1348664928227663 | 0.03135538613423705 | 0.10351110668852925 |
-
-最小事实结论：
-- 三种 depth 在同一 tiny protocol 下都能在多个样本上下降
-- Issue 6 需要的 fixed-protocol `L=1/3/5` 容量 sweep 已补齐
-
-## 当前可以说的结论
-
-- 当前 Stage 3 optical decoder skeleton 是可运行的，且 optical/readout/crop contract 已稳定。
-- 在当前 tiny synthetic protocol 下，`L=1/3/5` 三种 depth 都表现出可优化的 decoder-only capacity。
-- 当前结果已经足以支撑：
-  - 进入未来 Stage 4 时不必重新设计 optical core
-  - future encoder 只需要对接 phase-provider / `forward_from_phase(...)` contract
-
-## 当前不能说的结论
-
-- 不能说论文性能已经复现。
-- 不能说 `L=5` 或任何更深 depth 已经被严格证明更优。
-- 不能说当前 tiny synthetic subset 结果可直接外推到真实数据集或自然图像。
-- 不能说当前 optical module 已经完成 final paper-setting alignment。
-- 不能说 Stage 4 end-to-end training 已经就绪到可以跳过进一步调试。
-
-## 已知限制与风险
-
-- 当前验证协议使用的是 Stage 3 工程化 tiny setting，不是 final paper full-setting。
-- 当前子集目标是 deterministic synthetic ROI targets，主要用于 capacity sanity，不是正式 benchmark。
-- 当前 sweep 在 CPU 上完成，默认使用 float32 计算与较小 grid。
-- propagation primitive 来自 upstream optics 思路的重写版本，当前已做 forward / fitting sanity，但尚未扩展到硬件鲁棒性或更严格物理对照。
-- current depth comparison 只说明“在相同预算下都能下降”，不说明更深层必然更好。
-
-## 后续阶段边界
-
-- Stage 4 才进入 encoder 接入与最小闭环训练。
-- Stage 5/6 才进入 paper-final setting alignment、更多数据协议和系统化实验。
+本文档是结果摘要，不是实现说明书，也不是后续阶段计划文档。
 
 ---
 
-## Stage 4 Closed-Loop Learnability Summary
+## 当前阶段
 
-### �ѽ�������ʵ
+- 当前可信阶段结论：`Stage 4 minimal closed-loop learnability = PASS`
+- 当前工程状态：
+  - Stage 3 optical module verification 已完成
+  - Stage 4 单样本 closed-loop 验收已完成
+  - Stage 4 小子集 closed-loop 验收已完成（带保留项）
+  - Stage 5 paper-aligned planning 已起草，但 paper-aligned implementation 尚未开始
 
-- �������ջ� loss ��ȷ�½���encoder �� optics �ݶȿɹ۲⣬�� NaN/Inf
-- С�Ӽ��ջ� loss �����½����������������Ӧ�������� collapse
-- Stage 4 learnability gate ������PASS��
+---
 
-### ��δ��������ʵ
+## 当前已验证的事实
 
-- ���ļ�����������ָ�꣨PSNR/SSIM ��ƫ�ͣ�
-- paper-final setting alignment
-- ���ģѵ����ϵͳ������
+### 1. Stage 3 optical contract 已冻结并落地
 
-### ��Ҫ������
+- 当前主链路稳定为：
+  - `phi_lr -> U0 -> U_out_full -> I_out_full -> I_out_roi`
+- full-grid forward 与 ROI supervision 已显式分离
+- `U_out_full`、`I_out_full`、`I_out_roi` 由 optical module 直接返回
 
-- С�Ӽ�������ƫģ����blob-like
-- normalized MAE �� loss ƽֵ̨�ϸ�
-- ����ԭ�������С encoder ������toy optics grid��Ŀ���һ����ʽ�ȣ��� Stage 5 ��һ����֤��
+### 2. Readout / crop / forward sanity 已通过
 
-### Stage 5 ����
+来源：
 
-- ���ۣ�**GO**
-- ���ɣ�Stage 4 learnability gate ��ͨ��������������δ�������趨��Stage 5 �������Ǳ�Ҫ����
+- `scripts/check_optical_readout.py`
+- `scripts/check_optical_forward_depths.py`
+
+最小事实：
+
+- `I_out_full` / `I_out_roi` 保持 real 且 nonnegative
+- `U_out_full` 保持 complex
+- `output_crop_hw` 越界会显式报错
+- `L=1/3/5` 在当前 Stage 3 tiny setting 下都可 forward
+
+### 3. Decoder-only optical capacity 已通过最小验证
+
+来源：
+
+- `outputs/optics/decoder_only_single_sample_smoke/summary.json`
+- `outputs/optics/decoder_only_small_subset_sweep_run1/sweep_summary.json`
+
+最小事实：
+
+- decoder-only 单样本拟合中，loss 可明确下降
+- decoder-only 小子集 fixed-protocol sweep 中，`L=1/3/5` 都能在多个样本上下降
+- 这些结果说明 optical decoder stack 具备可优化容量
+- 这些结果不等价于 paper-aligned end-to-end 性能已经成立
+
+### 4. Stage 4 单样本 closed-loop 验收已通过
+
+来源：
+
+- `docs/execution/stage4_single_sample_report.md`
+- `outputs/stage4/minimal_trainer/issue4_6_single_sample_100/run_summary.json`
+- `outputs/stage4/minimal_trainer/issue4_6_single_sample_300/run_summary.json`
+
+结果摘要：
+
+| run | steps | initial_loss | best_loss | final_loss | encoder grad | optics grad | NaN/Inf |
+| --- | ---: | ---: | ---: | ---: | --- | --- | --- |
+| `issue4_6_single_sample_100` | 100 | 0.213564 | 0.164205 | 0.164152 | observed | observed | none |
+| `issue4_6_single_sample_300` | 300 | 0.213564 | 0.117267 | 0.116939 | observed | observed | none |
+
+最小事实：
+
+- loss 明确下降
+- encoder / optics 梯度全程可观测
+- 无 NaN / Inf
+- 预测 ROI 从初始扩散亮斑演化到与 target 更接近的结构
+
+### 5. Stage 4 小子集 closed-loop 验收已通过
+
+来源：
+
+- `docs/execution/stage4_small_subset_report.md`
+- `outputs/stage4/minimal_trainer/issue4_7_small_subset_16_s200/run_summary.json`
+- `outputs/stage4/minimal_trainer/issue4_7_small_subset_16_s400/run_summary.json`
+
+结果摘要：
+
+| run | steps | initial_loss | best_loss | final_loss | val_loss | encoder grad | optics grad | verdict |
+| --- | ---: | ---: | ---: | ---: | ---: | --- | --- | --- |
+| `issue4_7_small_subset_16_s200` | 200 | 0.217708 | 0.149736 | 0.180445 | 0.192186 | observed | observed | PASS |
+| `issue4_7_small_subset_16_s400` | 400 | 0.217708 | 0.144116 | 0.171176 | 0.190612 | observed | observed | PASS |
+
+最小事实：
+
+- 小子集上 train loss 明确下降
+- val loss 从初始状态下降后进入平台
+- 输出对输入仍有响应，没有明显 collapse 到单一模式
+- 无 NaN / Inf
+
+---
+
+## 当前可以说的结论
+
+- 当前仓库已经通过 Stage 4 learnability gate。
+- 现有 optical core 不需要在 Stage 5 之前重写。
+- Stage 5 应把重点放在 paper-aligned dataset / optics config / encoder / loss / eval，而不是重新证明“系统能不能学”。
+- Stage 4 的单样本和小子集工件应被保留为后续 Stage 5 回归基线。
+
+---
+
+## 当前不能说的结论
+
+- 不能说论文指标已经复现。
+- 不能说 paper-aligned pipeline 已经落地。
+- 不能说 `L=5` 或任何更深 depth 已被严格证明更优。
+- 不能说当前 Stage 4 结果可直接外推为 paper-final 质量。
+- 不能说 blind line-pair、量化、鲁棒性或系统化消融已经完成。
+
+---
+
+## 已知限制与风险
+
+- 当前 Stage 4 使用的是最小闭环协议，不是 paper-final setting。
+- 当前 raw 读出质量仍偏模糊，PSNR / SSIM 偏低。
+- Stage 4 的主损失是 normalized MAE；其优化目标与 raw 强度可视化 / PSNR / SSIM 不完全同向。
+- 400x400 propagation grid、paper dataset protocol、efficiency penalty 和 line-pair eval 尚未进入正式实现。
+
+---
+
+## 对 Stage 5 的含义
+
+- 结论：`GO`
+- 解释：
+  - Stage 4 已经回答“encoder + optics 是否可学”
+  - Stage 5 的任务不再是 learnability gate，而是把系统对齐到论文设定
+  - Stage 5 仍需对未决项保持诚实记录，不能把假设伪装成论文已明确
+
+---
+
+## 相关文档
+
+- `docs/execution/stage4_single_sample_report.md`
+- `docs/execution/stage4_small_subset_report.md`
+- `docs/plan/stage_plan/stage5/stage5_plan.md`
+- `docs/plan/stage_plan/stage5/stage5_issue_plan.md`

--- a/docs/execution/stage4_single_sample_report.md
+++ b/docs/execution/stage4_single_sample_report.md
@@ -1,0 +1,111 @@
+# Stage 4 Single-Sample Report
+
+## 1. 任务边界
+
+- 本次只验证 Stage 4 单样本 closed-loop learnability
+- 不重写 optical core
+- 不重写 dataset / adapter / wrapper / trainer
+- 不进入 Stage 5 paper-aligned settings
+
+## 2. 运行命令
+
+正式验收运行：
+
+```bash
+python scripts/train_stage4_minimal.py \
+  --single-sample \
+  --steps 100 \
+  --device cuda \
+  --dataset-root data/raw/emnist \
+  --download \
+  --run-name issue4_6_single_sample_100
+```
+
+补充运行：
+
+```bash
+python scripts/train_stage4_minimal.py \
+  --single-sample \
+  --steps 300 \
+  --device cuda \
+  --dataset-root data/raw/emnist \
+  --run-name issue4_6_single_sample_300
+```
+
+## 3. 设备与工件目录
+
+- 设备：`cuda`
+- 工件目录：
+  - `outputs/stage4/minimal_trainer/issue4_6_single_sample_100/`
+  - `outputs/stage4/minimal_trainer/issue4_6_single_sample_300/`
+
+## 4. Core Scalar Results
+
+| run | steps | initial loss | best loss | final loss | encoder grad | optics grad | NaN/Inf |
+| --- | ---: | ---: | ---: | ---: | --- | --- | --- |
+| `issue4_6_single_sample_100` | 100 | 0.213564 | 0.164205 | 0.164152 | observed | observed | none |
+| `issue4_6_single_sample_300` | 300 | 0.213564 | 0.117267 | 0.116939 | observed | observed | none |
+
+补充指标：
+
+- 100-step final val metrics:
+  - `val_loss = 0.164152`
+  - `val_psnr = 12.1184`
+  - `val_ssim = 0.3732`
+- 300-step final val metrics:
+  - `val_loss = 0.116939`
+  - `val_psnr = 10.8155`
+  - `val_ssim = 0.2243`
+
+## 5. Preview / Artifact Inspection Findings
+
+- `preview_step0.png` 中的 `pred I_out_roi` 主要是扩散亮斑，和 `target_roi` 不对齐。
+- 到 100-step 时，预测已从泛化亮斑收缩成更接近字符拓扑的结构。
+- 到 300-step 时，预测主轮廓进一步贴近 target，背景更暗，误差主要集中在字符边缘与局部笔画残差。
+
+说明：
+
+- 当前预览图展示的是 raw `I_out_roi`。
+- 训练目标是 ROI-level normalized MAE，内部存在按样本重标定的 `sigma`。
+- 因此 raw 读出预览、PSNR/SSIM 与训练主损失不完全同向。
+
+## 6. Gradient Findings
+
+- 100-step：`encoder_nonzero_steps = 100 / 100`，`optics_nonzero_steps = 100 / 100`
+- 300-step：`encoder_nonzero_steps = 300 / 300`，`optics_nonzero_steps = 300 / 300`
+
+结论：
+
+- encoder 与 optics 在整个训练过程中都持续收到有效梯度
+
+## 7. Stability Findings
+
+- `run_summary.json` 中 `initial_preview_finite = true`
+- `run_summary.json` 中 `final_preview_finite = true`
+- 无 NaN / Inf
+- loss curve 连续，没有爆炸或异常跳变
+
+## 8. Verdict
+
+**PASS**
+
+理由：
+
+1. 单样本 closed-loop loss 明确下降。
+2. 预测 ROI 从初始扩散亮斑演化到与目标更接近的结构。
+3. encoder 与 optics 梯度在整个训练中均被持续观测到。
+4. 没有 NaN / Inf 或明显数值不稳定。
+
+## 9. 非阻塞保留项
+
+- 300-step 的 raw PSNR / SSIM 低于 100-step，不应忽略。
+- 在当前 Stage 4 最小协议下，这更像是 normalized-MAE 训练目标与 raw ROI 可视化指标不完全一致，而不是 learnability 消失。
+- 当前 PASS 的含义是“单样本 learnability 已成立”，不是“paper-final 读出质量已经理想”。
+
+## 10. 下一步
+
+进入 Stage 4 的小子集闭环验收，重点检查：
+
+- 小子集下 loss 是否仍能稳定下降
+- 梯度可观测性是否保持
+- 预览图是否从单样本记忆延伸到少量真实样本上的持续可学

--- a/docs/paper/paper_notes.md
+++ b/docs/paper/paper_notes.md
@@ -19,10 +19,10 @@
 - 数值实验主线
 - phase-only 输入调制
 - 电子编码器 + 衍射解码器联合训练
-- optical decoder 的层数对比（L=1/3/5）
+- optical decoder 的层数对比（L=1/3/5；先保证 paper-aligned configs 可运行，系统化比较后置到 Stage 6）
 - PSNR / SSIM 指标
-- blind 高频 line-pair test
-- 量化 sweep（至少推理阶段测试）
+- blind 高频 line-pair test（在 paper-aligned pipeline 就绪后进入 Stage 5）
+- 量化 sweep（至少推理阶段测试；属于总复现范围，但按当前阶段计划后置到 Stage 6）
 
 ### 暂不优先
 - 真实 THz 实验系统
@@ -300,15 +300,15 @@
 - baseline 先做 bicubic + 纯电子模型
 
 ### 第二步
-- blind line-pair test
-- efficiency on/off ablation
-- complex-valued 对照
+- blind line-pair test（Stage 5，在 paper-aligned pipeline 建立后执行）
 
 ### 第三步
-- quantization sweep
-- misalignment test / vaccination
+- efficiency on/off ablation（Stage 6）
+- complex-valued 对照（Stage 6）
+- quantization sweep（Stage 6）
 
 ### 第四步（以后）
+- misalignment test / vaccination
 - THz experimental setting closer reproduction
 
 ---

--- a/docs/plan/stage_plan/stage5/stage5_issue_plan.md
+++ b/docs/plan/stage_plan/stage5/stage5_issue_plan.md
@@ -1,13 +1,18 @@
-﻿**GPT-5.4**
+**GPT-5.4**
 
-下面给出一份 **Stage 5 详细工程推进计划**，用于直接拆成 GitHub issues 执行。内容基于当前仓库与既有文档：`plan_overview.md`、`stage4_protocol_freeze.md`、`paper_notes.md` 和 execution logs。
+下面给出一份 **Stage 5 详细工程推进计划**，用于直接拆成 GitHub issues 执行。内容基于当前仓库与既有文档：`PROJECT_CONTEXT.md`、`stage4_protocol_freeze.md`、`paper_notes.md`、`stage5_plan.md` 与 execution docs。
 
 Stage 5 的核心不是“系统化消融”，而是 **把论文主设定落地成可运行、可复盘的工程协议**。系统化 sweep、量化、鲁棒性和大规模对比应后置到 Stage 6。
 
+范围冲突提醒：
+
+- 当 `paper_notes.md` 记录的是更宽的复现总范围，而 `stage5_plan.md` / 本文件记录的是当前阶段排期时，以 Stage 5 文档为准。
+- 特别是 quantization、misalignment、systematic ablations 不应提前塞进 Stage 5 implementation prompt。
+
 前置条件提醒：
 
-- Stage 4 单样本 overfit 与小子集闭环必须已经通过
-- 若单样本闭环报告缺失，建议先补齐，再进入 Stage 5
+- Stage 4 单样本 overfit 与小子集闭环已经通过
+- Stage 4 regression baseline 只用于继承，不应在 Stage 5 issue 中重开
 
 ---
 
@@ -15,16 +20,16 @@ Stage 5 的核心不是“系统化消融”，而是 **把论文主设定落地
 
 一句话版本：
 
-> **把论文的完整设定（96×96 数据协议、200/400 光学网格、L=1/3/5、phase-only encoder、loss/效率项、训练超参、评估口径）落地为可复现 pipeline，并产出首个 paper-aligned 训练结果。**
+> **把论文的完整设定（96×96 数据协议、200/400 光学网格、L=1/3/5、phase-only encoder、loss/效率项、训练超参、评估口径）落地为可复现 pipeline，并形成至少一个可真实启动的 paper-aligned 主线运行路径。**
 
 ---
 
-# 二、Stage 5 拆解为 10 个 GitHub Issues
+# 二、Stage 5 拆解为 11 个 GitHub Issues
 
 建议命名方式：
 
 - Milestone: `Stage 5 — Paper-Aligned Settings`
-- Issue 编号：`5.1 ~ 5.10`
+- Issue 编号：`5.1 ~ 5.11`
 
 ---
 
@@ -34,28 +39,23 @@ Stage 5 的核心不是“系统化消融”，而是 **把论文主设定落地
 
 先把 Stage 5 的协议冻住，不然所有实现都会漂。
 
-要明确：数据构造、光学 grid、distance schedule、encoder 输出尺寸、loss 公式、训练超参与评估协议，并把未决项列成清单。
+要明确：
 
-## 输入
-
-- `docs/plan/plan_overview.md`
-- `docs/plan/stage_plan/stage4/stage4_protocol_freeze.md`
-- `docs/paper/paper_notes.md`
-- `docs/execution/results_summary.md`
+- 数据构造
+- 光学 grid 与 distance mapping
+- encoder 输出尺寸与 phase mapping
+- loss 公式与 gamma 默认值
+- 训练 / 评估协议
+- 每个未决项由哪个后续 issue 拍板
 
 ## 产物
 
 - `docs/plan/stage_plan/stage5/stage5_protocol_freeze.md`
 
-## 验收标准
-
-- 文档明确 Stage 5 与 Stage 6 的边界
-- 论文设定中的关键参数都写清楚
-- 所有不确定项以“待确认”列出
-
 ## 风险点
 
-最大风险是把 Stage 5 写成 Stage 6 的消融计划。
+- 把 Stage 5 写成 Stage 6 的消融计划
+- 让后续 issue 在错误位置擅自拍板未决项
 
 ## GitHub issue 正文建议
 
@@ -67,6 +67,9 @@ Body:
 ## Background
 Stage 5 should align the repo to the paper's full settings. Without a frozen protocol, implementations will drift and become untraceable.
 
+## Suggested Branch
+`docs/update`
+
 ## Goal
 Write and freeze a Stage-5 protocol document that defines:
 - paper-aligned data protocol
@@ -76,19 +79,26 @@ Write and freeze a Stage-5 protocol document that defines:
 - training hyperparameters
 - evaluation protocol
 - explicit unresolved items
+- ownership mapping from unresolved items to later issues
+
+## Scope Priority
+If `paper_notes.md` and Stage 5 planning docs disagree on stage scope, Stage 5 planning docs win.
 
 ## Tasks
-- Review plan_overview, Stage-4 protocol freeze, and paper_notes
+- Review PROJECT_CONTEXT, Stage-4 protocol freeze, paper_notes, and stage5_plan
 - Define the Stage 5 dataflow and tensor contract
-- Freeze optics grid and distance schedule mapping
-- Freeze loss definition and efficiency term defaults
+- Freeze optics grid and distance schedule mapping rules
+- Freeze loss definition and efficiency-term defaults as configurable policy
 - Record all unresolved items explicitly
+- Record which later issue is allowed to finalize each unresolved item
 
 ## Deliverable
 - `docs/plan/stage_plan/stage5/stage5_protocol_freeze.md`
 
 ## Acceptance
-The document makes Stage 5 scope explicit and prevents confusion with Stage 6.
+- The document makes Stage 5 scope explicit and prevents confusion with Stage 6
+- Each unresolved item has an owner issue
+- Future implementation issues can tell what they may or may not finalize
 ```
 
 ---
@@ -103,24 +113,14 @@ The document makes Stage 5 scope explicit and prevents confusion with Stage 6.
 
 - train/val 含 1~4 letters
 - test 含 6~9 letters
-- 记录 tile 规则与随机种子
-- 加入 rotation / flip / contrast augmentation
+- tile 规则、随机种子、空位策略必须可追溯
+- augmentation 只做论文主线提到的 rotation / flip / contrast
 
 ## 产物
 
 - 新数据模块（建议 `src/data/stage5_emnist_display.py`）
-- 可视化样本预览
-- config 入口（不把参数写死）
-
-## 验收标准
-
-- 可生成 96×96 图像 batch
-- train/val/test 分布符合论文描述
-- 保存预览图可解释
-
-## 风险点
-
-tile 规则若不透明，后续结果无法对齐论文。
+- 样本预览
+- dataset config
 
 ## GitHub issue 正文建议
 
@@ -132,6 +132,9 @@ Body:
 ## Background
 Paper-aligned training requires the 96×96 EMNIST display dataset with specific train/val/test composition rules.
 
+## Suggested Branch
+`feat/data`
+
 ## Goal
 Implement a dataset pipeline that reproduces the paper's 96×96 display protocol, including augmentation.
 
@@ -140,7 +143,12 @@ Implement a dataset pipeline that reproduces the paper's 96×96 display protocol
 - Enforce train/val/test size and letter-count distribution
 - Add rotation/flip/contrast augmentation options
 - Save a small preview grid of generated samples
-- Keep all rules configurable
+- Keep tile rules and randomization explicitly configurable
+
+## Non-Goals
+- Do not introduce natural-image datasets
+- Do not redesign Stage 4 data path
+- Do not add Stage 6 quantization or robustness logic
 
 ## Deliverable
 - Dataset module under `src/data/`
@@ -159,29 +167,19 @@ Implement a dataset pipeline that reproduces the paper's 96×96 display protocol
 
 ## 这个 issue 要解决什么
 
-把论文的 optical geometry 变成可复用的 config，并确保 L=1/3/5 都可 forward。
+把论文的 optical geometry 变成可复用 config，并确保 L=1/3/5 都可 forward。
 
 ## 关键要点
 
 - layer grid 200×200
 - propagation grid 400×400（zero padding）
 - input/output FOV 96×96
-- 距离 schedule 必须显式映射到 `input_to_first / inter_layer / last_to_sensor`
-
-## 产物
-
-- optics config（建议 `configs/optics/paper_l1.yaml`、`paper_l3.yaml`、`paper_l5.yaml`）
-- smoke check 脚本或更新现有 sanity script
-
-## 验收标准
-
-- L=1/3/5 forward 成功
-- 输出 shape 与 ROI 对齐
-- distances mapping 清楚且可追溯
+- distance schedule 显式映射到 `input_to_first / inter_layer / last_to_sensor`
 
 ## 风险点
 
-距离映射不清会导致“跑得通但不对齐”。
+- distance mapping 被悄悄拍板到代码里
+- 顺手改动 optical core 设计
 
 ## GitHub issue 正文建议
 
@@ -193,13 +191,32 @@ Body:
 ## Background
 Stage 5 requires paper-aligned optics geometry: 200×200 layer grid, 400×400 propagation grid, and explicit distance schedules.
 
+## Suggested Branch
+`feat/optics`
+
+## Frozen Inheritance
+- Keep the frozen optical contract:
+  `phi_lr -> U0 -> U_out_full -> I_out_full -> I_out_roi`
+- Reuse the current optics hooks and module boundaries
+- Treat Stage 4 artifacts as regression baseline, not as work to redo
+
 ## Goal
 Create reusable optics configs for L=1/3/5 that match the paper settings and pass forward sanity checks.
+
+## Allowed Decisions
+- Express the paper distances as explicit config values
+- Document the chosen mapping from paper notation to `input_to_first / inter_layer / last_to_sensor`
+
+## Must Not Finalize Here
+- Do not redefine the optical contract
+- Do not add post-optics electrical heads
+- Do not silently encode distance assumptions inside implementation logic
 
 ## Tasks
 - Define paper-aligned grid/padding settings in config files
 - Map paper distances to input_to_first / inter_layer / last_to_sensor
 - Add or reuse a sanity script to validate shapes and forward stability
+- Record the mapping rationale in docs or config comments
 
 ## Deliverable
 - Optics config files under `configs/optics/`
@@ -208,6 +225,7 @@ Create reusable optics configs for L=1/3/5 that match the paper settings and pas
 ## Acceptance
 - L=1/3/5 forward works with correct shapes
 - Distance mapping is explicit and documented
+- No optical-core redesign is introduced
 ```
 
 ---
@@ -218,26 +236,11 @@ Create reusable optics configs for L=1/3/5 that match the paper settings and pas
 
 实现论文主线 encoder，把 96×96 HR 输入映射为低分辨率 phase-only `phi_lr`。
 
-## 设计要点
+## 关键要点
 
-- 输出 shape 对齐 paper LR pattern（默认 32×32，但需在协议中确认）
-- 显式相位范围映射（例如 `[-π, π]`）
-- 不改 optical core
-
-## 产物
-
-- `src/models/encoder/paper_encoder_v1.py`
-- 对应 config 入口
-
-## 验收标准
-
-- forward 输出 shape 正确
-- phase 范围受控
-- 可接入 `forward_from_phase(...)`
-
-## 风险点
-
-输出尺寸或相位范围不明确会导致全链路偏差。
+- 输出 shape 对齐 paper LR pattern
+- 相位范围映射必须显式
+- 不能借机改 optical core
 
 ## GitHub issue 正文建议
 
@@ -249,12 +252,28 @@ Body:
 ## Background
 Stage 5 requires a paper-aligned encoder that outputs a low-resolution phase-only pattern compatible with the frozen optical contract.
 
+## Suggested Branch
+`feat/model`
+
+## Frozen Inheritance
+- Keep the optical contract unchanged
+- Reuse `forward_from_phase(...)` / current phase-provider-friendly integration path
+- Stage 4 baseline remains the regression reference
+
 ## Goal
 Add a paper-aligned encoder module that maps 96×96 HR input to a phase-only `phi_lr` tensor.
 
+## Allowed Decisions
+- Implement a configurable phase mapping
+- Make output size configurable if the final paper-aligned size is still unresolved
+
+## Must Not Finalize Here
+- Do not claim one phase range is paper-uniquely settled if docs still mark it unresolved
+- Do not modify optics-core files to accommodate encoder convenience
+
 ## Tasks
 - Implement `paper_encoder_v1.py` under `src/models/encoder/`
-- Ensure output spatial size matches the paper LR pattern size
+- Ensure output spatial size matches the Stage 5 protocol choice
 - Apply explicit phase-range mapping
 - Keep the optical core untouched
 
@@ -265,6 +284,7 @@ Add a paper-aligned encoder module that maps 96×96 HR input to a phase-only `ph
 ## Acceptance
 - Output shape and range are correct
 - Forward integrates with the current diffractive decoder
+- Unresolved phase-range choices stay configurable and logged
 ```
 
 ---
@@ -275,26 +295,11 @@ Add a paper-aligned encoder module that maps 96×96 HR input to a phase-only `ph
 
 把论文的 normalized MAE + efficiency term 落地为可配置损失。
 
-## 设计要点
+## 关键要点
 
 - σ 归一化项按论文公式实现
 - efficiency term 可开关
 - γ 对 L=1/3/5 可配置
-
-## 产物
-
-- loss 实现（建议 `src/losses/paper_sr_loss.py`）
-- config 入口
-- 最小 unit check（前向数值稳定）
-
-## 验收标准
-
-- loss 数值稳定（无 NaN/Inf）
-- γ 与开关可配置
-
-## 风险点
-
-若 σ 归一化实现偏差，会导致训练曲线不可对齐。
 
 ## GitHub issue 正文建议
 
@@ -306,8 +311,23 @@ Body:
 ## Background
 The paper uses normalized MAE plus an efficiency term. Stage 5 must align this loss exactly and keep it configurable.
 
+## Suggested Branch
+`feat/train`
+
+## Frozen Inheritance
+- Keep the frozen optical readout contract
+- Reuse the current Stage 4 understanding of normalized ROI supervision as historical context only
+
 ## Goal
 Implement the paper-aligned loss function with a switchable efficiency term and configurable gamma values.
+
+## Allowed Decisions
+- Implement configurable gamma defaults per depth
+- Record unresolved gamma policy in config / summary
+
+## Must Not Finalize Here
+- Do not hard-code an unreviewed L=5 gamma as if it were settled
+- Do not bundle Stage 6 ablation logic into the loss implementation
 
 ## Tasks
 - Implement normalized MAE with sigma normalization
@@ -322,6 +342,7 @@ Implement the paper-aligned loss function with a switchable efficiency term and 
 ## Acceptance
 - Loss runs stably on a fake batch
 - Gamma values and toggles are configurable and logged
+- Unresolved gamma policy remains explicit
 ```
 
 ---
@@ -332,25 +353,11 @@ Implement the paper-aligned loss function with a switchable efficiency term and 
 
 实现 Stage 5 主线训练脚本，能跑 paper-aligned 设置并保存完整工件。
 
-## 设计要点
+## 关键要点
 
 - 支持 encoder / decoder 参数分组（不同 LR）
-- 支持长训与 resume
-- 保存 config snapshot / summary / metrics / checkpoints / sample previews
-
-## 产物
-
-- `scripts/train_stage5_paper.py`
-- 训练 config 模板（dataset / optics / loss / optimizer）
-
-## 验收标准
-
-- 能完成短 smoke 训练
-- 产物齐全且可追溯
-
-## 风险点
-
-trainer 过度泛化会把 Stage 6 需求提前塞进来。
+- 支持 resume
+- 只为 Stage 5 paper path 服务，不做通用训练框架
 
 ## GitHub issue 正文建议
 
@@ -362,14 +369,27 @@ Body:
 ## Background
 Stage 5 needs a dedicated trainer that runs the paper-aligned pipeline with correct configs and artifacts.
 
+## Suggested Branch
+`feat/train`
+
+## Frozen Inheritance
+- Keep the optical contract unchanged
+- Keep Stage 4 as regression baseline
+- Reuse trusted training skeleton ideas where useful, without generalizing the whole repo
+
 ## Goal
 Create a paper-aligned training script with clear configs, artifact saving, and resume support.
+
+## Non-Goals
+- Do not turn this into a general training framework
+- Do not fill empty `scripts/train.py` as a global entrypoint
+- Do not redesign Stage 4 trainer for reuse beyond what Stage 5 strictly needs
 
 ## Tasks
 - Add `scripts/train_stage5_paper.py`
 - Support separate LR for encoder and decoder
 - Save config snapshots, summary, metrics, checkpoints, and previews
-- Keep the script minimal and paper-focused
+- Keep the script Stage-5-specific and paper-focused
 
 ## Deliverable
 - Stage 5 trainer script
@@ -378,83 +398,109 @@ Create a paper-aligned training script with clear configs, artifact saving, and 
 ## Acceptance
 - A short run completes successfully
 - All expected artifacts are generated and logged
+- The script remains Stage-5-specific rather than framework-generic
 ```
 
 ---
 
-# Issue 5.7 — Add evaluation runner + bicubic baseline + line-pair test
+# Issue 5.7 — Add regular evaluation runner with bicubic baseline
 
 ## 这个 issue 要解决什么
 
-实现 paper-aligned 评估：PSNR/SSIM、bicubic baseline、blind line-pair test。
+实现 paper-aligned 常规评估：PSNR/SSIM 与 bicubic baseline。
 
-## 产物
+## 关键要点
 
-- `scripts/eval_stage5_paper.py`
-- bicubic baseline 生成逻辑
-- line-pair / resolution target 生成与评估入口
-
-## 验收标准
-
-- 可以对 val/test 集输出 PSNR/SSIM
-- baseline 结果可复盘
-- line-pair 测试可运行
-
-## 风险点
-
-评估口径不一致会导致结果不可比较。
+- 先把常规 eval 打通
+- 不与 blind line-pair test 混在一个 issue 里
 
 ## GitHub issue 正文建议
 
 Title:
-`Add Stage 5 evaluation runner with bicubic baseline and line-pair test`
+`Add Stage 5 evaluation runner with bicubic baseline`
 
 Body:
 ```md
 ## Background
-Paper alignment requires consistent evaluation: PSNR/SSIM, bicubic baseline, and blind line-pair tests.
+Stage 5 needs a regular evaluation path for PSNR/SSIM and the paper's bicubic baseline before adding blind line-pair tests.
+
+## Suggested Branch
+`feat/eval`
 
 ## Goal
-Provide a unified evaluation runner that reproduces paper-aligned metrics and baselines.
+Provide a unified evaluation runner for regular val/test evaluation and bicubic baseline comparison.
 
 ## Tasks
 - Implement `scripts/eval_stage5_paper.py`
-- Add bicubic baseline generation (with anti-aliasing)
-- Add line-pair / resolution target generator and eval hook
-- Log metric outputs in a reproducible format
+- Add bicubic baseline generation with anti-aliasing
+- Log PSNR/SSIM outputs in a reproducible format
+- Record crop / normalization choices explicitly
+
+## Non-Goals
+- Do not add blind line-pair generation here
+- Do not build a broad evaluation subsystem
 
 ## Deliverable
 - Evaluation script
-- Baseline and line-pair utilities
+- Bicubic baseline utility
 
 ## Acceptance
 - PSNR/SSIM can be computed on val/test
 - Bicubic baseline is reproducible
-- Line-pair tests can be executed and logged
+- Metric outputs and evaluation assumptions are logged
 ```
 
 ---
 
-# Issue 5.8 — Run paper-aligned smoke training and write report
+# Issue 5.8 — Add blind line-pair generator and eval hook
+
+## 这个 issue 要解决什么
+
+把 blind line-pair / resolution target 测试独立出来，避免和常规 eval 混成一个大任务。
+
+## GitHub issue 正文建议
+
+Title:
+`Add Stage 5 blind line-pair generator and evaluation hook`
+
+Body:
+```md
+## Background
+Blind line-pair testing is important for paper alignment, but it should be implemented as a separate scoped task instead of being bundled into the regular evaluation runner.
+
+## Suggested Branch
+`feat/eval`
+
+## Goal
+Add a blind line-pair / resolution-target generation path and hook it into the Stage 5 evaluation workflow.
+
+## Tasks
+- Add line-pair / resolution-target generator utilities
+- Define how blind-test outputs are stored and compared
+- Hook blind-test execution into the evaluation path without rewriting regular eval
+- Document assumptions about target generation and reporting
+
+## Non-Goals
+- Do not redesign the regular evaluation runner
+- Do not introduce quantization or robustness studies here
+
+## Deliverable
+- Blind line-pair utility / hook
+- Logged blind-test artifact path and reporting convention
+
+## Acceptance
+- Blind line-pair tests can be generated and executed
+- Artifacts are saved in a reproducible format
+- The implementation stays separate from regular eval concerns
+```
+
+---
+
+# Issue 5.9 — Run paper-aligned smoke training and write report
 
 ## 这个 issue 要解决什么
 
 用 paper-aligned 配置做一次短训 smoke，验证 pipeline 稳定。
-
-## 产物
-
-- `outputs/stage5/paper_smoke/...`
-- `docs/execution/stage5_smoke_report.md`
-
-## 验收标准
-
-- 无 NaN/Inf
-- loss 有下降趋势
-- 训练产物齐全
-
-## 风险点
-
-若 smoke 不通过，应先修 pipeline，不进入主线大训。
 
 ## GitHub issue 正文建议
 
@@ -466,6 +512,9 @@ Body:
 ## Background
 Before launching long runs, we need a paper-aligned smoke run to validate the pipeline end-to-end.
 
+## Suggested Branch
+`feat/train`
+
 ## Goal
 Run a short paper-aligned training and record stability and artifacts.
 
@@ -474,6 +523,10 @@ Run a short paper-aligned training and record stability and artifacts.
 - Save checkpoints and preview outputs
 - Record loss trends and stability findings
 - Write a concise smoke report
+
+## Non-Goals
+- Do not treat smoke as the final paper result
+- Do not expand this into main-run tuning
 
 ## Deliverable
 - Smoke run outputs under `outputs/stage5/`
@@ -487,26 +540,16 @@ Run a short paper-aligned training and record stability and artifacts.
 
 ---
 
-# Issue 5.9 — Run paper-aligned main training (phase-only, L=5) + report
+# Issue 5.10 — Run paper-aligned main training (phase-only, L=5) + report
 
 ## 这个 issue 要解决什么
 
 执行 paper-aligned 主线训练（建议 L=5 phase-only），并记录结果。
 
-## 产物
+## 关键要点
 
-- `outputs/stage5/paper_main_l5/...`
-- `docs/execution/stage5_main_run_report.md`
-
-## 验收标准
-
-- 训练完成并生成完整工件
-- PSNR/SSIM 与 baseline 可对比
-- 未决项在报告中被明确记录
-
-## 风险点
-
-训练成本高，需提前评估算力与时间预算。
+- 这是 main-run issue，不是 trainer / eval 功能开发 issue
+- 必须把“代码已就绪”与“长训资源是否足够”分开记录
 
 ## GitHub issue 正文建议
 
@@ -516,45 +559,47 @@ Title:
 Body:
 ```md
 ## Background
-Stage 5 should produce at least one paper-aligned main run to anchor the reproduction results.
+Stage 5 should produce a paper-aligned main run once the pipeline, trainer, and evaluation path are already in place.
+
+## Suggested Branch
+`feat/train`
 
 ## Goal
 Run the paper-aligned main training for phase-only L=5 and document the results.
 
 ## Tasks
-- Train with the paper-aligned L=5 config
-- Run evaluation on val/test
+- Launch the paper-aligned L=5 config
+- Run evaluation on val/test using the existing Stage 5 eval path
 - Compare against bicubic baseline
-- Write a main-run report with assumptions and gaps
+- Write a main-run report with assumptions, results, and remaining gaps
+
+## Resource Boundary
+- Distinguish clearly between:
+  - code/config path is launch-ready
+  - long-run budget was or was not fully available
+- If compute limits block a full target-budget run, record that as a resource constraint, not as a hidden implementation detail
+
+## Non-Goals
+- Do not reopen trainer architecture here
+- Do not add Stage 6 sweeps or ablations here
 
 ## Deliverable
 - Main run outputs under `outputs/stage5/`
 - `docs/execution/stage5_main_run_report.md`
 
 ## Acceptance
-- Training completes with full artifacts
-- Evaluation metrics are recorded and comparable
-- Report clearly states assumptions and remaining gaps
+- A real paper-aligned main run is launched and logged
+- Evaluation metrics are recorded in a comparable format
+- The report separates implementation readiness from resource-limited execution state
 ```
 
 ---
 
-# Issue 5.10 — Consolidate Stage-5 docs and make Stage-6 go/no-go decision
+# Issue 5.11 — Consolidate Stage-5 docs and make Stage-6 go/no-go decision
 
 ## 这个 issue 要解决什么
 
 把 Stage 5 执行结果收口，更新文档，并明确是否进入 Stage 6。
-
-## 产物
-
-- 更新 `docs/execution/experiment_log.md`
-- 更新 `docs/execution/results_summary.md`
-- 更新 `docs/plan/reproduction_plan.md`
-
-## 验收标准
-
-- Stage 5 结果与假设被清楚记录
-- Stage 6 进入条件被明确判定
 
 ## GitHub issue 正文建议
 
@@ -566,12 +611,15 @@ Body:
 ## Background
 Stage 5 is only useful if its results are consolidated and used to decide Stage 6 entry.
 
+## Suggested Branch
+`docs/update`
+
 ## Goal
 Summarize Stage 5 execution, update docs, and make an explicit Stage-6 decision.
 
 ## Tasks
 - Update experiment log and results summary
-- Record all paper-aligned assumptions and unresolved items
+- Record all paper-aligned assumptions and unresolved-item outcomes
 - Summarize smoke and main-run outcomes
 - Make a clear go/no-go call for Stage 6
 
@@ -579,7 +627,9 @@ Summarize Stage 5 execution, update docs, and make an explicit Stage-6 decision.
 - Updated docs with a clear Stage 6 decision
 
 ## Acceptance
-The repo states clearly whether Stage 5 passed and whether Stage 6 may start.
+- The repo states clearly whether Stage 5 passed
+- The docs distinguish engineering completion from resource-limited run status
+- Stage 6 entry conditions are explicit
 ```
 
 ---
@@ -594,6 +644,7 @@ The repo states clearly whether Stage 5 passed and whether Stage 6 may start.
 6. Issue 5.8
 7. Issue 5.9
 8. Issue 5.10
+9. Issue 5.11
 
 ---
 
@@ -609,7 +660,8 @@ Issues：
 - 5.4 Implement paper-aligned phase-only encoder for Stage 5
 - 5.5 Add paper-aligned SR loss with efficiency penalty
 - 5.6 Implement Stage 5 paper-aligned trainer and configs
-- 5.7 Add Stage 5 evaluation runner with bicubic baseline and line-pair test
-- 5.8 Run paper-aligned smoke training and write Stage 5 smoke report
-- 5.9 Run paper-aligned main training (phase-only, L=5) and write report
-- 5.10 Consolidate Stage 5 results and make Stage-6 go/no-go decision
+- 5.7 Add Stage 5 evaluation runner with bicubic baseline
+- 5.8 Add Stage 5 blind line-pair generator and evaluation hook
+- 5.9 Run paper-aligned smoke training and write Stage 5 smoke report
+- 5.10 Run paper-aligned main training (phase-only, L=5) and write report
+- 5.11 Consolidate Stage 5 results and make Stage-6 go/no-go decision

--- a/docs/plan/stage_plan/stage5/stage5_plan.md
+++ b/docs/plan/stage_plan/stage5/stage5_plan.md
@@ -24,6 +24,11 @@ Stage 5 的任务不是做系统化消融，而是把论文主设定（数据、
 6. `docs/execution/results_summary.md`
 7. `docs/execution/experiment_log.md`
 
+范围冲突处理规则：
+
+- 当 `docs/paper/paper_notes.md` 记录的是更宽的复现总范围，而本文件记录的是当前阶段排期时，以本文件为准。
+- 特别是 quantization、misalignment、systematic ablations 虽属于总复现范围，但当前明确后置到 Stage 6。
+
 ---
 
 # 2. Stage 5 核心目标
@@ -60,13 +65,8 @@ Stage 5 的任务不是做系统化消融，而是把论文主设定（数据、
 
 当前仓库已存在：
 
+- `docs/execution/stage4_single_sample_report.md`（已通过）
 - `docs/execution/stage4_small_subset_report.md`（已通过）
-
-仍需确认：
-
-- 是否已有单样本闭环报告（建议路径：`docs/execution/stage4_single_sample_report.md`）
-
-若单样本证据缺失，应先补齐再进入 Stage 5。
 
 ---
 
@@ -148,6 +148,11 @@ Stage 5 的任务不是做系统化消融，而是把论文主设定（数据、
 - γ = 0.015 for L=3
 - 其它情况 γ = 0（需明确是否对 L=5 也为 0）
 
+Stage 5 的实现要求：
+
+- loss 必须支持 configurable gamma，而不是把 L=5 gamma 静态拍死在代码里
+- 若实现阶段暂未拍板 L=5 gamma，则必须把默认值与理由写入 config / summary / protocol freeze
+
 ## 6.5 训练设定
 
 - optimizer：Adam
@@ -173,13 +178,15 @@ Stage 5 的任务不是做系统化消融，而是把论文主设定（数据、
 
 # 7. 待确认与假设清单（Stage 5 必须显式记录）
 
-1. `phi_lr` 的精确尺寸是否固定为 32×32（默认假设为 96/3）。
-2. 96×96 display 的具体 tile 规则（布局、放置策略、随机性、空位处理）。
-3. distance schedule 与代码中 `input_to_first / inter_layer / last_to_sensor` 的映射关系。
-4. efficiency penalty 是否对 L=5 也为 0。
-5. phase mapping 使用 `[0, 2π)` 还是 `[-π, π]`（以及初始分布）。
-6. σ 的归一化在 batch 维的 exact 计算方式（逐样本还是逐 batch）。
-7. output FOV 与 full-grid 的 crop 对齐是否有额外 margin / padding 处理。
+| 未决项 | 当前默认处理 | 主要拍板 issue | 当前不允许发生的事 |
+| --- | --- | --- | --- |
+| `phi_lr` 的精确尺寸是否固定为 32×32 | 默认假设 `96 / 3 = 32`，但不得伪装成论文唯一明示 | Issue 5.1, 5.4 | 在 encoder 实现里把 `32×32` 写成“论文已明确唯一正确值” |
+| 96×96 display 的 tile 规则 | 需要显式写进 dataset config 与预览 | Issue 5.1, 5.2 | 在 dataset 代码里隐式写死随机布局而不记录 |
+| distance schedule 与 `input_to_first / inter_layer / last_to_sensor` 的映射 | 必须显式写进 optics config 与协议文档 | Issue 5.1, 5.3 | 在 optics 实现中靠隐式位置约定或 layer-index special case 拍板 |
+| efficiency penalty 是否对 L=5 也为 0 | 必须做成 configurable default，并在文档中记录 | Issue 5.1, 5.5 | 在 loss 代码里静态宣布 L=5 gamma 已被论文唯一确定 |
+| phase mapping 使用 `[0, 2π)` 还是 `[-π, π]` | 允许实现 configurable mapping | Issue 5.1, 5.4 | 把某个 mapping 写成论文唯一明确事实 |
+| σ 的归一化按逐样本还是逐 batch | 必须在 loss 实现与 protocol freeze 中明确 | Issue 5.1, 5.5 | 在训练代码里默认拍板且不记录 |
+| output FOV / full-grid crop 对齐是否有额外 margin | 必须在 eval / config 中显式记录 | Issue 5.1, 5.3, 5.7 | 在 eval 里悄悄改 crop 口径 |
 
 这些条目必须被写入 Stage 5 protocol freeze 文档，不能隐性处理。
 
@@ -193,25 +200,38 @@ Stage 5 的任务不是做系统化消融，而是把论文主设定（数据、
 - **Stage 5D — Encoder 对齐**：实现 paper-aligned phase-only encoder。
 - **Stage 5E — 损失函数对齐**：normalized MAE + efficiency penalty 可配置化。
 - **Stage 5F — 训练骨架对齐**：Stage 5 trainer + configs，支持长训与 resume。
-- **Stage 5G — 评估协议对齐**：PSNR/SSIM + bicubic baseline + line-pair test。
-- **Stage 5H — paper-aligned smoke**：短跑验证 pipeline 稳定。
-- **Stage 5I — paper-aligned main run**：主线训练与评估结果记录。
-- **Stage 5J — 文档收口**：更新执行日志、结果摘要，给出 Stage 6 入口结论。
+- **Stage 5G — 常规评估协议对齐**：PSNR/SSIM + bicubic baseline。
+- **Stage 5H — blind line-pair 协议对齐**：line-pair / resolution target 生成与评估挂接。
+- **Stage 5I — paper-aligned smoke**：短跑验证 pipeline 稳定。
+- **Stage 5J — paper-aligned main run**：主线训练与评估结果记录。
+- **Stage 5K — 文档收口**：更新执行日志、结果摘要，给出 Stage 6 入口结论。
 
 ---
 
 # 9. Stage 5 验收标准
 
-Stage 5 至少需要满足以下可验证标准：
+## 9.1 最小工程完成标准
 
 1. 96×96 display 数据集可稳定生成，预览样本可解释。
 2. paper-aligned optics config 能在 L=1/3/5 下 forward 成功且 shape 正确。
 3. paper-aligned loss / efficiency term 可开关，并在 config 中可追溯。
 4. paper-aligned trainer 可完成 smoke 训练且无 NaN/Inf。
-5. 至少完成一次 paper-aligned 主线训练（建议 L=5 phase-only）。
-6. PSNR/SSIM 与 bicubic baseline 结果可复盘、可对比。
-7. blind line-pair 测试可生成并在 eval 中复用。
+5. 常规 eval runner 可输出 PSNR / SSIM，并可复用 bicubic baseline。
+6. blind line-pair 测试可独立生成并挂接到 eval 路径。
+7. main-run config、启动命令和工件协议已定义清楚，可作为 launch-ready recipe 使用。
 8. 所有关键假设已在 protocol freeze 与 summary 中明确记录。
+
+## 9.2 更强的复现完成标准（资源允许时）
+
+1. 至少完成一次 paper-aligned 主线训练（建议 L=5 phase-only）。
+2. main run 的 val/test 结果可以与 bicubic baseline 和 blind line-pair 测试一起复盘。
+3. main run 中所有资源相关妥协都被显式记录，而不是隐含在代码里。
+
+## 9.3 对 Prompt 的含义
+
+- 后续给 Codex 的 implementation prompt 应优先对齐 `9.1 最小工程完成标准`。
+- `9.2` 属于更强证据目标，不能反向逼迫前置 issue 提前扩张成“大而全框架”。
+- 若主线训练受算力或时间预算限制，报告必须把“代码/配置已就绪”和“长训尚未跑完”明确分开记录。
 
 ---
 
@@ -241,4 +261,14 @@ Stage 5 至少需要满足以下可验证标准：
 
 # 12. Stage 6 入口条件（简述）
 
-只有当 Stage 5 完成 **paper-aligned pipeline + 至少一次主线训练**，并明确记录所有假设后，才进入 Stage 6 的系统化消融与扩展实验。
+进入 Stage 6 前，至少需要满足：
+
+1. `9.1 最小工程完成标准` 已全部满足。
+2. 已有至少一次 paper-aligned 主线训练被实际启动并形成可复盘记录。
+3. 若主线训练尚未达到理想预算，也必须把资源限制、当前结果和阻塞点写清楚。
+
+换句话说，Stage 6 的前提不是“Stage 5 所有长训都已经完美跑满”，而是：
+
+- paper-aligned pipeline 已落地
+- 主线运行路径已被真实执行过
+- 后续系统化实验有可信起点可继承

--- a/docs/plan/stage_plan/stage5/stage5_protocol_freeze.md
+++ b/docs/plan/stage_plan/stage5/stage5_protocol_freeze.md
@@ -1,0 +1,336 @@
+# Stage 5 Protocol Freeze
+
+## 1. 文档目的
+
+本文档用于冻结 Stage 5（论文设定对齐）的实现边界，约束后续实现 issue 不再在以下问题上漂移：
+
+- Stage 5 到底要对齐什么
+- Stage 5 明确不包含什么
+- Stage 3 / Stage 4 哪些事实已经继承且不得重写
+- 当前 Stage 5 采用哪些 paper-aligned 默认值
+- 哪些参数仍未完全拍板
+- 每个未决项只能由哪个后续 issue 最终拍板
+
+本文档直接约束以下 issue 家族：
+
+- 5.2 dataset
+- 5.3 optics config
+- 5.4 encoder
+- 5.5 loss
+- 5.6 trainer
+- 5.7 regular eval
+- 5.8 blind eval hook
+- 5.9 smoke run
+- 5.10 main run
+
+范围冲突处理规则：
+
+- 当 `docs/paper/paper_notes.md` 记录的是更宽的复现路线，而 `docs/plan/stage_plan/stage5/stage5_plan.md` / `docs/plan/stage_plan/stage5/stage5_issue_plan.md` 记录的是当前 Stage 5 排期时，以 Stage 5 planning docs 为准。
+- 当后续实现 issue 需要为未决项做最终拍板时，必须遵守本文档的 owner 约束；不允许在代码里静默拍板。
+
+---
+
+## 2. Stage 5 范围边界
+
+### 2.1 In scope
+
+Stage 5 的目标是把论文主线设定落地为可运行、可审计、可复盘的工程协议，具体包括：
+
+- 96×96 EMNIST display 数据协议
+- paper-aligned optics geometry 与 distance schedule
+- phase-only encoder 到 `phi_lr` 的主线实现
+- normalized MAE + efficiency term 的主线 loss
+- paper-aligned training hyperparameters 与 configs
+- PSNR / SSIM、bicubic baseline、blind line-pair test 的评估挂接
+- paper-aligned smoke / main run 的启动路径与工件协议
+
+### 2.2 Out of scope
+
+以下内容明确不属于 Stage 5，仍归 Stage 6：
+
+- quantization sweep
+- misalignment / robustness
+- systematic `L=1/3/5` ablations
+- complex-valued / amplitude-only comparisons
+- efficiency penalty 的系统化 ablation
+- 大规模调参矩阵或广义框架重构
+
+### 2.3 Stage 5 的一句话边界
+
+Stage 5 是本仓库第一次对齐论文完整主设定的阶段；它要建立 launch-ready 的 paper-aligned pipeline，而不是提前吞进 Stage 6 的系统化实验工作。
+
+---
+
+## 3. 继承且冻结的事实
+
+以下内容从 Stage 3 / Stage 4 继承，在 Stage 5 中视为冻结约束：
+
+1. 冻结 optical contract：
+
+```text
+phi_lr -> U0 -> U_out_full -> I_out_full -> I_out_roi
+```
+
+2. Stage 4 learnability gate 已通过。
+3. Stage 4 artifacts 是 regression baseline，不是 Stage 5 要重做的工作。
+4. Stage 5 必须在现有 optical core 之上对齐论文设定，而不是借机重写 optical core。
+5. `phi_lr -> U0` 仍由 optical decoder 负责；encoder / wrapper 只负责产出 phase-domain `phi_lr`。
+6. `U_out_full` 与 `I_out_full` 继续保留为调试工件；主监督 / 主评估读出仍是 `I_out_roi`。
+7. Stage 5 需要支持 `L ∈ {1, 3, 5}` 的 paper-aligned config，但不把系统化深度对比挪到本阶段。
+
+明确禁止：
+
+- 重定义 optical tensor contract
+- 在 optical decoder 后追加 electrical post-head 作为 Stage 5 主线
+- 以“为了 paper alignment”为理由重写 Stage 4 已通过的 learnability 结论
+
+---
+
+## 4. Paper-Aligned 目标协议
+
+本节给出 Stage 5 默认采用的 paper-aligned 目标协议。若某项仍有论文歧义，则冻结“当前默认处理 + 后续 owner”，而不是伪装成已完全确定事实。
+
+### 4.1 Dataset protocol
+
+- 数据源：EMNIST letters
+- 原始样本：`28×28`
+- 预处理：bicubic 插值到 `32×32`
+- display 目标：构造 `96×96` 图像
+- 数据量目标：train `60,000` / val `6,000` / test `6,000`
+- 内容分布目标：
+  - train / val：每张图含 `1~4` 个 letters
+  - test：每张图含 `6~9` 个 letters
+- 增强目标：
+  - rotations：`0 / 90 / 180 / 270`
+  - random flip
+  - random contrast adjustment
+
+冻结说明：
+
+- Stage 5 dataset path 只服务论文主线 display protocol，不引入自然图像数据或 Stage 6 robustness 扰动。
+- `96×96` display 的精确 tile 规则仍有实现层面的未决细节，见第 5 节 ledger。
+
+### 4.2 Optics geometry targets
+
+- sampling period：`0.533 λ`
+- diffractive layer size：`200×200`
+- propagation grid：`400×400`（zero padding）
+- input / output FOV target：`96×96`
+- depth：`L = 1 / 3 / 5`
+- 初始化：diffractive phase masks 全零
+
+当前 Stage 5 默认 distance mapping 采用：
+
+- `input_to_first = d1`
+- `inter_layer = d2`，在所有相邻 diffractive layers 之间重复
+- `last_to_sensor = d3`
+
+按此默认可写为：
+
+- `L=1`：
+  - `input_to_first = 6.667 λ`
+  - `last_to_sensor = 173.333 λ`
+- `L=3`：
+  - `input_to_first = 4 λ`
+  - `inter_layer = 53.334 λ`
+  - `last_to_sensor = 53.334 λ`
+- `L=5`：
+  - `input_to_first = 2.667 λ`
+  - `inter_layer = 66.667 λ`
+  - `last_to_sensor = 80 λ`
+
+冻结说明：
+
+- 这是 Stage 5 当前默认映射，不等价于“论文已无歧义地给出了代码级 distance list”。
+- 5.3 可以把该映射最终落实为 config 字段或显式距离列表，但不得在 optics core 中静默藏规则。
+
+### 4.3 Encoder / phase representation target
+
+- 上游输入：单通道 `96×96` HR target image
+- encoder 输出：phase-only `phi_lr`
+- `phi_lr` 继续遵守已有 optical contract，不改为 field-domain tensor
+- optical decoder 继续负责 `phi_lr -> U0`
+- 相位范围映射必须显式存在于 encoder / wrapper，而不是隐式藏在 optics core
+
+当前 Stage 5 默认：
+
+- `phi_lr` 目标空间尺寸先按 `32×32` 处理
+- `phase_range` 默认按 `[0, 2π)` 处理
+
+冻结说明：
+
+- 上述两项都是 Stage 5 当前默认，不是“论文唯一明确事实”。
+- 5.4 可以最终拍板 encoder 暴露的 `phi_lr` 尺寸和 phase mapping range，但在拍板前必须保持可配置。
+
+### 4.4 Loss / gamma policy
+
+Stage 5 目标 loss 为论文主线：
+
+\[
+\mathcal L = \frac{1}{N}\sum_i |y_i - \sigma \hat y_i| + \gamma e^{-\eta}
+\]
+
+其中：
+
+\[
+\sigma = \frac{\sum_i y_i}{\sum_i \hat y_i + \epsilon}
+\]
+
+\[
+\eta = 100 \times \frac{P_o}{P_i}
+\]
+
+冻结要求：
+
+- 主监督对象仍为 `I_out_roi`
+- `sigma` 与 `eta` 的计算口径必须显式记录
+- `gamma` 必须按 depth 可配置，不能硬编码为不可追踪常数
+
+当前 Stage 5 默认 gamma policy：
+
+- `L=1`: `gamma = 0.005`
+- `L=3`: `gamma = 0.015`
+- `L=5`: `gamma = 0.0`（暂定默认，非最终定论）
+
+当前 Stage 5 默认 sigma policy：
+
+- 先按单样本 ROI 计算 `sigma`
+- 再在 batch 维聚合 loss
+
+冻结说明：
+
+- 5.5 可以最终拍板 `L=5 gamma` 和 `sigma` granularity。
+- 在 5.5 之前，trainer / smoke / main run 只能消费这些默认值，不能自行改写 loss 语义。
+
+### 4.5 Training hyperparameter targets
+
+- optimizer：Adam
+- decoder LR：`0.001`
+- encoder LR：`0.0005`
+- batch size：`40`
+- epoch target：`500`
+- 训练实现必须支持 encoder / decoder parameter groups
+
+冻结说明：
+
+- 这些是 Stage 5 的 main-run target，不等价于每个 smoke run 都必须跑满 `500 epochs`。
+- 5.9 可以为了 smoke 把训练预算降到短跑版本，但必须显式标为 smoke config，不能伪装成 paper-aligned full-budget run。
+
+### 4.6 Eval target protocol
+
+- 常规指标：PSNR / SSIM
+- baseline：bicubic，且需 anti-aliasing
+- blind eval：line-pair / resolution target
+- train / val / test 口径必须与 dataset protocol 对齐
+- 输出 crop / normalization 口径必须显式记录
+
+冻结说明：
+
+- 5.7 负责 regular eval + bicubic baseline
+- 5.8 负责 blind line-pair hook
+- eval 路径不得反向修改 optics crop 语义；crop/FOV 对齐由第 5 节 ledger 约束
+
+---
+
+## 5. Unresolved Parameters Ledger
+
+下表冻结的是“当前默认处理 + owner issue + 不允许偷拍板的 issue”。
+
+| 未决项 | 当前 Stage 5 默认处理 | 仍未知的点 | 允许最终拍板的 issue | 必须不得静默拍板的 issue | 配置要求 |
+| --- | --- | --- | --- | --- | --- |
+| `phi_lr` size | 默认按 `32×32`；encoder 输出尺寸与 optics `input_pattern_hw` 必须一致 | 论文是否足以把 `32×32` 视为唯一代码级尺寸；是否需要额外显式说明与 `3×` SR 的关系 | `5.4` | `5.2`, `5.5`, `5.6`, `5.7`, `5.8`, `5.9`, `5.10` | 在 `5.4` 前必须保持可配置 |
+| `96×96` display tiling rule | 默认按 `3×3` 个 `32×32` cells 构造，occupied cell 数量遵守 train/val/test 分布；样本预览必须落地 | cell 采样、空位策略、是否允许重复字母、随机种子与布局是否固定 | `5.2` | `5.4`, `5.5`, `5.6`, `5.7`, `5.8`, `5.9`, `5.10` | tile 规则、seed、split 口径必须进 config / preview |
+| distance mapping 到 `input_to_first / inter_layer / last_to_sensor` | 默认按 `d1 / d2 / d3` 对应；`d2` 在多层间重复；`L=1` 无 `inter_layer` | 论文记号是否无歧义地支持该重复规则；是否需要 depth-specific distance list 表达 | `5.3` | `5.4`, `5.5`, `5.6`, `5.7`, `5.8`, `5.9`, `5.10` | 必须显式进 optics config，不得埋在实现分支里 |
+| `L=5` gamma policy | 当前默认 `gamma = 0.0`，并要求 `gamma_by_depth` 可配置 | 论文“其它设计 γ=0”是否应直接覆盖 `L=5` 主线 run | `5.5` | `5.6`, `5.7`, `5.8`, `5.9`, `5.10` | `gamma_by_depth` 必须可配置并写入 summary |
+| phase mapping range | 当前默认 `[0, 2π)`；映射在 encoder / wrapper 内完成 | `[0, 2π)` 与 `[-π, π]` 哪个更接近论文 / 器件语义 | `5.4` | `5.3`, `5.5`, `5.6`, `5.9`, `5.10` | 必须保留显式 `phase_range` 配置 |
+| sigma normalization granularity | 当前默认“逐样本 ROI 求 `sigma`，再 batch 聚合” | 论文公式在 mini-batch 实现中是否应按逐 batch 或逐样本解释 | `5.5` | `5.6`, `5.7`, `5.8`, `5.9`, `5.10` | 必须保留显式 `sigma_mode` 或等价记录字段 |
+| output crop / FOV alignment details | 当前默认延续 Stage 3/4 center-crop 语义；目标 crop 为 `96×96`，无额外 margin | full `400×400` grid 到 `96×96` FOV 的精确对齐、像素中心、offset / margin 是否需要更严格说明 | `5.3` | `5.6`, `5.7`, `5.8`, `5.9`, `5.10` | crop size、origin、offset 必须显式记录 |
+
+Ledger 约束：
+
+- owner issue 若要把默认值改成最终值，必须在其交付物中显式记录“相对本文档默认的变化”。
+- 非 owner issue 只能消费当前默认或配置项，不能用代码行为偷拍板。
+- 5.9 / 5.10 只能验证冻结后的协议，不是拍板协议的地方。
+
+---
+
+## 6. 对后续 Issue 家族的约束
+
+### 6.1 Dataset（5.2）
+
+- 可以最终拍板：`96×96` tiling rule、split 生成细则、augmentation 参数暴露方式
+- 必须保持：样本预览、split 口径、随机种子可追踪
+- 不得触碰：optics geometry、phase mapping、loss 语义、eval crop
+
+### 6.2 Optics config（5.3）
+
+- 可以最终拍板：distance mapping、paper-aligned grid/padding、output crop / FOV alignment 细节
+- 必须保持：冻结 optical contract 不变；no optical-core redesign
+- 不得触碰：dataset tile 规则、encoder 内部结构、loss 公式含义
+
+### 6.3 Encoder（5.4）
+
+- 可以最终拍板：`phi_lr` 暴露尺寸、phase mapping range
+- 必须保持：输出对象仍是 phase-domain `phi_lr`；`phi_lr -> U0` 仍在 optical decoder
+- 不得触碰：distance mapping、loss 公式、eval 口径
+
+### 6.4 Loss（5.5）
+
+- 可以最终拍板：`L=5 gamma`、`sigma` granularity、efficiency-term 配置接口
+- 必须保持：gamma 按 depth 可配置；loss 行为可追踪
+- 不得触碰：dataset 构造、optics crop 几何、trainer 的 smoke/main 预算策略
+
+### 6.5 Trainer（5.6）
+
+- 必须消费已冻结 dataset / optics / encoder / loss config
+- 可以新增：resume、artifact 保存、paper-aligned config 入口
+- 不得拍板：tiling、distance mapping、phase range、gamma policy、sigma granularity、crop 语义
+
+### 6.6 Eval（5.7 / 5.8）
+
+- 5.7 只负责 regular eval + bicubic baseline
+- 5.8 只负责 blind line-pair hook
+- 二者都必须复用已冻结 crop / normalization 口径
+- 不得反向修改：dataset split、optics geometry、loss 默认值
+
+### 6.7 Smoke / main run（5.9 / 5.10）
+
+- 5.9 只验证 pipeline 稳定性与工件完整性，可使用缩短预算，但必须显式标记为 smoke
+- 5.10 负责 paper-aligned main-run 启动与结果记录
+- 二者都不得作为协议拍板入口；若发现协议错误，只能回写文档/issue 再修正，不得靠 run 脚本悄悄改默认
+
+---
+
+## 7. Acceptance / Exit Criteria
+
+### 7.1 Stage 5 engineering-complete 的最低标准
+
+在工程层面，Stage 5 视为完成至少需要同时满足：
+
+1. `stage5_protocol_freeze.md` 已存在，且未决项 owner 明确。
+2. paper-aligned dataset path 已落地，并有可复盘的 preview / split 记录。
+3. `L=1/3/5` 的 paper-aligned optics configs 已落地，forward sanity 可通过。
+4. paper-aligned encoder、loss、trainer、regular eval、blind eval hook 已落地。
+5. 关键未决项在 owner issue 拍板前都保持可配置并被日志记录。
+6. 至少一次 paper-aligned smoke run 已完成，且工件完整。
+7. main-run recipe 已清楚：config、命令、工件路径、评估入口都可审计。
+
+### 7.2 更强但资源相关的证据
+
+以下属于更强证据，但受算力 / 时间预算影响，不是前置工程完成门槛：
+
+- 一次真实启动并有结果记录的 paper-aligned `L=5` main run
+- val / test 上可复盘的 PSNR / SSIM
+- blind line-pair 结果与 bicubic baseline 的对照记录
+- 明确区分“代码 / 配置已就绪”与“长训预算是否跑满”
+
+### 7.3 Stage 6 入口边界
+
+只有当 Stage 5 已具备可信的 paper-aligned launch path 之后，以下工作才允许进入 Stage 6：
+
+- quantization sweep
+- misalignment / robustness
+- systematic `L=1/3/5` ablations
+- complex-valued / amplitude-only comparisons
+
+在此之前，不允许以后续实验名义反向修改本文档定义的 Stage 5 边界。


### PR DESCRIPTION
why:
avoid drift before later stage5 implementation issues and make the paper-aligned scope explicit after the stage4 learnability gate

what:
add a stage5 protocol freeze document covering inherited optical contracts, paper-aligned defaults, stage5 vs stage6 boundaries, and an unresolved-parameter ledger with owner mapping for follow-up issues