### PR TITLE
feat(data | stage5-2): add paper-aligned emnist display dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# sdn-for-super-resolution-reproduction
+﻿# sdn-for-super-resolution-reproduction
 
-​	This repository is a reproduction for paper "Super-resolution image display using diffractive decoders".
+This repository is a reproduction for the paper "Super-resolution image display using diffractive decoders".
 
-​	This project use a universal used file structure.
+This project uses a universal file structure.
 
-​	The developer use codex to assist in development.
+The developer uses Codex to assist development.
 
 ## environment config
 
 ## orders for running
 
-More order see docs/run_order.md. Here are some frequently used orders.
+More orders are listed in docs/run_order.md. Here are some frequently used commands.
 
 - Validate Stage 3 Issue 3 optical readout/crop:
   `python scripts/check_optical_readout.py`
@@ -22,4 +22,5 @@ More order see docs/run_order.md. Here are some frequently used orders.
   `python scripts/train_decoder_only_small_subset.py --depth 3 --subset-size 4 --steps 80`
 - Run Stage 3 Issue 6 fixed-protocol depth sweep for L=1/3/5:
   `python scripts/train_decoder_only_small_subset_sweep.py --depths 1 3 5 --subset-size 4 --steps 80`
-
+- Preview the Stage 5 Issue 5.2 EMNIST 96x96 display dataset:
+  `python scripts/preview_stage5_emnist_display.py --config docs/plan/stage_plan/stage5/stage5_emnist_display_config.yaml`

--- a/configs/stage5/stage5_emnist_display.yaml
+++ b/configs/stage5/stage5_emnist_display.yaml
@@ -1,0 +1,52 @@
+data:
+  stage5_display:
+    # Finalized Issue 5.2 tiling rule:
+    # - fixed 96x96 canvas
+    # - fixed 3x3 grid of non-overlapping 32x32 cells
+    # - exactly one resized EMNIST letter per occupied cell
+    dataset_root: data/raw/emnist
+    emnist_split: letters
+    seed: 2026
+    canvas_hw: [96, 96]
+    cell_hw: [32, 32]
+    grid_shape: [3, 3]
+    fix_emnist_orientation: true
+
+    sample_counts:
+      train: 60000
+      val: 6000
+      test: 6000
+
+    letter_count_choices:
+      train: [1, 2, 3, 4]
+      val: [1, 2, 3, 4]
+      test: [6, 7, 8, 9]
+
+    augmentation:
+      train:
+        enable_rotation: true
+        rotation_choices: [0, 90, 180, 270]
+        enable_flip: true
+        flip_modes: [horizontal, vertical]
+        enable_contrast: true
+        contrast_range: [0.8, 1.2]
+      val:
+        enable_rotation: false
+        rotation_choices: [0]
+        enable_flip: false
+        flip_modes: []
+        enable_contrast: false
+        contrast_range: [1.0, 1.0]
+      test:
+        enable_rotation: false
+        rotation_choices: [0]
+        enable_flip: false
+        flip_modes: []
+        enable_contrast: false
+        contrast_range: [1.0, 1.0]
+
+    preview:
+      output_root: outputs/stage5/dataset_preview
+      preview_count: 8
+      grid_cols: 4
+      seed_offset: 17

--- a/docs/ai/CodexFeedback/stage5/feedback_stage5-2.md
+++ b/docs/ai/CodexFeedback/stage5/feedback_stage5-2.md
@@ -1,0 +1,44 @@
+实现了一个可复现的 Stage 5 EMNIST `96x96` display 数据路径：新增了确定性合成数据集、一个小型 preview 脚本、Stage 5 数据配置示例，并实际生成了 train/val/test 的审计工件。这个 issue 只落在数据协议范围，没有触碰 optics、encoder、loss、trainer 或 eval 逻辑。
+
+精确变更文件：
+- [src/datasets/stage5_emnist_display.py](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/src/datasets/stage5_emnist_display.py)
+- [src/datasets/__init__.py](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/src/datasets/__init__.py)
+- [scripts/preview_stage5_emnist_display.py](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/scripts/preview_stage5_emnist_display.py)
+- [docs/plan/stage_plan/stage5/stage5_emnist_display_config.yaml](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/docs/plan/stage_plan/stage5/stage5_emnist_display_config.yaml)
+- [README.md](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/README.md)
+
+最终拍板的 `96x96` tiling rule：
+- `96x96` display 固定为 `3x3` 个非重叠 `32x32` cells。
+- 每个 occupied cell 恰好放 1 个由 EMNIST `28x28 -> 32x32` bicubic resize 得到的 letter。
+- 同一张合成图里 occupied cells 从 9 个 cell 中无放回采样。
+- letter 之间不重叠，empty cells 保持为 0。
+- train/val 的 letter count 从 `{1,2,3,4}` 采样；test 从 `{6,7,8,9}` 采样。
+- 当前实现显式修正了 EMNIST 常见的朝向问题，预览中是 upright letters。
+
+split 生成和随机性控制：
+- train/val 组合样本使用 EMNIST `letters` 的 train partition；test 使用 EMNIST `letters` 的 test partition。
+- 样本量固定为 train `60000` / val `6000` / test `6000`。
+- 每个 composite sample 都由稳定 seed 函数基于 `(base_seed, split, dataset_index)` 单独生成，所以访问顺序无关、同 seed 下可重现。
+- preview 采样使用单独的 deterministic preview seed offset，不会改动数据集本身的生成规则。
+- augmentation 只暴露 Stage 5 范围内的 rotation / flip / contrast；train 默认开启，val/test 默认关闭。
+
+生成的 preview artifacts：
+- [train preview](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/dataset_preview/train/preview_grid.png)
+- [train summary](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/dataset_preview/train/summary.json)
+- [val preview](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/dataset_preview/val/preview_grid.png)
+- [val summary](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/dataset_preview/val/summary.json)
+- [test preview](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/dataset_preview/test/preview_grid.png)
+- [test summary](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/dataset_preview/test/summary.json)
+
+有意留给后续 issue 的未决项：
+- optics geometry 和 distance mapping，仍归 `5.3`
+- phase mapping range，仍归 `5.4`
+- gamma policy 和 sigma normalization，仍归 `5.5`
+- output crop / FOV alignment，仍归 `5.3` / `5.7`
+
+验证已执行：
+- `python -m py_compile src/datasets/stage5_emnist_display.py scripts/preview_stage5_emnist_display.py`
+- `python scripts/preview_stage5_emnist_display.py --config docs/plan/stage_plan/stage5/stage5_emnist_display_config.yaml --splits train val test --preview-count 4`
+
+补充说明：
+- 这个环境当前拒绝向 `configs/` 子树写入新文件，所以配置示例放在了 Stage 5 文档目录下，并由 preview 脚本直接读取。

--- a/docs/ai/prompt/stage5/prompt_stage5-2.md
+++ b/docs/ai/prompt/stage5/prompt_stage5-2.md
@@ -1,0 +1,187 @@
+You are working in a research-engineering repository for reproducing
+"Super-resolution image display using diffractive decoders".
+
+Your task is to complete GitHub Issue 5.2:
+
+Issue title:
+Build paper-aligned 96x96 EMNIST display dataset with augmentation
+
+This is a Stage-5-scoped data-protocol task.
+Do not write optics code, encoder code, loss code, trainer code, or evaluation code in this issue.
+
+==================================================
+0. MUST-READ CONTEXT FIRST
+==================================================
+
+Before doing anything, you MUST read and follow these files in order:
+
+1. `AGENTS.md`
+2. `docs/ai/PROJECT_CONTEXT.md`
+3. `docs/paper/paper_notes.md`
+4. `docs/plan/stage_plan/stage5/stage5_protocol_freeze.md`
+5. `docs/plan/stage_plan/stage5/stage5_plan.md`
+6. `docs/plan/stage_plan/stage5/stage5_issue_plan.md`
+
+You may inspect current Stage 4 dataset / trainer code only as implementation reference.
+Do not treat Stage 4 data protocol as the target to preserve. It is only a baseline reference.
+
+Important scope rule:
+- If `paper_notes.md` is broader than the Stage 5 schedule, follow the Stage 5 docs.
+- For unresolved items, respect the ownership defined in `stage5_protocol_freeze.md`.
+
+==================================================
+1. ISSUE 5.2 GOAL
+==================================================
+
+Implement the paper-aligned EMNIST display dataset path for Stage 5.
+
+The result should provide a reproducible dataset pipeline that:
+
+1. starts from EMNIST letters
+2. resizes 28x28 letters to 32x32
+3. composes 96x96 display samples
+4. enforces the train / val / test sample-count protocol
+5. enforces the train/val vs test letter-count distribution
+6. exposes augmentation options consistent with the paper
+7. saves enough preview artifacts to audit the protocol
+
+==================================================
+2. NON-GOALS — DO NOT DRIFT
+==================================================
+
+Do NOT do any of the following:
+
+- do not implement optics configs
+- do not implement encoder / loss / trainer / eval code
+- do not introduce natural-image datasets
+- do not redesign Stage 4 data code unless a tiny shared helper is strictly justified
+- do not add Stage 6 quantization / robustness / ablation logic
+- do not silently bury tiling rules or split logic inside code without logging/config
+
+This issue is successful only if it cleanly freezes and implements the Stage 5 data protocol.
+
+==================================================
+3. BRANCH EXPECTATION
+==================================================
+
+Suggested branch:
+- `feat/data`
+
+Stay on a data-oriented branch.
+Do not use this issue to modify `feat/optics`, `feat/model`, or `feat/train`.
+
+==================================================
+4. REQUIRED INHERITANCE
+==================================================
+
+From `stage5_protocol_freeze.md`, this issue must inherit and obey:
+
+1. Stage 5 is the first paper-aligned stage.
+2. Stage 4 artifacts are regression baseline only.
+3. The optical contract remains frozen, but this issue must not touch it.
+4. The `96x96` display tiling rule is owned by Issue 5.2 and may be finalized here.
+5. Other unresolved items such as distance mapping, phase range, gamma policy, and crop alignment are NOT owned by this issue and must not be finalized here.
+
+==================================================
+5. WHAT YOU ARE ALLOWED TO FINALIZE HERE
+==================================================
+
+This issue MAY finalize:
+
+1. the exact 96x96 tiling rule
+2. how many 32x32 cells are used and how they are occupied
+3. how train/val/test letter-count distributions are instantiated
+4. how dataset seeds / randomness are controlled
+5. how augmentation options are exposed in config
+
+This issue MUST keep the following out of scope:
+
+1. optics geometry
+2. phase mapping
+3. gamma policy
+4. sigma normalization policy
+5. output crop / FOV alignment
+
+==================================================
+6. IMPLEMENTATION REQUIREMENTS
+==================================================
+
+Implement a Stage 5 dataset module and the minimum surrounding support needed to inspect it.
+
+The implementation should likely include:
+
+- a dataset module under `src/data/` or the repo's current equivalent
+- config entries for:
+  - dataset root
+  - split
+  - sample count
+  - letter-count distribution
+  - RNG seed
+  - augmentation toggles
+- a preview / sanity path to save generated samples
+
+Prefer a deterministic and auditable design:
+
+- same seed -> same split / same sample generation behavior
+- protocol choices visible in config snapshot or summary
+- preview artifacts easy to inspect manually
+
+==================================================
+7. REQUIRED ARTIFACTS
+==================================================
+
+You must produce enough artifacts to verify that the dataset protocol is real and inspectable.
+
+At minimum, provide:
+
+- a config example or config section for Stage 5 dataset construction
+- a small preview artifact showing generated 96x96 samples
+- a concise summary of:
+  - split sizes
+  - train/val letter-count range
+  - test letter-count range
+  - seed / randomization policy
+  - augmentation policy
+
+If the repo already has a preferred place for saved previews or summaries, follow it.
+Do not build a heavy dataset visualization framework.
+
+==================================================
+8. FILE SCOPE
+==================================================
+
+Primary files likely to be changed or added:
+
+- dataset code under `src/data/`
+- Stage 5 dataset config under `configs/`
+- a small preview / sanity script under `scripts/` only if strictly needed
+- a brief execution or design note only if needed to explain finalized tiling rules
+
+Avoid unrelated edits.
+Do not refactor the entire data layer.
+
+==================================================
+9. ACCEPTANCE CRITERIA
+==================================================
+
+Issue 5.2 is complete only if:
+
+1. A real Stage 5 dataset path exists for EMNIST -> 96x96 display samples
+2. Train / val / test protocol is explicit and reproducible
+3. The finalized tiling rule is visible in code/config and not hidden
+4. Preview artifacts make the generated protocol auditable
+5. Augmentation options are exposed and limited to the Stage 5 paper-aligned scope
+6. No non-owned unresolved item is silently finalized here
+
+==================================================
+10. FINAL RESPONSE FORMAT
+==================================================
+
+After finishing, respond with:
+
+- short summary of what was implemented
+- exact files changed
+- the finalized 96x96 tiling rule
+- how split generation and randomness are controlled
+- what preview artifacts were produced
+- what was intentionally left unresolved for later issues

--- a/docs/gitflow/gitflow.md
+++ b/docs/gitflow/gitflow.md
@@ -4,7 +4,7 @@
 
 ```
 main        稳定版本
-develop     日常开发主分支
+dev         日常开发主分支
 feature/*   功能开发
 fix/*       bug修复
 docs/*      文档更新
@@ -92,7 +92,7 @@ git switch -c feature/xxx
 切换分支：
 
 ```bash
-git switch develop
+git switch dev
 ```
 
 旧写法（仍可用）：
@@ -120,7 +120,7 @@ git branch -D feature/xxx
 ### 1 开发前更新代码
 
 ```bash
-git pull origin develop
+git pull origin dev
 ```
 
 ------
@@ -128,8 +128,8 @@ git pull origin develop
 ### 2 新建功能分支
 
 ```bash
-git switch develop
-git pull origin develop
+git switch dev
+git pull origin dev
 git switch -c feature/xxx
 ```
 
@@ -173,15 +173,15 @@ git push -u origin feature/xxx
 
 ------
 
-# 五、更新分支（同步 develop）
+# 五、更新分支（同步 dev）
 
 开发过程中需要同步主分支：
 
 ```bash
-git switch develop
-git pull origin develop
+git switch dev
+git pull origin dev
 git switch feature/xxx
-git merge develop
+git merge dev
 ```
 
 如果出现冲突，解决后：
@@ -189,6 +189,52 @@ git merge develop
 ```bash
 git add .
 git commit
+```
+
+### 本仓库常用：从 `docs/update` 切到 `feat/data`，并合并最新 `origin/dev`
+
+如果当前分支上还有未提交改动，尤其包含未追踪文件或目录变动，先 stash，再切分支。这样可以避免在 Git Bash / MINGW 下切分支时出现目录删除失败或反复重试的问题。
+
+推荐流程：
+
+```bash
+git status --short
+git stash push -u -m "wip before switching to feat/data"
+
+git switch feat/data
+git fetch origin
+git merge origin/dev
+```
+
+说明：
+
+- `git stash push -u` 会同时暂存未追踪文件，适合切分支前清理工作区
+- `git fetch origin` 后直接 `git merge origin/dev`，表示把最新远程 `dev` 合并到当前 `feat/data`
+- 如果这个 stash 来自 `docs/update`，不要在 `feat/data` 上立刻 `git stash pop`，避免把文档分支的改动带到数据分支
+
+当你之后回到原分支再恢复暂存内容：
+
+```bash
+git switch docs/update
+git stash pop
+```
+
+如果只是想确认 stash 还在：
+
+```bash
+git stash list
+```
+
+如果你希望本地 `dev` 也保持同步，可以使用等价流程：
+
+```bash
+git stash push -u -m "wip before switching to feat/data"
+
+git switch dev
+git pull --ff-only origin dev
+
+git switch feat/data
+git merge dev
 ```
 
 ------
@@ -274,7 +320,7 @@ git reset --hard HEAD~1
 拉取远程更新：
 
 ```bash
-git pull origin develop
+git pull origin dev
 ```
 
 推送代码：
@@ -363,8 +409,8 @@ docs: update project structure
 完整开发流程：
 
 ```bash
-git switch develop
-git pull origin develop
+git switch dev
+git pull origin dev
 
 git switch -c feature/dataset-check
 
@@ -391,5 +437,3 @@ docs/experiment-log
 exp/ablation-loss
 exp/interpolation-test
 ```
-
-git ls-files --others --exclude-standard

--- a/docs/plan/stage_plan/stage5/stage5_emnist_display_config.yaml
+++ b/docs/plan/stage_plan/stage5/stage5_emnist_display_config.yaml
@@ -1,0 +1,52 @@
+﻿data:
+  stage5_display:
+    # Finalized Issue 5.2 tiling rule:
+    # - fixed 96x96 canvas
+    # - fixed 3x3 grid of non-overlapping 32x32 cells
+    # - exactly one resized EMNIST letter per occupied cell
+    dataset_root: data/raw/emnist
+    emnist_split: letters
+    seed: 2026
+    canvas_hw: [96, 96]
+    cell_hw: [32, 32]
+    grid_shape: [3, 3]
+    fix_emnist_orientation: true
+
+    sample_counts:
+      train: 60000
+      val: 6000
+      test: 6000
+
+    letter_count_choices:
+      train: [1, 2, 3, 4]
+      val: [1, 2, 3, 4]
+      test: [6, 7, 8, 9]
+
+    augmentation:
+      train:
+        enable_rotation: true
+        rotation_choices: [0, 90, 180, 270]
+        enable_flip: true
+        flip_modes: [horizontal, vertical]
+        enable_contrast: true
+        contrast_range: [0.8, 1.2]
+      val:
+        enable_rotation: false
+        rotation_choices: [0]
+        enable_flip: false
+        flip_modes: []
+        enable_contrast: false
+        contrast_range: [1.0, 1.0]
+      test:
+        enable_rotation: false
+        rotation_choices: [0]
+        enable_flip: false
+        flip_modes: []
+        enable_contrast: false
+        contrast_range: [1.0, 1.0]
+
+    preview:
+      output_root: outputs/stage5/dataset_preview
+      preview_count: 8
+      grid_cols: 4
+      seed_offset: 17

--- a/scripts/preview_stage5_emnist_display.py
+++ b/scripts/preview_stage5_emnist_display.py
@@ -1,0 +1,247 @@
+﻿#!/usr/bin/env python
+"""Preview the Stage 5 paper-aligned EMNIST 96x96 display dataset."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.datasets import Stage5EMNISTDisplayDataset
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate auditable preview artifacts for the Stage 5 EMNIST display dataset."
+    )
+    parser.add_argument(
+        "--config",
+        type=str,
+        default="docs/plan/stage_plan/stage5/stage5_emnist_display_config.yaml",
+    )
+    parser.add_argument(
+        "--splits",
+        nargs="+",
+        choices=("train", "val", "test"),
+        default=("train", "val", "test"),
+    )
+    parser.add_argument("--preview-count", type=int, default=None)
+    parser.add_argument("--output-root", type=str, default=None)
+    parser.add_argument("--download", action="store_true", default=False)
+    return parser.parse_args()
+
+
+def load_yaml_config(path: str) -> dict[str, Any]:
+    config_path = Path(path)
+    if not config_path.exists():
+        raise FileNotFoundError(f"Config file does not exist: {config_path}")
+
+    try:
+        import yaml  # type: ignore
+    except ImportError as exc:
+        raise RuntimeError("PyYAML is required to load the Stage 5 dataset config.") from exc
+
+    with config_path.open("r", encoding="utf-8") as file:
+        payload = yaml.safe_load(file) or {}
+    if not isinstance(payload, dict):
+        raise TypeError(f"Expected top-level config mapping, got {type(payload)!r}.")
+    return payload
+
+
+def get_nested(config: dict[str, Any], *keys: str, default: Any = None) -> Any:
+    current: Any = config
+    for key in keys:
+        if not isinstance(current, dict) or key not in current:
+            return default
+        current = current[key]
+    return current
+
+
+def resolve_stage5_dataset_section(config: dict[str, Any]) -> dict[str, Any]:
+    data_section = get_nested(config, "data", "stage5_display", default=None)
+    if not isinstance(data_section, dict):
+        raise KeyError("Expected config path data.stage5_display to be present.")
+    return data_section
+
+
+def pick_preview_indices(
+    dataset: Stage5EMNISTDisplayDataset,
+    *,
+    preview_count: int,
+    preview_seed: int,
+) -> list[int]:
+    if preview_count < 1:
+        raise ValueError(f"preview_count must be >= 1, got {preview_count}.")
+    preview_count = min(preview_count, len(dataset))
+    rng = np.random.default_rng(preview_seed)
+    chosen = rng.choice(len(dataset), size=preview_count, replace=False)
+    return sorted(int(index) for index in chosen.tolist())
+
+
+def save_preview_grid(
+    output_path: Path,
+    *,
+    dataset: Stage5EMNISTDisplayDataset,
+    indices: list[int],
+    grid_cols: int,
+) -> None:
+    if not indices:
+        raise ValueError("Need at least one preview index to save a grid.")
+    grid_cols = max(1, int(grid_cols))
+    grid_rows = int(np.ceil(len(indices) / grid_cols))
+
+    fig, axes = plt.subplots(
+        grid_rows,
+        grid_cols,
+        figsize=(3.4 * grid_cols, 3.6 * grid_rows),
+    )
+    axes_array = np.atleast_1d(axes).reshape(grid_rows, grid_cols)
+
+    for axis in axes_array.flat:
+        axis.axis("off")
+
+    for axis, dataset_index in zip(axes_array.flat, indices):
+        sample = dataset[dataset_index]
+        metadata = dataset.get_sample_metadata(dataset_index)
+        image = sample["x_hr"][0].detach().cpu().numpy()
+        axis.imshow(image, cmap="gray", vmin=0.0, vmax=1.0)
+        cell_text = ",".join(str(cell) for cell in metadata["occupied_cells"])
+        axis.set_title(
+            f"idx={dataset_index} count={metadata['letter_count']}\n"
+            f"cells=[{cell_text}]",
+            fontsize=9,
+        )
+        axis.axis("off")
+
+    fig.tight_layout()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output_path, dpi=180, bbox_inches="tight")
+    plt.close(fig)
+
+
+def build_dataset_from_config(
+    stage5_cfg: dict[str, Any],
+    *,
+    split: str,
+    download: bool,
+) -> Stage5EMNISTDisplayDataset:
+    sample_counts = stage5_cfg.get("sample_counts", {})
+    letter_count_choices = stage5_cfg.get("letter_count_choices", {})
+    augmentation = stage5_cfg.get("augmentation", {})
+
+    return Stage5EMNISTDisplayDataset(
+        split=split,
+        dataset_root=stage5_cfg.get("dataset_root"),
+        emnist_split=str(stage5_cfg.get("emnist_split", "letters")),
+        sample_count=sample_counts.get(split),
+        letter_count_choices=letter_count_choices.get(split),
+        seed=int(stage5_cfg.get("seed", 2026)),
+        canvas_hw=tuple(stage5_cfg.get("canvas_hw", (96, 96))),
+        cell_hw=tuple(stage5_cfg.get("cell_hw", (32, 32))),
+        grid_shape=tuple(stage5_cfg.get("grid_shape", (3, 3))),
+        augmentation=augmentation.get(split),
+        fix_emnist_orientation=bool(stage5_cfg.get("fix_emnist_orientation", True)),
+        download=download,
+    )
+
+
+def save_split_artifacts(
+    output_root: Path,
+    *,
+    dataset: Stage5EMNISTDisplayDataset,
+    preview_indices: list[int],
+    preview_seed: int,
+    grid_cols: int,
+) -> dict[str, Any]:
+    split_dir = output_root / dataset.split
+    split_dir.mkdir(parents=True, exist_ok=True)
+
+    preview_path = split_dir / "preview_grid.png"
+    save_preview_grid(
+        preview_path,
+        dataset=dataset,
+        indices=preview_indices,
+        grid_cols=grid_cols,
+    )
+
+    preview_samples = [dataset.get_sample_metadata(index) for index in preview_indices]
+    summary = dataset.get_protocol_summary()
+    summary.update(
+        {
+            "created_at_utc": datetime.now(timezone.utc).isoformat(),
+            "preview_seed": preview_seed,
+            "preview_indices": preview_indices,
+            "preview_grid": str(preview_path.resolve()),
+            "preview_samples": preview_samples,
+        }
+    )
+
+    summary_path = split_dir / "summary.json"
+    with summary_path.open("w", encoding="utf-8") as file:
+        json.dump(summary, file, indent=2, ensure_ascii=False)
+
+    return {
+        "split": dataset.split,
+        "summary_path": str(summary_path.resolve()),
+        "preview_path": str(preview_path.resolve()),
+    }
+
+
+def split_seed_offset(split: str) -> int:
+    return {"train": 0, "val": 1_003, "test": 2_003}[split]
+
+
+def main() -> None:
+    args = parse_args()
+    config = load_yaml_config(args.config)
+    stage5_cfg = resolve_stage5_dataset_section(config)
+    preview_cfg = stage5_cfg.get("preview", {})
+
+    preview_count = int(args.preview_count or preview_cfg.get("preview_count", 8))
+    grid_cols = int(preview_cfg.get("grid_cols", 4))
+    preview_seed_offset = int(preview_cfg.get("seed_offset", 17))
+    output_root = Path(args.output_root or preview_cfg.get("output_root", "outputs/stage5/dataset_preview"))
+
+    artifact_records: list[dict[str, Any]] = []
+    base_seed = int(stage5_cfg.get("seed", 2026))
+
+    for split in args.splits:
+        dataset = build_dataset_from_config(stage5_cfg, split=split, download=args.download)
+        preview_seed = base_seed + preview_seed_offset + split_seed_offset(split)
+        preview_indices = pick_preview_indices(
+            dataset,
+            preview_count=preview_count,
+            preview_seed=preview_seed,
+        )
+        artifact_records.append(
+            save_split_artifacts(
+                output_root,
+                dataset=dataset,
+                preview_indices=preview_indices,
+                preview_seed=preview_seed,
+                grid_cols=grid_cols,
+            )
+        )
+
+    print("Stage 5 dataset preview completed.")
+    for record in artifact_records:
+        print(f"{record['split']}: preview={record['preview_path']}")
+        print(f"{record['split']}: summary={record['summary_path']}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/datasets/__init__.py
+++ b/src/datasets/__init__.py
@@ -1,10 +1,21 @@
-"""Dataset helpers for the repo's staged reproduction workflow."""
+﻿"""Dataset helpers for the repo's staged reproduction workflow."""
 
 from src.datasets.stage4_emnist import (
     DEFAULT_STAGE4_DATASET_ROOT,
     Stage4EMNISTDataset,
     build_stage4_train_val_datasets,
     resolve_stage4_dataset_root,
+)
+from src.datasets.stage5_emnist_display import (
+    DEFAULT_STAGE5_CANVAS_HW,
+    DEFAULT_STAGE5_CELL_HW,
+    DEFAULT_STAGE5_DATASET_ROOT,
+    DEFAULT_STAGE5_GRID_SHAPE,
+    DEFAULT_STAGE5_LETTER_COUNT_CHOICES,
+    DEFAULT_STAGE5_SAMPLE_COUNTS,
+    Stage5AugmentationConfig,
+    Stage5EMNISTDisplayDataset,
+    build_stage5_emnist_display_dataset,
 )
 from src.datasets.target_adapter import (
     Stage4RoiTargetAdapter,
@@ -13,9 +24,18 @@ from src.datasets.target_adapter import (
 
 __all__ = [
     "DEFAULT_STAGE4_DATASET_ROOT",
+    "DEFAULT_STAGE5_CANVAS_HW",
+    "DEFAULT_STAGE5_CELL_HW",
+    "DEFAULT_STAGE5_DATASET_ROOT",
+    "DEFAULT_STAGE5_GRID_SHAPE",
+    "DEFAULT_STAGE5_LETTER_COUNT_CHOICES",
+    "DEFAULT_STAGE5_SAMPLE_COUNTS",
     "Stage4EMNISTDataset",
     "Stage4RoiTargetAdapter",
+    "Stage5AugmentationConfig",
+    "Stage5EMNISTDisplayDataset",
     "build_stage4_train_val_datasets",
+    "build_stage5_emnist_display_dataset",
     "resolve_stage4_dataset_root",
     "save_stage4_input_target_preview",
 ]

--- a/src/datasets/stage5_emnist_display.py
+++ b/src/datasets/stage5_emnist_display.py
@@ -1,0 +1,526 @@
+﻿"""Stage 5 paper-aligned EMNIST 96x96 display dataset.
+
+This module finalizes the Stage 5 data protocol choices owned by Issue 5.2:
+
+- source dataset: EMNIST letters
+- base letter size: 28x28, explicitly resized to 32x32
+- display canvas: fixed 96x96 image made of a 3x3 grid of non-overlapping
+  32x32 cells
+- train/val letter-count choices: 1, 2, 3, 4
+- test letter-count choices: 6, 7, 8, 9
+- deterministic generation: the same `(seed, split, index)` always produces
+  the same composite sample, independent of access order
+
+The module intentionally does not define optics, encoder, loss, trainer, or
+evaluation behavior.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+import torch
+from torch.utils.data import Dataset
+from torchvision.datasets import EMNIST
+from torchvision.transforms import InterpolationMode
+from torchvision.transforms import functional as TF
+
+from src.datasets.stage4_emnist import resolve_stage4_dataset_root
+
+
+DEFAULT_STAGE5_SAMPLE_COUNTS: dict[str, int] = {
+    "train": 60_000,
+    "val": 6_000,
+    "test": 6_000,
+}
+
+DEFAULT_STAGE5_LETTER_COUNT_CHOICES: dict[str, tuple[int, ...]] = {
+    "train": (1, 2, 3, 4),
+    "val": (1, 2, 3, 4),
+    "test": (6, 7, 8, 9),
+}
+
+DEFAULT_STAGE5_CANVAS_HW = (96, 96)
+DEFAULT_STAGE5_CELL_HW = (32, 32)
+DEFAULT_STAGE5_GRID_SHAPE = (3, 3)
+DEFAULT_STAGE5_ORIENTATION_FIX = True
+DEFAULT_STAGE5_DATASET_ROOT = Path("data/raw/emnist")
+
+_VALID_SPLITS = ("train", "val", "test")
+_VALID_FLIP_MODES = {"horizontal", "vertical"}
+
+
+def _normalize_hw(value: int | tuple[int, int], *, name: str) -> tuple[int, int]:
+    if isinstance(value, int):
+        if value < 1:
+            raise ValueError(f"{name} must be >= 1, got {value}.")
+        return (value, value)
+
+    if not isinstance(value, tuple) or len(value) != 2:
+        raise TypeError(f"{name} must be an int or a length-2 tuple, got {value!r}.")
+
+    height = int(value[0])
+    width = int(value[1])
+    if height < 1 or width < 1:
+        raise ValueError(f"{name} values must be >= 1, got {(height, width)}.")
+    return (height, width)
+
+
+def _normalize_split(split: str) -> str:
+    normalized = str(split).lower()
+    if normalized not in _VALID_SPLITS:
+        raise ValueError(f"split must be one of {_VALID_SPLITS}, got {split!r}.")
+    return normalized
+
+
+def _normalize_letter_count_choices(
+    choices: tuple[int, ...] | list[int],
+    *,
+    split: str,
+    num_cells: int,
+) -> tuple[int, ...]:
+    normalized = tuple(int(value) for value in choices)
+    if not normalized:
+        raise ValueError(f"{split} letter_count_choices must not be empty.")
+    if any(value < 1 for value in normalized):
+        raise ValueError(f"{split} letter_count_choices must be >= 1, got {normalized}.")
+    if any(value > num_cells for value in normalized):
+        raise ValueError(
+            f"{split} letter_count_choices cannot exceed the {num_cells} available cells, "
+            f"got {normalized}."
+        )
+    return normalized
+
+
+def _stable_seed(*parts: object) -> int:
+    joined = "|".join(str(part) for part in parts).encode("utf-8")
+    digest = hashlib.sha256(joined).digest()
+    return int.from_bytes(digest[:8], byteorder="big", signed=False)
+
+
+def _fix_emnist_orientation(image_chw: torch.Tensor) -> torch.Tensor:
+    return torch.flip(torch.rot90(image_chw, k=1, dims=(-2, -1)), dims=(-1,))
+
+
+@dataclass(frozen=True)
+class Stage5AugmentationConfig:
+    enable_rotation: bool
+    rotation_choices: tuple[int, ...]
+    enable_flip: bool
+    flip_modes: tuple[str, ...]
+    enable_contrast: bool
+    contrast_range: tuple[float, float]
+
+    @classmethod
+    def default_for_split(cls, split: str) -> "Stage5AugmentationConfig":
+        if split == "train":
+            return cls(
+                enable_rotation=True,
+                rotation_choices=(0, 90, 180, 270),
+                enable_flip=True,
+                flip_modes=("horizontal", "vertical"),
+                enable_contrast=True,
+                contrast_range=(0.8, 1.2),
+            )
+
+        return cls(
+            enable_rotation=False,
+            rotation_choices=(0,),
+            enable_flip=False,
+            flip_modes=(),
+            enable_contrast=False,
+            contrast_range=(1.0, 1.0),
+        )
+
+    @classmethod
+    def from_mapping(
+        cls,
+        payload: Mapping[str, Any] | None,
+        *,
+        split: str,
+    ) -> "Stage5AugmentationConfig":
+        default = cls.default_for_split(split)
+        if payload is None:
+            return default
+
+        rotation_choices = tuple(
+            int(value) for value in payload.get("rotation_choices", default.rotation_choices)
+        )
+        if any(value not in (0, 90, 180, 270) for value in rotation_choices):
+            raise ValueError(
+                "rotation_choices must be drawn from {0, 90, 180, 270}, "
+                f"got {rotation_choices}."
+            )
+
+        flip_modes = tuple(
+            str(value).lower() for value in payload.get("flip_modes", default.flip_modes)
+        )
+        invalid_flip_modes = [value for value in flip_modes if value not in _VALID_FLIP_MODES]
+        if invalid_flip_modes:
+            raise ValueError(
+                f"flip_modes must be chosen from {_VALID_FLIP_MODES}, got {invalid_flip_modes}."
+            )
+
+        contrast_range_raw = payload.get("contrast_range", default.contrast_range)
+        if not isinstance(contrast_range_raw, (list, tuple)) or len(contrast_range_raw) != 2:
+            raise TypeError(
+                "contrast_range must be a length-2 sequence, "
+                f"got {contrast_range_raw!r}."
+            )
+        contrast_range = (float(contrast_range_raw[0]), float(contrast_range_raw[1]))
+        if contrast_range[0] <= 0.0 or contrast_range[1] <= 0.0:
+            raise ValueError(f"contrast_range must be positive, got {contrast_range}.")
+        if contrast_range[0] > contrast_range[1]:
+            raise ValueError(f"contrast_range must be increasing, got {contrast_range}.")
+
+        return cls(
+            enable_rotation=bool(payload.get("enable_rotation", default.enable_rotation)),
+            rotation_choices=rotation_choices,
+            enable_flip=bool(payload.get("enable_flip", default.enable_flip)),
+            flip_modes=flip_modes,
+            enable_contrast=bool(payload.get("enable_contrast", default.enable_contrast)),
+            contrast_range=contrast_range,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "enable_rotation": self.enable_rotation,
+            "rotation_choices": list(self.rotation_choices),
+            "enable_flip": self.enable_flip,
+            "flip_modes": list(self.flip_modes),
+            "enable_contrast": self.enable_contrast,
+            "contrast_range": list(self.contrast_range),
+        }
+
+
+@dataclass(frozen=True)
+class LetterPlacement:
+    cell_index: int
+    cell_row: int
+    cell_col: int
+    source_index: int
+    label: int
+    rotation_deg: int
+    flip_horizontal: bool
+    flip_vertical: bool
+    contrast_factor: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "cell_index": self.cell_index,
+            "cell_row": self.cell_row,
+            "cell_col": self.cell_col,
+            "source_index": self.source_index,
+            "label": self.label,
+            "rotation_deg": self.rotation_deg,
+            "flip_horizontal": self.flip_horizontal,
+            "flip_vertical": self.flip_vertical,
+            "contrast_factor": self.contrast_factor,
+        }
+
+
+@dataclass(frozen=True)
+class DisplaySampleSpec:
+    dataset_index: int
+    split: str
+    sample_seed: int
+    letter_count: int
+    occupied_cells: tuple[int, ...]
+    placements: tuple[LetterPlacement, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "dataset_index": self.dataset_index,
+            "split": self.split,
+            "sample_seed": self.sample_seed,
+            "letter_count": self.letter_count,
+            "occupied_cells": list(self.occupied_cells),
+            "placements": [placement.to_dict() for placement in self.placements],
+        }
+
+
+class Stage5EMNISTDisplayDataset(Dataset[dict[str, Any]]):
+    """Deterministic Stage 5 EMNIST display dataset.
+
+    Finalized tiling rule:
+    - the 96x96 display is a fixed 3x3 grid of 32x32 cells
+    - each occupied cell contains exactly one resized EMNIST letter
+    - occupied cells are sampled without replacement per composite image
+    - letters never overlap and empty cells remain zero-valued
+    """
+
+    def __init__(
+        self,
+        *,
+        split: str,
+        dataset_root: str | Path | None = None,
+        emnist_split: str = "letters",
+        sample_count: int | None = None,
+        letter_count_choices: tuple[int, ...] | list[int] | None = None,
+        seed: int = 2026,
+        canvas_hw: tuple[int, int] | int = DEFAULT_STAGE5_CANVAS_HW,
+        cell_hw: tuple[int, int] | int = DEFAULT_STAGE5_CELL_HW,
+        grid_shape: tuple[int, int] | int = DEFAULT_STAGE5_GRID_SHAPE,
+        augmentation: Stage5AugmentationConfig | Mapping[str, Any] | None = None,
+        fix_emnist_orientation: bool = DEFAULT_STAGE5_ORIENTATION_FIX,
+        download: bool = False,
+    ) -> None:
+        super().__init__()
+        self.split = _normalize_split(split)
+        self.dataset_root = resolve_stage4_dataset_root(
+            dataset_root or DEFAULT_STAGE5_DATASET_ROOT
+        )
+        self.emnist_split = emnist_split
+        self.canvas_hw = _normalize_hw(canvas_hw, name="canvas_hw")
+        self.cell_hw = _normalize_hw(cell_hw, name="cell_hw")
+        self.grid_shape = _normalize_hw(grid_shape, name="grid_shape")
+        self.seed = int(seed)
+        self.fix_emnist_orientation = bool(fix_emnist_orientation)
+        self.download = bool(download)
+        self.sample_count = int(sample_count or DEFAULT_STAGE5_SAMPLE_COUNTS[self.split])
+        if self.sample_count < 1:
+            raise ValueError(f"sample_count must be >= 1, got {self.sample_count}.")
+
+        grid_height = self.grid_shape[0] * self.cell_hw[0]
+        grid_width = self.grid_shape[1] * self.cell_hw[1]
+        if (grid_height, grid_width) != self.canvas_hw:
+            raise ValueError(
+                "canvas_hw must exactly match grid_shape * cell_hw, "
+                f"got canvas_hw={self.canvas_hw}, grid_shape={self.grid_shape}, "
+                f"cell_hw={self.cell_hw}."
+            )
+
+        self.num_cells = self.grid_shape[0] * self.grid_shape[1]
+        self.letter_count_choices = _normalize_letter_count_choices(
+            letter_count_choices or DEFAULT_STAGE5_LETTER_COUNT_CHOICES[self.split],
+            split=self.split,
+            num_cells=self.num_cells,
+        )
+
+        if isinstance(augmentation, Stage5AugmentationConfig):
+            self.augmentation = augmentation
+        else:
+            self.augmentation = Stage5AugmentationConfig.from_mapping(
+                augmentation,
+                split=self.split,
+            )
+
+        use_train_partition = self.split in {"train", "val"}
+        self.base_dataset = EMNIST(
+            root=str(self.dataset_root),
+            split=self.emnist_split,
+            train=use_train_partition,
+            download=self.download,
+        )
+        self.source_data = self.base_dataset.data
+        self.source_targets = self.base_dataset.targets
+        self.source_partition = "train" if use_train_partition else "test"
+        if len(self.source_data) < max(self.letter_count_choices):
+            raise ValueError(
+                "Underlying EMNIST partition is smaller than the requested max letter count."
+            )
+
+        self.tiling_rule = (
+            "Fixed 3x3 tiling over a 96x96 canvas: each 32x32 cell holds at most "
+            "one resized letter, occupied cells are sampled without replacement, "
+            "and empty cells remain zero."
+        )
+
+    def __len__(self) -> int:
+        return self.sample_count
+
+    def _sample_rng(self, index: int) -> random.Random:
+        if index < 0 or index >= self.sample_count:
+            raise IndexError(f"Index {index} is out of bounds for split {self.split}.")
+        sample_seed = _stable_seed("stage5_emnist_display", self.seed, self.split, index)
+        return random.Random(sample_seed)
+
+    def _sample_spec(self, index: int) -> DisplaySampleSpec:
+        rng = self._sample_rng(index)
+        sample_seed = _stable_seed("stage5_emnist_display", self.seed, self.split, index)
+        letter_count = int(rng.choice(self.letter_count_choices))
+        occupied_cells = tuple(sorted(rng.sample(range(self.num_cells), k=letter_count)))
+        source_indices = tuple(rng.sample(range(len(self.source_data)), k=letter_count))
+
+        placements: list[LetterPlacement] = []
+        for cell_index, source_index in zip(occupied_cells, source_indices):
+            row = cell_index // self.grid_shape[1]
+            col = cell_index % self.grid_shape[1]
+            rotation_deg = (
+                int(rng.choice(self.augmentation.rotation_choices))
+                if self.augmentation.enable_rotation
+                else 0
+            )
+            flip_horizontal = (
+                self.augmentation.enable_flip
+                and "horizontal" in self.augmentation.flip_modes
+                and (rng.random() < 0.5)
+            )
+            flip_vertical = (
+                self.augmentation.enable_flip
+                and "vertical" in self.augmentation.flip_modes
+                and (rng.random() < 0.5)
+            )
+            if self.augmentation.enable_contrast:
+                contrast_factor = rng.uniform(*self.augmentation.contrast_range)
+            else:
+                contrast_factor = 1.0
+
+            placements.append(
+                LetterPlacement(
+                    cell_index=int(cell_index),
+                    cell_row=int(row),
+                    cell_col=int(col),
+                    source_index=int(source_index),
+                    label=int(self.source_targets[source_index]),
+                    rotation_deg=int(rotation_deg),
+                    flip_horizontal=bool(flip_horizontal),
+                    flip_vertical=bool(flip_vertical),
+                    contrast_factor=float(contrast_factor),
+                )
+            )
+
+        return DisplaySampleSpec(
+            dataset_index=int(index),
+            split=self.split,
+            sample_seed=int(sample_seed),
+            letter_count=int(letter_count),
+            occupied_cells=occupied_cells,
+            placements=tuple(placements),
+        )
+
+    def _load_source_letter(self, source_index: int) -> torch.Tensor:
+        image = self.source_data[source_index].detach().clone().float().unsqueeze(0) / 255.0
+        if self.fix_emnist_orientation:
+            image = _fix_emnist_orientation(image)
+        image = TF.resize(
+            image,
+            size=list(self.cell_hw),
+            interpolation=InterpolationMode.BICUBIC,
+            antialias=True,
+        )
+        return torch.clamp(image, 0.0, 1.0).contiguous()
+
+    def _apply_augmentations(
+        self,
+        image: torch.Tensor,
+        placement: LetterPlacement,
+    ) -> torch.Tensor:
+        augmented = image
+        if placement.rotation_deg:
+            k = placement.rotation_deg // 90
+            augmented = torch.rot90(augmented, k=k, dims=(-2, -1))
+        if placement.flip_horizontal:
+            augmented = torch.flip(augmented, dims=(-1,))
+        if placement.flip_vertical:
+            augmented = torch.flip(augmented, dims=(-2,))
+        if placement.contrast_factor != 1.0:
+            augmented = TF.adjust_contrast(augmented, placement.contrast_factor)
+        return torch.clamp(augmented, 0.0, 1.0).contiguous()
+
+    def compose_display(self, index: int) -> torch.Tensor:
+        spec = self._sample_spec(index)
+        canvas = torch.zeros((1, *self.canvas_hw), dtype=torch.float32)
+        cell_height, cell_width = self.cell_hw
+        for placement in spec.placements:
+            patch = self._load_source_letter(placement.source_index)
+            patch = self._apply_augmentations(patch, placement)
+            top = placement.cell_row * cell_height
+            left = placement.cell_col * cell_width
+            canvas[:, top : top + cell_height, left : left + cell_width] = patch
+        return canvas.contiguous()
+
+    def __getitem__(self, index: int) -> dict[str, Any]:
+        display = self.compose_display(index)
+        spec = self._sample_spec(index)
+        return {
+            "x_hr": display,
+            "target_hr": display.clone(),
+            "letter_count": spec.letter_count,
+            "dataset_index": int(index),
+        }
+
+    def get_sample_metadata(self, index: int) -> dict[str, Any]:
+        spec = self._sample_spec(index)
+        metadata = spec.to_dict()
+        metadata.update(
+            {
+                "source_partition": self.source_partition,
+                "canvas_hw": list(self.canvas_hw),
+                "cell_hw": list(self.cell_hw),
+                "grid_shape": list(self.grid_shape),
+            }
+        )
+        return metadata
+
+    def get_protocol_summary(self) -> dict[str, Any]:
+        return {
+            "split": self.split,
+            "source_partition": self.source_partition,
+            "dataset_root": str(Path(self.dataset_root).resolve()),
+            "emnist_split": self.emnist_split,
+            "sample_count": self.sample_count,
+            "canvas_hw": list(self.canvas_hw),
+            "cell_hw": list(self.cell_hw),
+            "grid_shape": list(self.grid_shape),
+            "num_cells": self.num_cells,
+            "tiling_rule": self.tiling_rule,
+            "letter_count_choices": list(self.letter_count_choices),
+            "seed": self.seed,
+            "randomization_policy": (
+                "Each sample is generated from a deterministic RNG seeded by "
+                "(base_seed, split, dataset_index). Generation is order-independent."
+            ),
+            "fix_emnist_orientation": self.fix_emnist_orientation,
+            "augmentation": self.augmentation.to_dict(),
+        }
+
+
+def build_stage5_emnist_display_dataset(
+    *,
+    split: str,
+    dataset_root: str | Path | None = None,
+    emnist_split: str = "letters",
+    sample_count: int | None = None,
+    letter_count_choices: tuple[int, ...] | list[int] | None = None,
+    seed: int = 2026,
+    canvas_hw: tuple[int, int] | int = DEFAULT_STAGE5_CANVAS_HW,
+    cell_hw: tuple[int, int] | int = DEFAULT_STAGE5_CELL_HW,
+    grid_shape: tuple[int, int] | int = DEFAULT_STAGE5_GRID_SHAPE,
+    augmentation: Stage5AugmentationConfig | Mapping[str, Any] | None = None,
+    fix_emnist_orientation: bool = DEFAULT_STAGE5_ORIENTATION_FIX,
+    download: bool = False,
+) -> Stage5EMNISTDisplayDataset:
+    return Stage5EMNISTDisplayDataset(
+        split=split,
+        dataset_root=dataset_root,
+        emnist_split=emnist_split,
+        sample_count=sample_count,
+        letter_count_choices=letter_count_choices,
+        seed=seed,
+        canvas_hw=canvas_hw,
+        cell_hw=cell_hw,
+        grid_shape=grid_shape,
+        augmentation=augmentation,
+        fix_emnist_orientation=fix_emnist_orientation,
+        download=download,
+    )
+
+
+__all__ = [
+    "DEFAULT_STAGE5_CANVAS_HW",
+    "DEFAULT_STAGE5_CELL_HW",
+    "DEFAULT_STAGE5_DATASET_ROOT",
+    "DEFAULT_STAGE5_GRID_SHAPE",
+    "DEFAULT_STAGE5_LETTER_COUNT_CHOICES",
+    "DEFAULT_STAGE5_SAMPLE_COUNTS",
+    "DisplaySampleSpec",
+    "LetterPlacement",
+    "Stage5AugmentationConfig",
+    "Stage5EMNISTDisplayDataset",
+    "build_stage5_emnist_display_dataset",
+]


### PR DESCRIPTION
why:
establish the stage5 paper-aligned data protocol before later encoder, trainer, and eval issues, and make the 96x96 display construction auditable and reproducible

what:
add a deterministic EMNIST letters -> 32x32 -> 96x96 display dataset path, finalize the 3x3 tiling rule and split-specific letter-count policy, and add a small preview path with config example and saved artifacts for protocol inspection