### PR TITLE
feat(train | stage5-5): add paper-aligned sr loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ More orders are listed in docs/run_order.md. Here are some frequently used comma
   `python scripts/check_stage5_optics_configs.py --config configs/stage5/stage5_optics_paper_aligned.yaml`
 - Validate Stage 5 paper-aligned encoder + decoder integration:
   `python scripts/check_stage5_encoder_integration.py --config configs/stage5/stage5_paper_encoder.yaml`
+- Validate Stage 5 paper-aligned SR loss:
+  `python scripts/check_stage5_sr_loss.py --config configs/stage5/stage5_sr_loss.yaml`
 - Preview the Stage 5 Issue 5.2 EMNIST 96x96 display dataset:
   `python scripts/preview_stage5_emnist_display.py --config docs/plan/stage_plan/stage5/stage5_emnist_display_config.yaml`
 

--- a/configs/stage5/stage5_sr_loss.yaml
+++ b/configs/stage5/stage5_sr_loss.yaml
@@ -1,0 +1,25 @@
+loss:
+  stage5_sr:
+    note: >
+      Stage 5 finalizes sigma as per-sample normalization over all non-batch
+      ROI elements, with batch aggregation applied after per-sample normalized
+      MAE. gamma_by_depth keeps L=5 at 0.0 as the Stage 5 default policy,
+      not as paper-unique truth.
+    epsilon: 1.0e-8
+    sigma_mode: per_sample
+    aggregation: batch_mean_after_per_sample_mae
+    efficiency_term:
+      enabled: true
+      eta_scale: 100.0
+      output_power_source: prediction_roi_sum
+      input_power_source: explicit_input_power
+      gamma_by_depth:
+        "1": 0.005
+        "3": 0.015
+        "5": 0.0
+    sanity:
+      output_root: outputs/stage5/loss_sanity
+      depths: [1, 3, 5]
+      batch_size: 2
+      roi_hw: [96, 96]
+      seed: 55

--- a/docs/ai/CodexFeedback/stage5/feedback_stage5-5.md
+++ b/docs/ai/CodexFeedback/stage5/feedback_stage5-5.md
@@ -1,0 +1,73 @@
+实现了一个独立的 Stage 5 paper-aligned SR loss 路径：新增 `src/losses/`，把 `normalized MAE on I_out_roi + optional efficiency penalty` 从 Stage 4 脚本参考中抽离成可配置模块，并用小型 fake-batch sanity 脚本验证了 `sigma`、`eta`、`gamma_by_depth` 和 efficiency 开关行为。整个 issue 没有改 optics、encoder、trainer 或 eval。
+
+精确变更文件：
+- [src/losses/__init__.py](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/src/losses/__init__.py)
+- [src/losses/stage5_sr_loss.py](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/src/losses/stage5_sr_loss.py)
+- [configs/stage5/stage5_sr_loss.yaml](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/configs/stage5/stage5_sr_loss.yaml)
+- [scripts/check_stage5_sr_loss.py](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/scripts/check_stage5_sr_loss.py)
+- [README.md](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/README.md)
+
+本次拍板的 Stage 5 `sigma` policy：
+- 选择 `sigma_mode = per_sample`
+- `sigma` 按每个样本的 ROI 非 batch 维求和计算：`sigma = sum(target_roi) / (sum(prediction_roi) + epsilon)`
+- 先得到逐样本 `sigma`，再计算逐样本 normalized MAE，最后在 batch 维做 mean 聚合
+- 这与 Stage 5 protocol freeze 的默认口径一致，并在 config 中显式记录为 `aggregation = batch_mean_after_per_sample_mae`
+
+本次拍板的 Stage 5 `gamma_by_depth` policy：
+- `L=1`: `gamma = 0.005`
+- `L=3`: `gamma = 0.015`
+- `L=5`: `gamma = 0.0`
+- `L=5 = 0.0` 现在已经不再是隐含默认，而是显式写入 config 和 sanity summary 的 Stage 5 结论
+- 该结论被记录为 Stage 5 default policy，不表述为论文唯一无歧义真值
+
+`eta` 的实现口径：
+- `eta = 100 * P_o / P_i`
+- `P_o` 默认取 `prediction_roi` 在所有非 batch 维上的求和，也就是 `prediction_roi_sum`
+- `P_i` 不从 hidden global 获取，而是通过 `input_power` 显式传入 loss
+- 当 efficiency term 关闭时：
+  - `total_loss = mae_term`
+  - `efficiency_term = 0`
+  - `eta = None`
+
+sanity evidence：
+- 运行命令：
+  `python scripts/check_stage5_sr_loss.py --config configs/stage5/stage5_sr_loss.yaml`
+- 生成 summary：
+  [outputs/stage5/loss_sanity/stage5_sr_loss_summary.json](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/loss_sanity/stage5_sr_loss_summary.json)
+- 记录内容包括：
+  - `prediction_roi_shape = (2, 1, 96, 96)`
+  - `target_roi_shape = (2, 1, 96, 96)`
+  - `epsilon = 1e-8`
+  - `sigma_mode = per_sample`
+  - `gamma_by_depth = {1: 0.005, 3: 0.015, 5: 0.0}`
+  - `eta_scale = 100`
+  - `L=1/3/5` 下的 enabled/disabled loss、`mae_term`、`efficiency_term`、`sigma_mean`、`eta_mean`
+- sanity 结果显示：
+  - `L=1` 和 `L=3` 打开 efficiency term 后，总 loss 按预期增大
+  - `L=5` 因 `gamma = 0.0`，打开/关闭 efficiency term 的总 loss 不变，这是刻意保留的 Stage 5 policy，不是遗漏
+
+有意留给后续 issue 的未决项：
+- trainer 里具体从哪一个上游张量派生 `input_power` 仍留给 `5.6` 做窄集成；本 issue 只冻结 loss 接口，不写 trainer
+- smoke / main run 是否启用 efficiency term 作为运行策略，仍归 `5.9` / `5.10` 的 config 消费，不在这里扩成训练框架
+- dataset、distance mapping、phase range、crop/FOV semantics 不在本 issue 内重开
+
+已执行验证：
+- `python -m py_compile src/losses/stage5_sr_loss.py scripts/check_stage5_sr_loss.py`
+- `python scripts/check_stage5_sr_loss.py --config configs/stage5/stage5_sr_loss.yaml`
+
+推荐的 commit 三段式信息：
+
+```text
+feat(train | stage5-5): add paper-aligned sr loss
+
+why:
+freeze the stage5 loss contract before trainer work so sigma, eta, and
+gamma-by-depth are explicit, configurable, and no longer hidden inside
+historical stage4 reference scripts
+
+what:
+add a stage5 super-resolution loss module with normalized mae on
+I_out_roi, configurable efficiency penalty, explicit sigma and eta
+definitions, stage5 gamma_by_depth defaults including L=5, and a fake-
+batch sanity script with recorded toggle behavior
+```

--- a/docs/ai/prompt/stage5/prompt_stage5-6.md
+++ b/docs/ai/prompt/stage5/prompt_stage5-6.md
@@ -1,0 +1,257 @@
+You are working in a research-engineering repository for reproducing
+"Super-resolution image display using diffractive decoders".
+
+Your task is to complete GitHub Issue 5.6:
+
+Issue title:
+Implement Stage 5 paper-aligned trainer and configs
+
+This is a Stage-5-scoped trainer task.
+Do not turn it into a generic training framework, a Stage 6 sweep task, or an eval task.
+
+==================================================
+0. MUST-READ CONTEXT FIRST
+==================================================
+
+Before doing anything, you MUST read and follow these files in order:
+
+1. `AGENTS.md`
+2. `docs/ai/PROJECT_CONTEXT.md`
+3. `docs/plan/stage_plan/stage5/stage5_protocol_freeze.md`
+4. `docs/plan/stage_plan/stage5/stage5_plan.md`
+5. `docs/plan/stage_plan/stage5/stage5_issue_plan.md`
+6. `configs/stage5/stage5_emnist_display.yaml`
+7. `configs/stage5/stage5_optics_paper_aligned.yaml`
+8. `configs/stage5/stage5_paper_encoder.yaml`
+9. `configs/stage5/stage5_sr_loss.yaml`
+
+Then inspect these implementation-reference files before editing:
+
+10. `scripts/train_stage4_minimal.py`
+11. `src/datasets/target_adapter.py`
+12. `src/datasets/stage5_emnist_display.py`
+13. `src/models/hybrid/minimal_hybrid_wrapper.py`
+14. `src/models/encoders/paper_phase_encoder.py`
+15. `src/losses/stage5_sr_loss.py`
+
+Important scope rules:
+
+- If `paper_notes.md` is broader than the Stage 5 schedule, follow the Stage 5 docs.
+- For unresolved items, obey the ownership rules in `stage5_protocol_freeze.md`.
+- `5.2` through `5.5` already froze dataset / optics / encoder / loss defaults.
+  This trainer must consume them, not silently re-decide them.
+
+==================================================
+1. ISSUE 5.6 GOAL
+==================================================
+
+Implement a dedicated Stage 5 paper-aligned trainer that can run the current
+paper-path pipeline and save auditable artifacts.
+
+The result should provide a reproducible Stage 5 training path that:
+
+1. builds the Stage 5 dataset, encoder, decoder, and loss together
+2. supports separate optimizer parameter groups for encoder and decoder
+3. supports resume from checkpoint
+4. writes complete Stage 5 artifacts
+5. is suitable for short sanity runs now and smoke/main runs later
+
+==================================================
+2. NON-GOALS - DO NOT DRIFT
+==================================================
+
+Do NOT do any of the following:
+
+- do not turn this into a repo-wide training framework
+- do not fill `scripts/train.py` as a generic entrypoint
+- do not redesign the Stage 4 trainer for broad reuse
+- do not reopen dataset tiling, optics distances, phase range, gamma policy,
+  sigma policy, or crop semantics
+- do not build the Stage 5 eval runner here
+- do not add bicubic baseline or blind line-pair logic here
+- do not add Stage 6 sweeps, robustness, or quantization logic
+
+This issue is successful only if it lands a Stage-5-specific trainer path with
+clear configs and auditable artifacts.
+
+==================================================
+3. BRANCH EXPECTATION
+==================================================
+
+Suggested branch:
+- `feat/train`
+
+Stay on a training-oriented branch.
+Do not use this issue to modify `feat/eval` scope.
+
+==================================================
+4. REQUIRED INHERITANCE
+==================================================
+
+From `stage5_protocol_freeze.md`, this issue must inherit and obey:
+
+1. Frozen optical contract:
+   `phi_lr -> U0 -> U_out_full -> I_out_full -> I_out_roi`
+2. Stage 4 artifacts are regression baseline only
+3. The trainer must consume already frozen Stage 5 configs for:
+   - dataset
+   - optics
+   - encoder
+   - loss
+4. The trainer may add:
+   - resume support
+   - artifact saving
+   - Stage-5-specific config entrypoints
+5. The trainer must NOT finalize:
+   - tiling rules
+   - distance mapping
+   - phase range
+   - gamma policy
+   - sigma granularity
+   - crop semantics
+
+Important inheritance detail:
+
+- `Stage5SuperResolutionLoss` now requires explicit `input_power` when the
+  efficiency term is enabled.
+- This issue owns the narrow trainer-side wiring of that `input_power` input.
+- It does NOT own changing `eta` math or changing the loss contract.
+
+==================================================
+5. WHAT YOU ARE ALLOWED TO FINALIZE HERE
+==================================================
+
+This issue MAY finalize:
+
+1. the Stage 5 trainer script path and CLI/config interface
+2. the artifact directory structure for Stage 5 training runs
+3. the resume/checkpoint protocol
+4. the trainer-side source of `input_power` passed into the Stage 5 loss
+5. the short-run sanity configuration used to verify the trainer end to end
+
+This issue MUST keep the following explicit and auditable:
+
+1. encoder LR vs decoder LR
+2. whether the efficiency term is enabled for the run
+3. how `input_power` is sourced for the loss call
+4. where checkpoints, summaries, metrics, and previews are saved
+5. what is a short-run sanity config versus a later smoke/main config
+
+==================================================
+6. IMPLEMENTATION REQUIREMENTS
+==================================================
+
+Implement the smallest real Stage 5 trainer path needed for end-to-end sanity.
+
+Prefer a narrow Stage-5-specific structure such as:
+
+- `scripts/train_stage5_paper.py`
+- Stage 5 trainer config(s) under `configs/stage5/`
+- reuse of existing repo modules where helpful, without generalizing the repo
+
+The implementation should likely include:
+
+- Stage 5 dataset construction using the Stage 5 display dataset path
+- model assembly using the Stage 5 encoder + current diffractive decoder
+- ROI target adaptation using the existing target-adapter path or a very small
+  Stage-5-specific equivalent if strictly needed
+- Stage 5 loss wiring using `Stage5SuperResolutionLoss`
+- optimizer parameter groups with separate LR for encoder and decoder
+- checkpoint saving and resume loading
+- short-run artifact saving
+
+You must keep the script practical for later issues:
+
+- a short run should be able to complete now
+- later smoke/main issues should be able to reuse the trainer rather than rewrite it
+
+==================================================
+7. INPUT POWER WIRING REQUIREMENT
+==================================================
+
+Because `5.5` froze the loss interface but intentionally left trainer-side
+`input_power` sourcing to `5.6`, you must make that decision explicit here.
+
+You must:
+
+1. choose a concrete trainer-side source for per-sample `input_power`
+2. document that choice in config and/or run summary
+3. keep it narrow: consume existing forward-path tensors, do not redesign optics
+
+Do NOT:
+
+- hide `input_power` in a constant global without documentation
+- change `eta = 100 * P_o / P_i`
+- change the loss-side `output_power_source` silently
+
+==================================================
+8. REQUIRED ARTIFACTS
+==================================================
+
+You must produce enough artifacts to verify that the trainer path is real and inspectable.
+
+At minimum, provide:
+
+- a Stage 5 trainer script
+- Stage 5 trainer config entries
+- a short-run sanity output directory under `outputs/stage5/`
+- saved artifacts including:
+  - config snapshot
+  - run summary
+  - metrics history
+  - at least one checkpoint
+  - at least one preview artifact
+
+If the repo already has a preferred artifact style from Stage 4, reuse the good
+parts without turning this into a generalized framework.
+
+==================================================
+9. FILE SCOPE
+==================================================
+
+Primary files likely to be changed or added:
+
+- `scripts/train_stage5_paper.py`
+- Stage 5 trainer config(s) under `configs/stage5/`
+- small supporting integration code only if strictly needed
+
+Supporting edits are allowed in:
+
+- `src/models/hybrid/`
+- `src/datasets/`
+
+but only if they are narrow and directly required to make the Stage 5 trainer work.
+
+Avoid:
+
+- broad framework refactors
+- eval scripts
+- loss contract changes
+- optics contract changes
+
+==================================================
+10. ACCEPTANCE CRITERIA
+==================================================
+
+Issue 5.6 is complete only if:
+
+1. A short Stage 5 paper-path run completes successfully
+2. Encoder and decoder use separate optimizer parameter groups
+3. Resume works at least for a minimal checkpoint/restart path
+4. Expected artifacts are generated and logged
+5. The trainer remains Stage-5-specific rather than framework-generic
+6. No already-frozen Stage 5 policy is silently redefined here
+
+==================================================
+11. FINAL RESPONSE FORMAT
+==================================================
+
+After finishing, respond with:
+
+- short summary of what was implemented
+- exact files changed
+- how the trainer assembles dataset / model / loss
+- how `input_power` is sourced for the loss call
+- what artifacts are produced
+- what short-run sanity command was executed
+- what was intentionally left unresolved for later issues

--- a/scripts/check_stage5_sr_loss.py
+++ b/scripts/check_stage5_sr_loss.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python
+"""Stage 5 loss sanity for normalized MAE plus efficiency penalty."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+import torch
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.losses import Stage5SuperResolutionLoss
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        type=str,
+        default="configs/stage5/stage5_sr_loss.yaml",
+        help="Path to the Stage 5 loss YAML config.",
+    )
+    parser.add_argument(
+        "--output-root",
+        type=str,
+        default=None,
+        help="Optional override for the summary output directory.",
+    )
+    return parser.parse_args()
+
+
+def load_yaml_config(path: str) -> dict[str, Any]:
+    try:
+        import yaml  # type: ignore
+    except ImportError as exc:
+        raise RuntimeError("PyYAML is required to load the Stage 5 loss config.") from exc
+
+    with Path(path).open("r", encoding="utf-8") as file:
+        payload = yaml.safe_load(file) or {}
+    if not isinstance(payload, dict):
+        raise TypeError(f"Expected a mapping at YAML root, got {type(payload)!r}.")
+    return payload
+
+
+def make_fake_batch(batch_size: int, roi_hw: tuple[int, int]) -> tuple[torch.Tensor, torch.Tensor]:
+    height, width = roi_hw
+    y = torch.linspace(-1.0, 1.0, height, dtype=torch.float32)
+    x = torch.linspace(-1.0, 1.0, width, dtype=torch.float32)
+    yy, xx = torch.meshgrid(y, x, indexing="ij")
+
+    target_samples: list[torch.Tensor] = []
+    prediction_samples: list[torch.Tensor] = []
+    for sample_index in range(batch_size):
+        shift = 0.15 * sample_index
+        target = 0.03 + 0.02 * torch.exp(-((xx + 0.25 - shift) ** 2 + (yy - 0.10) ** 2) / 0.10)
+        target += 0.015 * torch.exp(-((xx - 0.30) ** 2 + (yy + 0.20 - shift) ** 2) / 0.08)
+        target += 0.010 * ((yy - 0.55 * xx).abs() < 0.10).to(torch.float32)
+
+        prediction = 0.82 * target
+        prediction += 0.006 * torch.cos((sample_index + 1) * math.pi * xx)
+        prediction += 0.004 * torch.sin((sample_index + 2) * math.pi * yy)
+        prediction = prediction.clamp_min(1e-4)
+
+        target_samples.append(target.unsqueeze(0))
+        prediction_samples.append(prediction.unsqueeze(0))
+
+    target_roi = torch.stack(target_samples, dim=0)
+    prediction_roi = torch.stack(prediction_samples, dim=0)
+    return prediction_roi, target_roi
+
+
+def assert_finite(name: str, tensor: torch.Tensor | None) -> None:
+    if tensor is None:
+        raise AssertionError(f"{name} must not be None.")
+    if not torch.isfinite(tensor).all():
+        raise AssertionError(f"{name} contains NaN or Inf values.")
+
+
+def build_loss(loss_config: dict[str, Any], *, enable_efficiency_term: bool) -> Stage5SuperResolutionLoss:
+    efficiency = loss_config["efficiency_term"]
+    return Stage5SuperResolutionLoss(
+        epsilon=float(loss_config["epsilon"]),
+        sigma_mode=str(loss_config["sigma_mode"]),
+        gamma_by_depth=efficiency["gamma_by_depth"],
+        enable_efficiency_term=enable_efficiency_term,
+        eta_scale=float(efficiency["eta_scale"]),
+    )
+
+
+def main() -> None:
+    args = parse_args()
+    config = load_yaml_config(args.config)
+    loss_config = config["loss"]["stage5_sr"]
+
+    torch.manual_seed(int(loss_config["sanity"]["seed"]))
+    roi_hw = tuple(int(v) for v in loss_config["sanity"]["roi_hw"])
+    batch_size = int(loss_config["sanity"]["batch_size"])
+    depths = [int(depth) for depth in loss_config["sanity"]["depths"]]
+
+    prediction_roi, target_roi = make_fake_batch(batch_size=batch_size, roi_hw=roi_hw)
+    input_power = torch.tensor([50000.0, 52000.0], dtype=torch.float32)
+    if batch_size != input_power.shape[0]:
+        raise AssertionError("Sanity input_power must match configured batch size.")
+
+    loss_enabled = build_loss(loss_config, enable_efficiency_term=True)
+    loss_disabled = build_loss(loss_config, enable_efficiency_term=False)
+
+    per_depth_summary: dict[str, Any] = {}
+    for depth in depths:
+        enabled = loss_enabled(
+            prediction_roi,
+            target_roi,
+            depth=depth,
+            input_power=input_power,
+        )
+        disabled = loss_disabled(
+            prediction_roi,
+            target_roi,
+            depth=depth,
+            input_power=None,
+        )
+
+        assert_finite("enabled.loss", enabled["loss"])
+        assert_finite("enabled.mae_term", enabled["mae_term"])
+        assert_finite("enabled.sigma", enabled["sigma"])
+        assert_finite("disabled.loss", disabled["loss"])
+        assert_finite("disabled.mae_term", disabled["mae_term"])
+        assert_finite("disabled.sigma", disabled["sigma"])
+        assert_finite("enabled.eta", enabled["eta"])
+
+        enabled_loss = float(enabled["loss"].item())
+        disabled_loss = float(disabled["loss"].item())
+        efficiency_term = float(enabled["efficiency_term"].item())
+        gamma = float(enabled["gamma"].item())
+        eta = enabled["eta"]
+        assert isinstance(eta, torch.Tensor)
+
+        if depth in (1, 3):
+            if efficiency_term <= 0.0:
+                raise AssertionError(f"Expected positive efficiency term for L={depth}, got {efficiency_term}.")
+            if abs(enabled_loss - disabled_loss) <= 1e-9:
+                raise AssertionError(f"Enabled and disabled losses should differ for L={depth}.")
+        if depth == 5:
+            if gamma != 0.0:
+                raise AssertionError(f"Stage 5 L=5 gamma must be explicit and currently 0.0, got {gamma}.")
+            if efficiency_term != 0.0:
+                raise AssertionError(f"Expected zero efficiency term for L=5 with gamma=0, got {efficiency_term}.")
+
+        per_depth_summary[str(depth)] = {
+            "gamma": gamma,
+            "enabled_loss": enabled_loss,
+            "disabled_loss": disabled_loss,
+            "mae_term": float(enabled["mae_term"].item()),
+            "efficiency_term": efficiency_term,
+            "sigma_mean": float(enabled["sigma"].mean().item()),
+            "eta_mean": float(eta.mean().item()),
+            "toggle_changes_total_loss": abs(enabled_loss - disabled_loss) > 1e-9,
+        }
+
+    output_root = Path(args.output_root or loss_config["sanity"]["output_root"])
+    output_root.mkdir(parents=True, exist_ok=True)
+    summary = {
+        "config_path": str(Path(args.config).as_posix()),
+        "loss": {
+            "epsilon": float(loss_config["epsilon"]),
+            "sigma_mode": str(loss_config["sigma_mode"]),
+            "aggregation": str(loss_config["aggregation"]),
+            "efficiency_term_enabled": bool(loss_config["efficiency_term"]["enabled"]),
+            "eta_scale": float(loss_config["efficiency_term"]["eta_scale"]),
+            "output_power_source": str(loss_config["efficiency_term"]["output_power_source"]),
+            "input_power_source": str(loss_config["efficiency_term"]["input_power_source"]),
+            "gamma_by_depth": {
+                str(key): float(value)
+                for key, value in loss_config["efficiency_term"]["gamma_by_depth"].items()
+            },
+        },
+        "observed": {
+            "prediction_roi_shape": list(prediction_roi.shape),
+            "target_roi_shape": list(target_roi.shape),
+            "input_power": [float(v) for v in input_power.tolist()],
+        },
+        "depths": per_depth_summary,
+    }
+    summary_path = output_root / "stage5_sr_loss_summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+
+    print("Stage 5 SR loss sanity passed.")
+    print(f"config={args.config}")
+    print(f"summary={summary_path.as_posix()}")
+    print(
+        f"prediction_roi_shape={tuple(prediction_roi.shape)} "
+        f"target_roi_shape={tuple(target_roi.shape)}"
+    )
+    for depth in depths:
+        depth_summary = per_depth_summary[str(depth)]
+        print(
+            f"L={depth} gamma={depth_summary['gamma']:.6f} "
+            f"enabled_loss={depth_summary['enabled_loss']:.6f} "
+            f"disabled_loss={depth_summary['disabled_loss']:.6f} "
+            f"efficiency_term={depth_summary['efficiency_term']:.6f} "
+            f"sigma_mean={depth_summary['sigma_mean']:.6f} "
+            f"eta_mean={depth_summary['eta_mean']:.6f}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/losses/__init__.py
+++ b/src/losses/__init__.py
@@ -1,0 +1,5 @@
+"""Loss modules used by the repo's training stack."""
+
+from src.losses.stage5_sr_loss import Stage5SuperResolutionLoss
+
+__all__ = ["Stage5SuperResolutionLoss"]

--- a/src/losses/stage5_sr_loss.py
+++ b/src/losses/stage5_sr_loss.py
@@ -1,0 +1,221 @@
+﻿"""Stage 5 paper-aligned super-resolution loss."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+
+def _non_batch_dims(tensor: torch.Tensor) -> tuple[int, ...]:
+    if tensor.ndim < 2:
+        raise ValueError(f"Expected tensor with at least 2 dims, got shape {tuple(tensor.shape)}.")
+    return tuple(range(1, tensor.ndim))
+
+
+def _validate_real_tensor(tensor: torch.Tensor, *, name: str) -> None:
+    if not isinstance(tensor, torch.Tensor):
+        raise TypeError(f"{name} must be a torch.Tensor, got {type(tensor)!r}.")
+    if tensor.is_complex():
+        raise ValueError(f"{name} must be real-valued, got dtype {tensor.dtype}.")
+
+
+def _normalize_gamma_by_depth(gamma_by_depth: Mapping[int | str, float] | None) -> dict[int, float]:
+    defaults = {1: 0.005, 3: 0.015, 5: 0.0}
+    if gamma_by_depth is None:
+        return defaults
+
+    normalized: dict[int, float] = {}
+    for key, value in gamma_by_depth.items():
+        depth = int(key)
+        normalized[depth] = float(value)
+
+    missing = sorted(set(defaults) - set(normalized))
+    if missing:
+        raise ValueError(f"gamma_by_depth is missing required depth keys: {missing}.")
+    return normalized
+
+
+def _normalize_batch_power(
+    value: torch.Tensor | float,
+    *,
+    batch_size: int,
+    device: torch.device,
+    dtype: torch.dtype,
+    name: str,
+) -> torch.Tensor:
+    if isinstance(value, (int, float)):
+        scalar = float(value)
+        if scalar <= 0.0:
+            raise ValueError(f"{name} must be positive, got {scalar}.")
+        return torch.full((batch_size,), scalar, device=device, dtype=dtype)
+
+    _validate_real_tensor(value, name=name)
+    tensor = value.to(device=device, dtype=dtype)
+    if tensor.ndim == 0:
+        scalar = float(tensor.item())
+        if scalar <= 0.0:
+            raise ValueError(f"{name} must be positive, got {scalar}.")
+        return torch.full((batch_size,), scalar, device=device, dtype=dtype)
+
+    if tensor.shape[0] != batch_size:
+        raise ValueError(
+            f"{name} batch dimension must match prediction batch size {batch_size}, got {tuple(tensor.shape)}."
+        )
+    flattened = tensor.reshape(batch_size, -1)
+    if flattened.shape[1] != 1:
+        raise ValueError(
+            f"{name} must be an already reduced per-sample power tensor, got shape {tuple(tensor.shape)}."
+        )
+    reduced = flattened[:, 0]
+    if (reduced <= 0.0).any():
+        raise ValueError(f"{name} must be positive for every sample, got {reduced}.")
+    return reduced
+
+
+class Stage5SuperResolutionLoss(nn.Module):
+    """Paper-aligned Stage 5 loss on the ROI path.
+
+    Target contract:
+      L = mean(|y - sigma * y_hat|) + gamma * exp(-eta)
+
+    with:
+      sigma = sum(y) / (sum(y_hat) + epsilon)
+      eta = 100 * P_o / P_i
+    """
+
+    VALID_SIGMA_MODES = ("per_sample", "per_batch")
+
+    def __init__(
+        self,
+        *,
+        epsilon: float = 1e-8,
+        sigma_mode: str = "per_sample",
+        gamma_by_depth: Mapping[int | str, float] | None = None,
+        enable_efficiency_term: bool = True,
+        eta_scale: float = 100.0,
+    ) -> None:
+        super().__init__()
+        if epsilon <= 0.0:
+            raise ValueError(f"epsilon must be positive, got {epsilon}.")
+        sigma_mode = str(sigma_mode)
+        if sigma_mode not in self.VALID_SIGMA_MODES:
+            raise ValueError(
+                f"sigma_mode must be one of {self.VALID_SIGMA_MODES}, got {sigma_mode!r}."
+            )
+        if eta_scale <= 0.0:
+            raise ValueError(f"eta_scale must be positive, got {eta_scale}.")
+
+        self.epsilon = float(epsilon)
+        self.sigma_mode = sigma_mode
+        self.gamma_by_depth = _normalize_gamma_by_depth(gamma_by_depth)
+        self.enable_efficiency_term = bool(enable_efficiency_term)
+        self.eta_scale = float(eta_scale)
+
+    def resolve_gamma(self, depth: int) -> float:
+        depth = int(depth)
+        if depth not in self.gamma_by_depth:
+            raise ValueError(
+                f"Unsupported depth {depth}; gamma_by_depth has keys {sorted(self.gamma_by_depth)}."
+            )
+        return self.gamma_by_depth[depth]
+
+    def compute_sigma(
+        self,
+        prediction_roi: torch.Tensor,
+        target_roi: torch.Tensor,
+    ) -> torch.Tensor:
+        reduce_dims = _non_batch_dims(prediction_roi)
+        if self.sigma_mode == "per_sample":
+            return target_roi.sum(dim=reduce_dims, keepdim=True) / (
+                prediction_roi.sum(dim=reduce_dims, keepdim=True) + self.epsilon
+            )
+
+        batch_scalar = target_roi.sum() / (prediction_roi.sum() + self.epsilon)
+        broadcast_shape = [1] * prediction_roi.ndim
+        return batch_scalar.reshape(*broadcast_shape)
+
+    def forward(
+        self,
+        prediction_roi: torch.Tensor,
+        target_roi: torch.Tensor,
+        *,
+        depth: int,
+        input_power: torch.Tensor | float | None = None,
+        output_power: torch.Tensor | float | None = None,
+    ) -> dict[str, Any]:
+        _validate_real_tensor(prediction_roi, name="prediction_roi")
+        _validate_real_tensor(target_roi, name="target_roi")
+        if prediction_roi.shape != target_roi.shape:
+            raise ValueError(
+                "prediction_roi and target_roi must match, "
+                f"got {tuple(prediction_roi.shape)} vs {tuple(target_roi.shape)}."
+            )
+
+        reduce_dims = _non_batch_dims(prediction_roi)
+        sigma = self.compute_sigma(prediction_roi, target_roi)
+        prediction_rescaled = sigma * prediction_roi
+        per_sample_mae = torch.mean(torch.abs(target_roi - prediction_rescaled), dim=reduce_dims)
+        mae_term = per_sample_mae.mean()
+
+        gamma_value = self.resolve_gamma(depth)
+        gamma = prediction_roi.new_tensor(gamma_value)
+        efficiency_term = prediction_roi.new_zeros(())
+        eta: torch.Tensor | None = None
+        output_power_tensor: torch.Tensor | None = None
+        input_power_tensor: torch.Tensor | None = None
+
+        if self.enable_efficiency_term:
+            batch_size = prediction_roi.shape[0]
+            if output_power is None:
+                output_power_tensor = prediction_roi.sum(dim=reduce_dims)
+            else:
+                output_power_tensor = _normalize_batch_power(
+                    output_power,
+                    batch_size=batch_size,
+                    device=prediction_roi.device,
+                    dtype=prediction_roi.dtype,
+                    name="output_power",
+                )
+
+            if input_power is None:
+                raise ValueError(
+                    "input_power must be provided when enable_efficiency_term=True."
+                )
+            input_power_tensor = _normalize_batch_power(
+                input_power,
+                batch_size=batch_size,
+                device=prediction_roi.device,
+                dtype=prediction_roi.dtype,
+                name="input_power",
+            )
+            eta = self.eta_scale * output_power_tensor / (input_power_tensor + self.epsilon)
+            efficiency_term = gamma * torch.exp(-eta).mean()
+
+        loss = mae_term + efficiency_term
+        return {
+            "loss": loss,
+            "mae_term": mae_term,
+            "efficiency_term": efficiency_term,
+            "sigma": sigma,
+            "eta": eta,
+            "gamma": gamma,
+            "input_power": input_power_tensor,
+            "output_power": output_power_tensor,
+            "prediction_rescaled": prediction_rescaled,
+        }
+
+    def extra_repr(self) -> str:
+        return (
+            f"epsilon={self.epsilon}, "
+            f"sigma_mode='{self.sigma_mode}', "
+            f"enable_efficiency_term={self.enable_efficiency_term}, "
+            f"eta_scale={self.eta_scale}, "
+            f"gamma_by_depth={self.gamma_by_depth}"
+        )
+
+
+__all__ = ["Stage5SuperResolutionLoss"]
+


### PR DESCRIPTION
why:
freeze the stage5 loss contract before trainer work so sigma, eta, and gamma-by-depth are explicit, configurable, and no longer hidden inside historical stage4 reference scripts

what:
add a stage5 super-resolution loss module with normalized mae on I_out_roi, configurable efficiency penalty, explicit sigma and eta definitions, stage5 gamma_by_depth defaults including L=5, and a fake- batch sanity script with recorded toggle behavior