### PR TITLE
feat(model | stage5-4): add paper-aligned phase encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ More orders are listed in docs/run_order.md. Here are some frequently used comma
   `python scripts/train_decoder_only_small_subset_sweep.py --depths 1 3 5 --subset-size 4 --steps 80`
 - Validate Stage 5 paper-aligned optics configs for L=1/3/5:
   `python scripts/check_stage5_optics_configs.py --config configs/stage5/stage5_optics_paper_aligned.yaml`
+- Validate Stage 5 paper-aligned encoder + decoder integration:
+  `python scripts/check_stage5_encoder_integration.py --config configs/stage5/stage5_paper_encoder.yaml`
 - Preview the Stage 5 Issue 5.2 EMNIST 96x96 display dataset:
   `python scripts/preview_stage5_emnist_display.py --config docs/plan/stage_plan/stage5/stage5_emnist_display_config.yaml`
 

--- a/configs/stage5/stage5_paper_encoder.yaml
+++ b/configs/stage5/stage5_paper_encoder.yaml
@@ -1,0 +1,20 @@
+encoder:
+  stage5_paper_aligned:
+    note: >
+      Stage 5 chooses phi_lr = 32x32 to align the encoder output with the
+      Stage 5 optics input_pattern_hw from Issue 5.3. This is the Stage 5
+      encoder/optics alignment decision, not paper-unique truth.
+    input_hw: [96, 96]
+    target_hw: [32, 32]
+    in_channels: 1
+    base_channels: 16
+    hidden_channels: 32
+    interpolation_mode: bilinear
+    align_corners: false
+    phase_mapping: sigmoid
+    phase_range: [0.0, 6.283185307179586]
+    sanity:
+      optics_config_path: configs/stage5/stage5_optics_paper_aligned.yaml
+      depths: [1, 3, 5]
+      output_root: outputs/stage5/encoder_sanity
+      seed: 54

--- a/docs/ai/CodexFeedback/stage5/feedback_stage5-4.md
+++ b/docs/ai/CodexFeedback/stage5/feedback_stage5-4.md
@@ -1,0 +1,63 @@
+实现了一个真实的 Stage 5 paper-aligned phase-only encoder 路径：新增 `PaperPhaseEncoder`，用显式配置拍板 `phi_lr = 32x32` 和 `phase_range = [0, 2π)`，并用小型 sanity 脚本验证了 `96x96 -> phi_lr -> DiffractiveDecoder.forward_from_phase(...)` 的闭环集成。整个 issue 没有改写 optical core，也没有扩张到 loss、trainer 或 eval。
+
+精确变更文件：
+- [src/models/encoders/paper_phase_encoder.py](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/src/models/encoders/paper_phase_encoder.py)
+- [src/models/encoders/__init__.py](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/src/models/encoders/__init__.py)
+- [configs/stage5/stage5_paper_encoder.yaml](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/configs/stage5/stage5_paper_encoder.yaml)
+- [scripts/check_stage5_encoder_integration.py](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/scripts/check_stage5_encoder_integration.py)
+- [README.md](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/README.md)
+
+本次拍板的 Stage 5 encoder 决策：
+- 选择的 Stage 5 `phi_lr` size 为 `32x32`
+- 选择的 Stage 5 `phase_range` 为 `[0, 2π)`，配置中写为 `[0.0, 6.283185307179586]`
+- 这两个结论都被记录为 Stage 5 的 encoder/optics alignment default，而不是论文唯一真值
+- 当前实现把 phase mapping 显式放在 encoder 侧，采用 `phase_mapping = sigmoid` 将 raw phase logits 映射到配置区间
+
+实现细节边界：
+- encoder 输出仍是 real-valued phase-domain `phi_lr`，没有输出 field-domain tensor
+- `phi_lr -> U0` 仍由 [src/models/optics/diffractive_decoder.py](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/src/models/optics/diffractive_decoder.py) 负责
+- 没有改动 [src/models/hybrid/minimal_hybrid_wrapper.py](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/src/models/hybrid/minimal_hybrid_wrapper.py)，因为这次用直接的 `encoder -> decoder.forward_from_phase(...)` sanity 路径就足够证明集成成功
+
+sanity / integration evidence：
+- 运行命令：
+  `python scripts/check_stage5_encoder_integration.py --config configs/stage5/stage5_paper_encoder.yaml`
+- 生成 summary：
+  [outputs/stage5/encoder_sanity/stage5_encoder_integration_summary.json](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/encoder_sanity/stage5_encoder_integration_summary.json)
+- 记录内容包括：
+  - encoder input shape：`(1, 1, 96, 96)`
+  - raw phase shape：`(1, 1, 32, 32)`
+  - `phi_lr` shape：`(1, 1, 32, 32)`
+  - configured phase range：`[0.0, 6.283185307179586]`
+  - observed `phi_lr` range：约 `(3.529985, 3.533639)`
+  - downstream decoder shapes for `L=1/3/5`：
+    - `U0 = (1, 1, 400, 400)`
+    - `U_out_full = (1, 1, 400, 400)`
+    - `I_out_full = (1, 1, 400, 400)`
+    - `I_out_roi = (1, 1, 96, 96)`
+
+有意留给后续 issue 的未决项：
+- distance mapping 和 crop / FOV alignment 已由 `5.3` 拍板，本 issue 只消费现有 optics config，不重开
+- loss semantics、`L=5 gamma`、`sigma normalization granularity` 仍归 `5.5`
+- trainer architecture 和 eval protocol 仍归 `5.6` / `5.7` / `5.8`
+- 本次没有把 `32x32` 或 `[0, 2π)` 叙述成论文唯一无歧义事实，只把它们固定为 Stage 5 的默认实现选择
+
+已执行验证：
+- `python -m py_compile src/models/encoders/paper_phase_encoder.py scripts/check_stage5_encoder_integration.py`
+- `python scripts/check_stage5_encoder_integration.py --config configs/stage5/stage5_paper_encoder.yaml`
+
+推荐的 commit 三段式信息：
+
+```text
+feat(model | stage5-4): add paper-aligned phase encoder
+
+why:
+freeze the stage5 encoder-side phi_lr contract before trainer and eval
+work, and make the chosen 32x32 phase output plus explicit phase range
+mapping auditable against the stage5 optics config
+
+what:
+add a paper-aligned phase-only encoder, expose target_hw and phase_range
+in stage5 config, finalize the stage5 default phi_lr size and phase
+range, and add an encoder-to-decoder sanity script with recorded range
+and downstream shape evidence
+```

--- a/docs/ai/prompt/stage5/prompt_stage5-5.md
+++ b/docs/ai/prompt/stage5/prompt_stage5-5.md
@@ -1,0 +1,259 @@
+You are working in a research-engineering repository for reproducing
+"Super-resolution image display using diffractive decoders".
+
+Your task is to complete GitHub Issue 5.5:
+
+Issue title:
+Add paper-aligned SR loss with efficiency penalty
+
+This is a Stage-5-scoped loss task.
+Do not turn it into an optics rewrite, trainer framework task, or eval task.
+
+==================================================
+0. MUST-READ CONTEXT FIRST
+==================================================
+
+Before doing anything, you MUST read and follow these files in order:
+
+1. `AGENTS.md`
+2. `docs/ai/PROJECT_CONTEXT.md`
+3. `docs/paper/paper_notes.md`
+4. `docs/plan/stage_plan/stage5/stage5_protocol_freeze.md`
+5. `docs/plan/stage_plan/stage5/stage5_plan.md`
+6. `docs/plan/stage_plan/stage5/stage5_issue_plan.md`
+7. `configs/stage5/stage5_optics_paper_aligned.yaml`
+8. `configs/stage5/stage5_paper_encoder.yaml`
+
+Then inspect these implementation-reference files before editing:
+
+9. `scripts/train_stage4_minimal.py`
+10. `scripts/train_decoder_only_single_sample.py`
+11. `scripts/train_decoder_only_small_subset.py`
+
+Important scope rules:
+
+- If `paper_notes.md` is broader than the Stage 5 schedule, follow the Stage 5 docs.
+- For unresolved items, obey the ownership rules in `stage5_protocol_freeze.md`.
+- The Stage 4 `normalized_mae_roi(...)` implementations are historical reference only.
+  They are not automatically the final Stage 5 loss contract.
+
+==================================================
+1. ISSUE 5.5 GOAL
+==================================================
+
+Implement the paper-aligned Stage 5 loss:
+
+- normalized MAE on `I_out_roi`
+- plus an optional efficiency penalty term
+
+The result should provide a reproducible Stage 5 loss path that:
+
+1. consumes prediction and target tensors on the ROI path
+2. computes `sigma` according to the Stage 5 loss contract
+3. computes the efficiency term with an explicit `eta` definition
+4. keeps `gamma` configurable by depth
+5. keeps unresolved policy choices explicit and auditable
+
+==================================================
+2. NON-GOALS - DO NOT DRIFT
+==================================================
+
+Do NOT do any of the following:
+
+- do not modify optics geometry or readout semantics
+- do not modify encoder semantics
+- do not build the Stage 5 trainer here
+- do not build eval scripts here
+- do not add Stage 6 ablation logic
+- do not hard-code an unreviewed `L=5` gamma as if it were paper-settled fact
+- do not silently change target supervision from `I_out_roi` to another tensor
+- do not broaden this into a generic repo-wide loss framework unless a very small
+  shared helper is strictly justified
+
+This issue is successful only if it lands the Stage 5 paper-aligned loss
+contract in a narrow, configurable, auditable way.
+
+==================================================
+3. BRANCH EXPECTATION
+==================================================
+
+Suggested branch:
+- `feat/train`
+
+Stay on a training/loss-oriented branch.
+Do not use this issue to modify `feat/model` or `feat/eval` concerns.
+
+==================================================
+4. REQUIRED INHERITANCE
+==================================================
+
+From `stage5_protocol_freeze.md`, this issue must inherit and obey:
+
+1. Frozen optical contract:
+   `phi_lr -> U0 -> U_out_full -> I_out_full -> I_out_roi`
+2. Main supervision target remains `I_out_roi`
+3. Stage 4 artifacts are regression baseline only
+4. Issue 5.5 owns:
+   - final `L=5 gamma` policy for Stage 5
+   - final `sigma` normalization granularity for Stage 5
+   - the Stage 5 efficiency-term config interface
+5. Issue 5.5 does NOT own:
+   - dataset protocol
+   - distance mapping
+   - phase range
+   - crop/FOV semantics
+   - trainer architecture
+
+Important inheritance detail:
+
+- `5.3` and `5.4` already froze the Stage 5 optics/encoder path.
+- Your loss must consume those paths, not reopen them.
+
+==================================================
+5. WHAT YOU ARE ALLOWED TO FINALIZE HERE
+==================================================
+
+This issue MAY finalize:
+
+1. the Stage 5 loss module path and API
+2. the explicit `sigma` computation mode used by Stage 5
+3. the explicit `eta` computation interface used by Stage 5
+4. the `gamma_by_depth` defaults, including `L=5`
+5. the config fields used to enable/disable the efficiency penalty
+
+This issue MUST keep the following explicit and auditable:
+
+1. `sigma` definition
+2. `eta` definition
+3. `gamma_by_depth`
+4. whether the efficiency term is enabled
+5. whether these are Stage 5 defaults or stronger conclusions
+
+This issue MUST keep the following out of scope:
+
+1. trainer loop changes beyond tiny loss-call integration helpers
+2. eval metric code
+3. any Stage 6 sweep or robustness logic
+
+==================================================
+6. IMPLEMENTATION REQUIREMENTS
+==================================================
+
+Implement the smallest real loss path needed for Stage 5.
+
+Prefer a narrow, explicit structure such as:
+
+- a new module under `src/losses/` if that directory does not yet exist
+- a clearly named Stage-5-specific loss class/function
+- a small config example under `configs/stage5/`
+- a small sanity script under `scripts/` only if needed
+
+The implementation should likely include:
+
+- normalized MAE with explicit `sigma` normalization
+- optional efficiency penalty term using:
+  - output power `P_o`
+  - input power `P_i`
+  - `eta = 100 * P_o / P_i`
+- configurable `gamma_by_depth`
+- an explicit switch for turning the efficiency term on/off
+
+You must keep the interface practical for later Stage 5 trainer work.
+For example, the loss path may need to consume:
+
+- `prediction_roi`
+- `target_roi`
+- optional extra tensors needed for power accounting, if the efficiency term requires them
+- current depth or preselected gamma value
+
+Do not bury the required inputs in hidden globals.
+
+==================================================
+7. REFERENCE MATH TO IMPLEMENT
+==================================================
+
+The Stage 5 target loss contract is:
+
+`L = mean_i | y_i - sigma * y_hat_i | + gamma * exp(-eta)`
+
+with:
+
+`sigma = sum_i y_i / (sum_i y_hat_i + epsilon)`
+
+and:
+
+`eta = 100 * P_o / P_i`
+
+You must make explicit:
+
+- over which dimensions `sigma` is computed
+- how batch aggregation is performed
+- what tensors are used for `P_o` and `P_i`
+- what happens when the efficiency term is disabled
+
+==================================================
+8. REQUIRED ARTIFACTS
+==================================================
+
+You must produce enough artifacts to verify that the loss path is real and inspectable.
+
+At minimum, provide:
+
+- the Stage 5 loss module
+- config entries for:
+  - `epsilon`
+  - `sigma_mode` or equivalent
+  - `gamma_by_depth`
+  - efficiency-term enable/disable
+- a fake-batch or small sanity command/script showing:
+  - loss is finite
+  - `sigma` is finite
+  - `eta` is finite when enabled
+  - toggling the efficiency term changes the total loss in a controlled way
+
+If the repo already has a preferred place for Stage 5 sanity outputs, follow it.
+Do not build a heavy training harness here.
+
+==================================================
+9. FILE SCOPE
+==================================================
+
+Primary files likely to be changed or added:
+
+- `src/losses/` for the new loss implementation
+- `configs/stage5/` for the loss config
+- a small sanity script under `scripts/` only if needed
+
+Avoid:
+
+- broad trainer changes
+- optics changes
+- encoder changes
+- eval changes
+
+==================================================
+10. ACCEPTANCE CRITERIA
+==================================================
+
+Issue 5.5 is complete only if:
+
+1. A real Stage 5 paper-aligned loss path exists
+2. `sigma` normalization is explicit and documented
+3. Efficiency penalty behavior is explicit and configurable
+4. `gamma_by_depth` is configurable and logged
+5. `L=5` gamma handling is no longer left implicit
+6. Loss runs stably on a fake batch without NaN/Inf
+
+==================================================
+11. FINAL RESPONSE FORMAT
+==================================================
+
+After finishing, respond with:
+
+- short summary of what was implemented
+- exact files changed
+- the chosen Stage 5 `sigma` policy
+- the chosen Stage 5 `gamma_by_depth` policy, including `L=5`
+- how `eta` is computed in the implementation
+- what sanity evidence was produced
+- what was intentionally left unresolved for later issues

--- a/scripts/check_stage5_encoder_integration.py
+++ b/scripts/check_stage5_encoder_integration.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python
+"""Stage 5 encoder-to-decoder sanity for the paper-aligned phase path."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+import torch
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.models.encoders import PaperPhaseEncoder
+from src.models.optics.diffractive_decoder import DiffractiveDecoder
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        type=str,
+        default="configs/stage5/stage5_paper_encoder.yaml",
+        help="Path to the Stage 5 paper encoder YAML config.",
+    )
+    parser.add_argument(
+        "--output-root",
+        type=str,
+        default=None,
+        help="Optional override for the summary output directory.",
+    )
+    return parser.parse_args()
+
+
+def load_yaml_config(path: str) -> dict[str, Any]:
+    try:
+        import yaml  # type: ignore
+    except ImportError as exc:
+        raise RuntimeError("PyYAML is required to load the Stage 5 configs.") from exc
+
+    with Path(path).open("r", encoding="utf-8") as file:
+        payload = yaml.safe_load(file) or {}
+    if not isinstance(payload, dict):
+        raise TypeError(f"Expected a mapping at YAML root, got {type(payload)!r}.")
+    return payload
+
+
+def make_controlled_hr(input_hw: tuple[int, int]) -> torch.Tensor:
+    height, width = input_hw
+    y = torch.linspace(-1.0, 1.0, height, dtype=torch.float32)
+    x = torch.linspace(-1.0, 1.0, width, dtype=torch.float32)
+    yy, xx = torch.meshgrid(y, x, indexing="ij")
+
+    image = 0.35 * torch.sin(math.pi * xx)
+    image += 0.25 * torch.cos(2.0 * math.pi * yy)
+    image += 0.20 * torch.exp(-4.5 * (xx.square() + yy.square()))
+    image[height // 4 : height // 4 + 12, width // 3 : width // 3 + 18] += 0.35
+    image = image - image.min()
+    image = image / image.max().clamp_min(1e-6)
+    return image.unsqueeze(0).unsqueeze(0)
+
+
+def build_encoder(encoder_config: dict[str, Any]) -> PaperPhaseEncoder:
+    return PaperPhaseEncoder(
+        in_channels=int(encoder_config["in_channels"]),
+        input_hw=tuple(int(v) for v in encoder_config["input_hw"]),
+        target_hw=tuple(int(v) for v in encoder_config["target_hw"]),
+        base_channels=int(encoder_config["base_channels"]),
+        hidden_channels=int(encoder_config["hidden_channels"]),
+        interpolation_mode=str(encoder_config["interpolation_mode"]),
+        align_corners=bool(encoder_config["align_corners"]),
+        phase_mapping=str(encoder_config["phase_mapping"]),
+        phase_range=tuple(float(v) for v in encoder_config["phase_range"]),
+    )
+
+
+def build_decoder(optics_config: dict[str, Any], *, depth_key: str) -> DiffractiveDecoder:
+    stage5_optics = optics_config["optics"]["stage5_paper_aligned"]
+    units = stage5_optics["units"]
+    grid = stage5_optics["grid"]
+    readout = stage5_optics["readout"]
+    depth_payload = stage5_optics["depths"][depth_key]
+    phase_mask_config = stage5_optics.get("phase_mask_config")
+
+    decoder_kwargs: dict[str, Any] = {
+        "num_diffractive_layers": int(depth_payload["num_diffractive_layers"]),
+        "wavelength": float(units["wavelength"]),
+        "pixel_pitch": float(units["pixel_pitch_lambda"]),
+        "grid_config": {
+            "input_pattern_hw": tuple(int(v) for v in grid["input_pattern_hw"]),
+            "layer_hw": tuple(int(v) for v in grid["layer_hw"]),
+            "propagation_hw": tuple(int(v) for v in grid["propagation_hw"]),
+        },
+        "distance_schedule": depth_payload["distance_schedule"],
+        "readout_config": {
+            "output_crop_hw": tuple(int(v) for v in readout["output_crop_hw"]),
+        },
+    }
+    if phase_mask_config is not None:
+        decoder_kwargs["phase_mask_config"] = phase_mask_config
+    return DiffractiveDecoder(**decoder_kwargs)
+
+
+def assert_phase_range(phi_lr: torch.Tensor, *, phase_range: tuple[float, float]) -> tuple[float, float]:
+    if phi_lr.is_complex():
+        raise AssertionError(f"phi_lr must be real-valued, got dtype {phi_lr.dtype}.")
+    detached = phi_lr.detach()
+    observed_min = float(detached.min())
+    observed_max = float(detached.max())
+    phase_min, phase_max = phase_range
+    if observed_min < phase_min - 1e-6 or observed_max > phase_max + 1e-6:
+        raise AssertionError(
+            f"phi_lr observed range {(observed_min, observed_max)} exceeds configured range {phase_range}."
+        )
+    return observed_min, observed_max
+
+
+def main() -> None:
+    args = parse_args()
+    config = load_yaml_config(args.config)
+    encoder_config = config["encoder"]["stage5_paper_aligned"]
+    optics_config = load_yaml_config(encoder_config["sanity"]["optics_config_path"])
+    stage5_optics = optics_config["optics"]["stage5_paper_aligned"]
+
+    torch.manual_seed(int(encoder_config["sanity"]["seed"]))
+
+    encoder = build_encoder(encoder_config)
+    optics_input_pattern_hw = tuple(int(v) for v in stage5_optics["grid"]["input_pattern_hw"])
+    if encoder.target_hw != optics_input_pattern_hw:
+        raise AssertionError(
+            "Encoder target_hw must match the Stage 5 optics input_pattern_hw, "
+            f"got {encoder.target_hw} vs {optics_input_pattern_hw}."
+        )
+
+    x_hr = make_controlled_hr(encoder.input_hw)
+    raw_phase = encoder.encode_raw_phase(x_hr)
+    phi_lr = encoder.map_raw_phase(raw_phase)
+    observed_min, observed_max = assert_phase_range(phi_lr, phase_range=encoder.phase_range)
+
+    depth_keys = [str(depth) for depth in encoder_config["sanity"]["depths"]]
+    downstream_summaries: dict[str, Any] = {}
+    for depth_key in depth_keys:
+        decoder = build_decoder(optics_config, depth_key=depth_key)
+        output = decoder.forward_from_phase(phi_lr)
+        U0 = output["U0"]
+        U_out_full = output["U_out_full"]
+        I_out_full = output["I_out_full"]
+        I_out_roi = output["I_out_roi"]
+        if not isinstance(U0, torch.Tensor) or not U0.is_complex():
+            raise AssertionError(f"L={depth_key} U0 must be a complex tensor.")
+        if not isinstance(U_out_full, torch.Tensor) or not U_out_full.is_complex():
+            raise AssertionError(f"L={depth_key} U_out_full must be a complex tensor.")
+        if not isinstance(I_out_full, torch.Tensor) or I_out_full.is_complex():
+            raise AssertionError(f"L={depth_key} I_out_full must be a real tensor.")
+        if not isinstance(I_out_roi, torch.Tensor) or I_out_roi.is_complex():
+            raise AssertionError(f"L={depth_key} I_out_roi must be a real tensor.")
+
+        downstream_summaries[depth_key] = {
+            "distance_schedule": {
+                "input_to_first": float(decoder.distance_schedule.input_to_first),
+                "inter_layer": [float(v) for v in decoder.distance_schedule.inter_layer],
+                "last_to_sensor": float(decoder.distance_schedule.last_to_sensor),
+            },
+            "output_shapes": {
+                "U0": list(U0.shape),
+                "U_out_full": list(U_out_full.shape),
+                "I_out_full": list(I_out_full.shape),
+                "I_out_roi": list(I_out_roi.shape),
+            },
+        }
+
+    output_root = Path(args.output_root or encoder_config["sanity"]["output_root"])
+    output_root.mkdir(parents=True, exist_ok=True)
+    summary = {
+        "encoder_config_path": str(Path(args.config).as_posix()),
+        "optics_config_path": str(Path(encoder_config["sanity"]["optics_config_path"]).as_posix()),
+        "encoder": {
+            "input_hw": list(encoder.input_hw),
+            "target_hw": list(encoder.target_hw),
+            "phase_mapping": encoder.phase_mapping,
+            "phase_range": [float(encoder.phase_range[0]), float(encoder.phase_range[1])],
+            "alignment_note": encoder_config["note"],
+        },
+        "observed": {
+            "encoder_input_shape": list(x_hr.shape),
+            "raw_phase_shape": list(raw_phase.shape),
+            "phi_lr_shape": list(phi_lr.shape),
+            "phi_lr_min": observed_min,
+            "phi_lr_max": observed_max,
+        },
+        "decoder_depths": downstream_summaries,
+    }
+    summary_path = output_root / "stage5_encoder_integration_summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+
+    print("Stage 5 encoder integration sanity passed.")
+    print(f"config={args.config}")
+    print(f"summary={summary_path.as_posix()}")
+    print(
+        f"encoder_input_shape={tuple(x_hr.shape)} raw_phase_shape={tuple(raw_phase.shape)} "
+        f"phi_lr_shape={tuple(phi_lr.shape)}"
+    )
+    print(
+        f"phase_mapping={encoder.phase_mapping} "
+        f"phase_range={encoder.phase_range} "
+        f"observed_phi_range=({observed_min:.6f}, {observed_max:.6f})"
+    )
+    for depth_key in depth_keys:
+        shapes = downstream_summaries[depth_key]["output_shapes"]
+        print(
+            f"L={depth_key} U0={tuple(shapes['U0'])} U_out_full={tuple(shapes['U_out_full'])} "
+            f"I_out_full={tuple(shapes['I_out_full'])} I_out_roi={tuple(shapes['I_out_roi'])}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/models/encoders/__init__.py
+++ b/src/models/encoders/__init__.py
@@ -1,5 +1,6 @@
 """Encoder modules used by the repo's model stack."""
 
 from src.models.encoders.minimal_phase_encoder import MinimalPhaseEncoder
+from src.models.encoders.paper_phase_encoder import PaperPhaseEncoder
 
-__all__ = ["MinimalPhaseEncoder"]
+__all__ = ["MinimalPhaseEncoder", "PaperPhaseEncoder"]

--- a/src/models/encoders/paper_phase_encoder.py
+++ b/src/models/encoders/paper_phase_encoder.py
@@ -1,0 +1,230 @@
+"""Paper-aligned phase-only encoder for the Stage 5 mainline."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+def _normalize_hw(hw: int | Sequence[int], *, name: str) -> tuple[int, int]:
+    if isinstance(hw, int):
+        if hw < 1:
+            raise ValueError(f"{name} must be >= 1, got {hw}.")
+        return (hw, hw)
+
+    if not isinstance(hw, Sequence) or isinstance(hw, (str, bytes)) or len(hw) != 2:
+        raise TypeError(f"{name} must be an int or a length-2 sequence, got {hw!r}.")
+
+    height = int(hw[0])
+    width = int(hw[1])
+    if height < 1 or width < 1:
+        raise ValueError(f"{name} values must be >= 1, got {(height, width)}.")
+    return (height, width)
+
+
+class ConvBlock(nn.Module):
+    """Small reusable conv block for the paper-aligned encoder."""
+
+    def __init__(self, in_channels: int, out_channels: int) -> None:
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Conv2d(in_channels, out_channels, kernel_size=3, padding=1),
+            nn.LeakyReLU(negative_slope=0.1, inplace=True),
+            nn.Conv2d(out_channels, out_channels, kernel_size=3, padding=1),
+            nn.LeakyReLU(negative_slope=0.1, inplace=True),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x)
+
+
+class PaperPhaseEncoder(nn.Module):
+    """Stage 5 paper-aligned encoder that outputs phase-domain `phi_lr`."""
+
+    VALID_PHASE_MAPPINGS = ("sigmoid", "tanh")
+
+    def __init__(
+        self,
+        *,
+        in_channels: int = 1,
+        input_hw: int | Sequence[int],
+        target_hw: int | Sequence[int],
+        base_channels: int = 16,
+        hidden_channels: int | None = None,
+        phase_mapping: str = "sigmoid",
+        phase_range: tuple[float, float] = (0.0, 2.0 * math.pi),
+        interpolation_mode: str = "bilinear",
+        align_corners: bool = False,
+    ) -> None:
+        super().__init__()
+        if in_channels < 1:
+            raise ValueError(f"in_channels must be >= 1, got {in_channels}.")
+        if base_channels < 1:
+            raise ValueError(f"base_channels must be >= 1, got {base_channels}.")
+
+        hidden = int(hidden_channels) if hidden_channels is not None else base_channels * 2
+        if hidden < 1:
+            raise ValueError(f"hidden_channels must be >= 1, got {hidden}.")
+
+        phase_mapping = str(phase_mapping)
+        if phase_mapping not in self.VALID_PHASE_MAPPINGS:
+            raise ValueError(
+                f"phase_mapping must be one of {self.VALID_PHASE_MAPPINGS}, got {phase_mapping!r}."
+            )
+
+        phase_min = float(phase_range[0])
+        phase_max = float(phase_range[1])
+        if not phase_min < phase_max:
+            raise ValueError(
+                "phase_range must be strictly increasing, "
+                f"got {(phase_min, phase_max)}."
+            )
+
+        self.in_channels = int(in_channels)
+        self.input_hw = _normalize_hw(input_hw, name="input_hw")
+        self.target_hw = _normalize_hw(target_hw, name="target_hw")
+        self.base_channels = int(base_channels)
+        self.hidden_channels = hidden
+        self.phase_mapping = phase_mapping
+        self.phase_range = (phase_min, phase_max)
+        self.interpolation_mode = interpolation_mode
+        self.align_corners = bool(align_corners)
+
+        self.stem = ConvBlock(self.in_channels, self.base_channels)
+        self.downsample = nn.Sequential(
+            nn.Conv2d(self.base_channels, self.hidden_channels, kernel_size=3, stride=2, padding=1),
+            nn.LeakyReLU(negative_slope=0.1, inplace=True),
+        )
+        self.body = ConvBlock(self.hidden_channels, self.hidden_channels)
+        self.proj = nn.Sequential(
+            nn.Conv2d(self.hidden_channels, self.base_channels, kernel_size=1),
+            nn.LeakyReLU(negative_slope=0.1, inplace=True),
+        )
+        self.raw_phase_head = nn.Conv2d(self.base_channels, 1, kernel_size=1)
+
+    def _validate_input(self, x: torch.Tensor) -> None:
+        if not isinstance(x, torch.Tensor):
+            raise TypeError(f"Expected x to be a torch.Tensor, got {type(x)!r}.")
+        if x.ndim != 4:
+            raise ValueError(
+                "PaperPhaseEncoder expects input shape [B,C,H,W], "
+                f"got {tuple(x.shape)}."
+            )
+        if x.shape[1] != self.in_channels:
+            raise ValueError(
+                "Input channel count does not match encoder configuration, "
+                f"got {tuple(x.shape)} with in_channels={self.in_channels}."
+            )
+        if tuple(x.shape[-2:]) != self.input_hw:
+            raise ValueError(
+                "Input spatial shape does not match the Stage 5 encoder contract, "
+                f"got {tuple(x.shape[-2:])} vs {self.input_hw}."
+            )
+
+    def _resize_to_target(self, features: torch.Tensor) -> torch.Tensor:
+        resize_kwargs: dict[str, object] = {
+            "size": self.target_hw,
+            "mode": self.interpolation_mode,
+        }
+        if self.interpolation_mode in {"linear", "bilinear", "bicubic", "trilinear"}:
+            resize_kwargs["align_corners"] = self.align_corners
+        return F.interpolate(features, **resize_kwargs)
+
+    def encode_features(self, x: torch.Tensor) -> torch.Tensor:
+        self._validate_input(x)
+        features = self.stem(x)
+        features = self.downsample(features)
+        features = self.body(features)
+        features = self._resize_to_target(features)
+        return self.proj(features)
+
+    def encode_raw_phase(self, x: torch.Tensor) -> torch.Tensor:
+        features = self.encode_features(x)
+        return self.raw_phase_head(features)
+
+    def map_raw_phase(self, raw_phase: torch.Tensor) -> torch.Tensor:
+        if raw_phase.ndim != 4 or raw_phase.shape[1] != 1:
+            raise ValueError(
+                "raw_phase must have shape [B,1,H,W], "
+                f"got {tuple(raw_phase.shape)}."
+            )
+        if tuple(raw_phase.shape[-2:]) != self.target_hw:
+            raise ValueError(
+                "raw_phase spatial shape must match target_hw, "
+                f"got {tuple(raw_phase.shape[-2:])} vs {self.target_hw}."
+            )
+        if raw_phase.is_complex():
+            raise ValueError(f"raw_phase must be real-valued, got dtype {raw_phase.dtype}.")
+
+        phase_min, phase_max = self.phase_range
+        if self.phase_mapping == "sigmoid":
+            return phase_min + (phase_max - phase_min) * torch.sigmoid(raw_phase)
+        if self.phase_mapping == "tanh":
+            phase_center = 0.5 * (phase_min + phase_max)
+            phase_half_span = 0.5 * (phase_max - phase_min)
+            return phase_center + phase_half_span * torch.tanh(raw_phase)
+        raise RuntimeError(f"Unsupported phase_mapping: {self.phase_mapping!r}.")
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        raw_phase = self.encode_raw_phase(x)
+        phi_lr = self.map_raw_phase(raw_phase)
+        return phi_lr
+
+    def extra_repr(self) -> str:
+        phase_min, phase_max = self.phase_range
+        return (
+            f"in_channels={self.in_channels}, "
+            f"input_hw={self.input_hw}, "
+            f"target_hw={self.target_hw}, "
+            f"base_channels={self.base_channels}, "
+            f"hidden_channels={self.hidden_channels}, "
+            f"phase_mapping='{self.phase_mapping}', "
+            f"phase_range=({phase_min:.4f}, {phase_max:.4f}), "
+            f"interpolation_mode='{self.interpolation_mode}'"
+        )
+
+
+@torch.no_grad()
+def _run_self_check() -> None:
+    encoder = PaperPhaseEncoder(
+        in_channels=1,
+        input_hw=(96, 96),
+        target_hw=(32, 32),
+        base_channels=8,
+        hidden_channels=16,
+        phase_mapping="sigmoid",
+        phase_range=(0.0, 2.0 * math.pi),
+    )
+    x_hr = torch.rand(2, 1, 96, 96, dtype=torch.float32)
+    raw_phase = encoder.encode_raw_phase(x_hr)
+    phi_lr = encoder.map_raw_phase(raw_phase)
+
+    expected_shape = (2, 1, 32, 32)
+    if tuple(phi_lr.shape) != expected_shape:
+        raise AssertionError(
+            f"Unexpected phi_lr shape: got {tuple(phi_lr.shape)}, expected {expected_shape}."
+        )
+
+    phase_min, phase_max = encoder.phase_range
+    if float(phi_lr.min()) < phase_min - 1e-6 or float(phi_lr.max()) > phase_max + 1e-6:
+        raise AssertionError(
+            "phi_lr is outside the configured phase range: "
+            f"range={encoder.phase_range}, "
+            f"observed=({float(phi_lr.min())}, {float(phi_lr.max())})."
+        )
+
+    print("PaperPhaseEncoder self-check passed.")
+    print(f"raw_phase.shape={tuple(raw_phase.shape)}")
+    print(f"phi_lr.shape={tuple(phi_lr.shape)}")
+    print(f"phi_lr.range=({float(phi_lr.min()):.6f}, {float(phi_lr.max()):.6f})")
+
+
+if __name__ == "__main__":
+    _run_self_check()
+
+
+__all__ = ["PaperPhaseEncoder"]


### PR DESCRIPTION
why:
freeze the stage5 encoder-side phi_lr contract before trainer and eval work, and make the chosen 32x32 phase output plus explicit phase range mapping auditable against the stage5 optics config

what:
add a paper-aligned phase-only encoder, expose target_hw and phase_range in stage5 config, finalize the stage5 default phi_lr size and phase range, and add an encoder-to-decoder sanity script with recorded range and downstream shape evidence