### PR TITLE
feat(train | stage5-6): add stage5 paper trainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ More orders are listed in docs/run_order.md. Here are some frequently used comma
   `python scripts/check_stage5_encoder_integration.py --config configs/stage5/stage5_paper_encoder.yaml`
 - Validate Stage 5 paper-aligned SR loss:
   `python scripts/check_stage5_sr_loss.py --config configs/stage5/stage5_sr_loss.yaml`
+- Run the Stage 5 paper-aligned short trainer sanity:
+  `python scripts/train_stage5_paper.py --config configs/stage5/stage5_trainer_short.yaml`
 - Preview the Stage 5 Issue 5.2 EMNIST 96x96 display dataset:
-  `python scripts/preview_stage5_emnist_display.py --config docs/plan/stage_plan/stage5/stage5_emnist_display_config.yaml`
+  `python scripts/preview_stage5_emnist_display.py --config configs/stage5/stage5_emnist_display.yaml`
 

--- a/configs/stage5/stage5_trainer_short.yaml
+++ b/configs/stage5/stage5_trainer_short.yaml
@@ -1,0 +1,36 @@
+trainer:
+  stage5_paper:
+    mode: short_sanity
+    protocol_note: >
+      Short Stage 5 paper-path sanity run. This consumes the frozen Stage 5
+      dataset, optics, encoder, and loss configs without redefining them. The
+      reduced train/val subset sizes are a trainer-side short-run budget
+      choice, not a new dataset protocol.
+    output_root: outputs/stage5/paper_trainer
+    run_name: sanity_short
+    config_paths:
+      dataset: configs/stage5/stage5_emnist_display.yaml
+      optics: configs/stage5/stage5_optics_paper_aligned.yaml
+      encoder: configs/stage5/stage5_paper_encoder.yaml
+      loss: configs/stage5/stage5_sr_loss.yaml
+    runtime:
+      steps: 2
+      batch_size: 2
+      validate_every: 1
+      preview_limit: 2
+      seed: 56
+      device: cpu
+      num_workers: 0
+      download: false
+      train_shuffle: true
+    dataset_selection:
+      train_subset_size: 8
+      val_subset_size: 4
+    model:
+      depth: 1
+    optimizer:
+      name: Adam
+      lr_encoder: 0.0005
+      lr_decoder: 0.001
+    loss_wiring:
+      input_power_source: U0_full_grid_intensity_sum

--- a/docs/ai/CodexFeedback/stage5/feedback_stage5-6.md
+++ b/docs/ai/CodexFeedback/stage5/feedback_stage5-6.md
@@ -1,0 +1,81 @@
+实现了一个 Stage 5 专用的 paper-aligned trainer 路径，没有把它扩成通用训练框架。核心落地是新增 `scripts/train_stage5_paper.py`，并配套 `configs/stage5/stage5_trainer_short.yaml`，让当前仓库能把 `Stage 5 dataset + encoder + diffractive decoder + Stage5SuperResolutionLoss` 串起来跑一个可审计的短程训练与断点续跑。
+
+精确变更文件：
+- [scripts/train_stage5_paper.py](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/scripts/train_stage5_paper.py)
+- [configs/stage5/stage5_trainer_short.yaml](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/configs/stage5/stage5_trainer_short.yaml)
+- [README.md](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/README.md)
+
+trainer 组装方式：
+- dataset：复用 `build_stage5_emnist_display_dataset(...)`，显式消费 Stage 5 已冻结的 EMNIST `96x96` display protocol
+- target 适配：复用 `Stage4RoiTargetAdapter`，按 decoder 的 `readout_config.output_crop_hw` 生成 `target_roi`
+- model：直接组装 `PaperPhaseEncoder + DiffractiveDecoder`
+- loss：直接调用 `Stage5SuperResolutionLoss`
+- optimizer：显式分成两组 parameter groups
+  - encoder LR = `0.0005`
+  - decoder LR = `0.001`
+
+本次拍板的 trainer-side `input_power` 来源：
+- 选择 `U0_full_grid_intensity_sum`
+- 具体实现为：对 decoder `forward_from_phase(...)` 返回的 `U0` 计算 `|U0|^2`，再在所有非 batch 维上求和
+- 也就是：
+  - `input_power = sum(|U0|^2)` per sample
+- 这个选择已经同时写进：
+  - [stage5_trainer_short.yaml](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/configs/stage5/stage5_trainer_short.yaml)
+  - [config_snapshot.json](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/paper_trainer/issue5_6_resume_demo/config_snapshot.json)
+  - [run_summary.json](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/paper_trainer/issue5_6_resume_demo/run_summary.json)
+
+artifact 产物：
+- [config_snapshot.json](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/paper_trainer/issue5_6_resume_demo/config_snapshot.json)
+- [history.json](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/paper_trainer/issue5_6_resume_demo/history.json)
+- [grad_stats.json](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/paper_trainer/issue5_6_resume_demo/grad_stats.json)
+- [loss_curve.png](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/paper_trainer/issue5_6_resume_demo/loss_curve.png)
+- [preview_step0.png](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/paper_trainer/issue5_6_resume_demo/preview_step0.png)
+- [preview_best.png](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/paper_trainer/issue5_6_resume_demo/preview_best.png)
+- [preview_final.png](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/paper_trainer/issue5_6_resume_demo/preview_final.png)
+- [preview_resume_start.png](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/paper_trainer/issue5_6_resume_demo/preview_resume_start.png)
+- [phi_preview_step0.png](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/paper_trainer/issue5_6_resume_demo/phi_preview_step0.png)
+- [phi_preview_best.png](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/paper_trainer/issue5_6_resume_demo/phi_preview_best.png)
+- [phi_preview_final.png](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/paper_trainer/issue5_6_resume_demo/phi_preview_final.png)
+- [phi_preview_resume_start.png](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/paper_trainer/issue5_6_resume_demo/phi_preview_resume_start.png)
+- [checkpoint_latest.pt](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/paper_trainer/issue5_6_resume_demo/checkpoints/checkpoint_latest.pt)
+- [checkpoint_best.pt](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/paper_trainer/issue5_6_resume_demo/checkpoints/checkpoint_best.pt)
+
+本次执行的 short-run sanity 命令：
+- `python -m py_compile scripts/train_stage5_paper.py`
+- `python scripts/train_stage5_paper.py --config configs/stage5/stage5_trainer_short.yaml --run-name issue5_6_resume_demo --steps 1`
+- `python scripts/train_stage5_paper.py --config configs/stage5/stage5_trainer_short.yaml --run-name issue5_6_resume_demo --steps 2 --resume outputs/stage5/paper_trainer/issue5_6_resume_demo/checkpoints/checkpoint_latest.pt`
+
+sanity evidence：
+- short run 完成到 step 2，且 resume 成功从 step 1 续跑到 step 2
+- `history.json` 里保留了 step 1 和 step 2 两条记录
+- `run_summary.json` 记录了：
+  - `encoder_input = [2, 1, 96, 96]`
+  - `phi_lr = [2, 1, 32, 32]`
+  - `U0 = [2, 1, 400, 400]`
+  - `I_out_full = [2, 1, 400, 400]`
+  - `I_out_roi = [2, 1, 96, 96]`
+- `best_val_loss = 0.06892300397157669`
+- `final_val_loss = 0.06892351806163788`
+
+有意留给后续 issue 的未决项：
+- Stage 5 smoke run / main run 的正式训练步数、运行预算与实验排程，仍留给后续 smoke/main run issue
+- eval runner、PSNR/SSIM、bicubic baseline、blind line-pair protocol 仍不在本 issue 内实现
+- dataset tiling、optics distance mapping、phase range、gamma policy、sigma policy 都继续沿用 5.2 到 5.5 的冻结结果，这个 trainer 不重开它们
+
+推荐的 commit 三段式信息：
+
+```text
+feat(train | stage5-6): add stage5 paper trainer
+
+why:
+land a stage5-specific end-to-end trainer before smoke and main runs so
+the frozen dataset, optics, encoder, and loss configs can be consumed by
+a reproducible path with explicit resume and artifact behavior
+
+what:
+add a stage5 paper trainer script and short-run config, wire dataset,
+encoder, decoder, target adapter, and stage5 sr loss together, use
+U0_full_grid_intensity_sum as the explicit input_power source, and save
+checkpoints, history, summaries, and previews for sanity and resume
+validation
+```

--- a/docs/ai/prompt/stage5/prompt_stage5-7.md
+++ b/docs/ai/prompt/stage5/prompt_stage5-7.md
@@ -1,0 +1,270 @@
+You are working in a research-engineering repository for reproducing
+"Super-resolution image display using diffractive decoders".
+
+Your task is to complete GitHub Issue 5.7:
+
+Issue title:
+Add Stage 5 evaluation runner with bicubic baseline
+
+This is a Stage-5-scoped regular-eval task.
+Do not turn it into a blind-test task, a trainer refactor, or a Stage 6 study.
+
+==================================================
+0. MUST-READ CONTEXT FIRST
+==================================================
+
+Before doing anything, you MUST read and follow these files in order:
+
+1. `AGENTS.md`
+2. `docs/ai/PROJECT_CONTEXT.md`
+3. `docs/paper/paper_notes.md`
+4. `docs/plan/stage_plan/stage5/stage5_protocol_freeze.md`
+5. `docs/plan/stage_plan/stage5/stage5_plan.md`
+6. `docs/plan/stage_plan/stage5/stage5_issue_plan.md`
+7. `configs/stage5/stage5_emnist_display.yaml`
+8. `configs/stage5/stage5_optics_paper_aligned.yaml`
+9. `configs/stage5/stage5_paper_encoder.yaml`
+10. `configs/stage5/stage5_sr_loss.yaml`
+11. `configs/stage5/stage5_trainer_short.yaml`
+
+Then inspect these implementation-reference files before editing:
+
+12. `scripts/train_stage5_paper.py`
+13. `src/eval/metrics.py`
+14. `src/eval/evaluator.py`
+15. `src/datasets/stage5_emnist_display.py`
+16. `src/datasets/target_adapter.py`
+
+Important scope rules:
+
+- If `paper_notes.md` is broader than the Stage 5 schedule, follow the Stage 5 docs.
+- For unresolved items, obey the ownership rules in `stage5_protocol_freeze.md`.
+- This issue owns regular eval + bicubic baseline only.
+- Blind line-pair / resolution-target evaluation belongs to Issue 5.8, not here.
+
+==================================================
+1. ISSUE 5.7 GOAL
+==================================================
+
+Implement a Stage 5 regular evaluation path that can:
+
+1. load a Stage 5 paper-path checkpoint
+2. run reproducible val/test evaluation
+3. compute PSNR / SSIM
+4. compute and report a bicubic baseline
+5. save auditable eval artifacts and assumptions
+
+The result should provide a narrow, usable Stage 5 eval runner for later smoke
+and main-run reporting.
+
+==================================================
+2. NON-GOALS - DO NOT DRIFT
+==================================================
+
+Do NOT do any of the following:
+
+- do not add blind line-pair generation or reporting
+- do not redesign the Stage 5 trainer
+- do not reopen dataset tiling rules or split semantics
+- do not reopen optics distance mapping or crop/FOV semantics
+- do not reopen encoder phase range or loss policy
+- do not build a broad repo-wide evaluation framework
+- do not add Stage 6 sweeps, robustness, quantization, or ablation logic
+- do not silently change normalization or crop assumptions inside metric code
+
+This issue is successful only if it lands a narrow Stage-5 regular eval path
+with explicit bicubic-baseline behavior.
+
+==================================================
+3. BRANCH EXPECTATION
+==================================================
+
+Suggested branch:
+- `feat/eval`
+
+Stay on an evaluation-oriented branch.
+Do not use this issue to absorb trainer or blind-eval scope.
+
+==================================================
+4. REQUIRED INHERITANCE
+==================================================
+
+From `stage5_protocol_freeze.md`, this issue must inherit and obey:
+
+1. Frozen optical contract:
+   `phi_lr -> U0 -> U_out_full -> I_out_full -> I_out_roi`
+2. Stage 4 artifacts are regression baseline only.
+3. Issue 5.3 already froze crop / FOV alignment semantics.
+4. Issue 5.4 already froze the Stage 5 encoder-facing `phi_lr` size and phase path.
+5. Issue 5.5 already froze the loss-side Stage 5 defaults.
+6. Issue 5.6 already landed the Stage 5 trainer / checkpoint path.
+7. Issue 5.7 must consume those paths, not silently redefine them.
+
+Important inheritance detail:
+
+- Regular eval must compare predictions against the frozen ROI-aligned target path.
+- Crop size, crop origin, and normalization assumptions must be logged, not hidden.
+- Metric helpers already exist in `src/eval/metrics.py` and `src/eval/evaluator.py`.
+  Reuse them unless a very small extension is strictly needed.
+
+==================================================
+5. WHAT YOU ARE ALLOWED TO FINALIZE HERE
+==================================================
+
+This issue MAY finalize:
+
+1. the Stage 5 regular-eval script path and CLI/config interface
+2. the eval artifact directory structure under `outputs/stage5/`
+3. the exact reporting schema for PSNR / SSIM outputs
+4. the bicubic-baseline implementation details needed for reproducibility
+5. the explicit recorded assumptions for split / crop / normalization / baseline scale
+
+This issue MUST keep the following explicit and auditable:
+
+1. which checkpoint is evaluated
+2. which split is evaluated
+3. what tensor is scored against what target tensor
+4. how the bicubic baseline is generated
+5. whether anti-aliasing is enabled
+6. what crop / normalization assumptions were used
+
+This issue MUST NOT finalize:
+
+1. blind line-pair protocol
+2. new crop semantics
+3. new dataset split rules
+4. new trainer architecture
+
+==================================================
+6. IMPLEMENTATION REQUIREMENTS
+==================================================
+
+Implement the smallest real Stage 5 regular-eval path needed for smoke and
+main-run reporting.
+
+Prefer a narrow structure such as:
+
+- `scripts/eval_stage5_paper.py`
+- a Stage 5 eval config under `configs/stage5/` if helpful
+- small reusable helpers under `src/eval/` only if strictly needed
+
+The implementation should likely include:
+
+- checkpoint loading for the Stage 5 encoder + diffractive decoder path
+- Stage 5 dataset loading for `val` and/or `test`
+- ROI-aligned target generation using the frozen target-adapter semantics
+- metric computation using the existing PSNR / SSIM helpers
+- bicubic baseline generation with anti-aliasing
+- saved eval summary artifacts
+
+Do not broaden the repo's empty global eval entrypoints just because they exist.
+Keep this Stage-5-specific and practical.
+
+==================================================
+7. BICUBIC BASELINE REQUIREMENT
+==================================================
+
+The paper notes and Stage 5 docs require a bicubic baseline with anti-aliasing.
+
+You must make the baseline path explicit and reproducible.
+
+At minimum, record:
+
+1. the low-resolution spatial size or scale factor used by the baseline
+2. whether the baseline is implemented as downsample -> upsample
+3. where anti-aliasing is enabled
+4. the interpolation mode used in each step
+
+If the paper/docs do not justify one uniquely final baseline degradation path,
+do NOT fake certainty.
+
+Instead:
+
+- make the baseline resolution / scale configurable
+- pick a clear Stage 5 default
+- log that default in config and summary
+
+Do NOT:
+
+- use nearest-neighbor as the baseline
+- hide baseline resize assumptions in code without logging
+- silently choose a baseline crop that disagrees with the frozen ROI semantics
+
+==================================================
+8. REQUIRED ARTIFACTS
+==================================================
+
+You must produce enough artifacts to verify that the eval path is real and inspectable.
+
+At minimum, provide:
+
+- a Stage 5 eval script
+- any small Stage 5 eval config needed
+- an eval output directory under `outputs/stage5/`
+- a saved summary containing:
+  - checkpoint path
+  - evaluated split
+  - PSNR / SSIM for the model path
+  - PSNR / SSIM for the bicubic baseline
+  - crop / normalization assumptions
+  - bicubic baseline assumptions
+
+Prefer also saving a small preview artifact that makes comparison easy, such as:
+
+- input
+- target
+- model prediction
+- bicubic baseline
+- absolute-error views
+
+If the repo already has a good Stage 5 artifact style, reuse it.
+
+==================================================
+9. FILE SCOPE
+==================================================
+
+Primary files likely to be changed or added:
+
+- `scripts/eval_stage5_paper.py`
+- a Stage 5 eval config under `configs/stage5/`
+- narrow helper additions under `src/eval/` only if strictly needed
+
+Supporting edits are allowed in:
+
+- `README.md`
+
+but only if you add a new user-facing eval command that should be documented.
+
+Avoid:
+
+- trainer refactors
+- optics-core changes
+- dataset-protocol rewrites
+- blind-test code
+
+==================================================
+10. ACCEPTANCE CRITERIA
+==================================================
+
+Issue 5.7 is complete only if:
+
+1. A real Stage 5 regular eval path exists
+2. PSNR / SSIM can be computed on a Stage 5 split
+3. A bicubic baseline is computed reproducibly with anti-aliasing
+4. Metric outputs and evaluation assumptions are saved and inspectable
+5. The implementation stays separate from blind line-pair concerns
+6. No frozen Stage 5 crop / normalization semantics are silently changed
+
+==================================================
+11. FINAL RESPONSE FORMAT
+==================================================
+
+After finishing, respond with:
+
+- short summary of what was implemented
+- exact files changed
+- how the Stage 5 regular eval path works
+- how the bicubic baseline is generated
+- what command(s) were executed for sanity
+- what artifacts were produced
+- what was intentionally left for Issue 5.8

--- a/scripts/train_stage5_paper.py
+++ b/scripts/train_stage5_paper.py
@@ -1,0 +1,910 @@
+#!/usr/bin/env python
+"""Train the Stage 5 paper-aligned encoder + diffractive decoder pipeline."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import random
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+import yaml
+from torch.optim import Adam
+from torch.utils.data import DataLoader, Subset
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.datasets import Stage4RoiTargetAdapter, build_stage5_emnist_display_dataset
+from src.losses import Stage5SuperResolutionLoss
+from src.models.encoders import PaperPhaseEncoder
+from src.models.optics.diffractive_decoder import DiffractiveDecoder
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Train the Stage 5 paper-aligned super-resolution pipeline."
+    )
+    parser.add_argument("--config", type=str, required=True)
+    parser.add_argument("--run-name", type=str, default=None)
+    parser.add_argument("--steps", type=int, default=None)
+    parser.add_argument("--device", type=str, default=None)
+    parser.add_argument("--resume", type=str, default=None)
+    parser.add_argument("--preview-limit", type=int, default=None)
+    parser.add_argument("--download", action="store_true")
+    return parser.parse_args()
+
+
+def load_yaml(path: str | Path) -> dict[str, Any]:
+    with Path(path).open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle)
+    if not isinstance(data, dict):
+        raise TypeError(f"Config at {path} must load to a dict, got {type(data)!r}.")
+    return data
+
+
+def require_mapping(root: dict[str, Any], *keys: str) -> dict[str, Any]:
+    current: Any = root
+    for key in keys:
+        if not isinstance(current, dict) or key not in current:
+            raise KeyError(f"Missing config path: {'/'.join(keys)}")
+        current = current[key]
+    if not isinstance(current, dict):
+        raise TypeError(f"Config path {'/'.join(keys)} must be a mapping.")
+    return current
+
+
+def normalize_device(device_arg: str) -> torch.device:
+    normalized = device_arg.lower()
+    if normalized == "auto":
+        return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if normalized == "cuda" and not torch.cuda.is_available():
+        raise RuntimeError("Requested CUDA but it is not available.")
+    if normalized not in {"cpu", "cuda"}:
+        raise ValueError(f"Unsupported device value: {device_arg}.")
+    return torch.device(normalized)
+
+
+def set_seed(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+
+def save_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, ensure_ascii=False)
+
+
+def move_batch_to_device(batch: dict[str, Any], device: torch.device) -> dict[str, Any]:
+    moved: dict[str, Any] = {}
+    for key, value in batch.items():
+        if isinstance(value, torch.Tensor):
+            moved[key] = value.to(device, non_blocking=device.type == "cuda")
+        else:
+            moved[key] = value
+    return moved
+
+
+def _non_batch_dims(tensor: torch.Tensor) -> tuple[int, ...]:
+    return tuple(range(1, tensor.ndim))
+
+
+def _assert_finite(name: str, tensor: torch.Tensor) -> None:
+    if not torch.isfinite(tensor).all():
+        raise AssertionError(f"{name} contains NaN or Inf.")
+
+
+def collect_module_grad_stats(module: torch.nn.Module) -> dict[str, Any]:
+    trainable_tensor_count = 0
+    grad_tensor_count = 0
+    nonzero_grad_tensor_count = 0
+    mean_abs_values: list[float] = []
+    max_abs_value = 0.0
+    grad_l2_sq = 0.0
+
+    for parameter in module.parameters():
+        if not parameter.requires_grad:
+            continue
+        trainable_tensor_count += 1
+        grad = parameter.grad
+        if grad is None:
+            continue
+        grad_tensor_count += 1
+        grad_detached = grad.detach()
+        abs_grad = grad_detached.abs()
+        mean_abs = float(abs_grad.mean().item())
+        max_abs = float(abs_grad.max().item())
+        mean_abs_values.append(mean_abs)
+        max_abs_value = max(max_abs_value, max_abs)
+        grad_l2_sq += float(torch.sum(grad_detached.square()).item())
+        if max_abs > 0.0:
+            nonzero_grad_tensor_count += 1
+
+    return {
+        "trainable_tensor_count": trainable_tensor_count,
+        "grad_tensor_count": grad_tensor_count,
+        "nonzero_grad_tensor_count": nonzero_grad_tensor_count,
+        "has_any_grad": grad_tensor_count > 0,
+        "has_nonzero_grad": nonzero_grad_tensor_count > 0,
+        "mean_abs_grad": (
+            sum(mean_abs_values) / len(mean_abs_values) if mean_abs_values else 0.0
+        ),
+        "max_abs_grad": max_abs_value,
+        "l2_grad_norm": math.sqrt(grad_l2_sq),
+    }
+
+
+def build_dataset(
+    dataset_cfg: dict[str, Any],
+    *,
+    split: str,
+    download: bool,
+) -> Any:
+    return build_stage5_emnist_display_dataset(
+        split=split,
+        dataset_root=dataset_cfg["dataset_root"],
+        emnist_split=dataset_cfg["emnist_split"],
+        sample_count=int(dataset_cfg["sample_counts"][split]),
+        letter_count_choices=list(dataset_cfg["letter_count_choices"][split]),
+        seed=int(dataset_cfg["seed"]),
+        canvas_hw=tuple(dataset_cfg["canvas_hw"]),
+        cell_hw=tuple(dataset_cfg["cell_hw"]),
+        grid_shape=tuple(dataset_cfg["grid_shape"]),
+        augmentation=dataset_cfg["augmentation"][split],
+        fix_emnist_orientation=bool(dataset_cfg.get("fix_emnist_orientation", True)),
+        download=download,
+    )
+
+
+def maybe_subset(dataset: Any, subset_size: int | None) -> Any:
+    if subset_size is None:
+        return dataset
+    subset_size = int(subset_size)
+    if subset_size < 1:
+        raise ValueError("Subset size must be >= 1.")
+    if subset_size > len(dataset):
+        raise ValueError(f"Subset size {subset_size} exceeds dataset length {len(dataset)}.")
+    return Subset(dataset, list(range(subset_size)))
+
+
+def build_encoder_decoder(
+    encoder_cfg: dict[str, Any],
+    optics_cfg: dict[str, Any],
+    *,
+    depth: int,
+    device: torch.device,
+) -> tuple[PaperPhaseEncoder, DiffractiveDecoder]:
+    input_hw = tuple(encoder_cfg["target_hw"])
+    optics_input_hw = tuple(optics_cfg["grid"]["input_pattern_hw"])
+    if input_hw != optics_input_hw:
+        raise ValueError(
+            "Stage 5 encoder target_hw must match optics input_pattern_hw, "
+            f"got {input_hw} vs {optics_input_hw}."
+        )
+
+    encoder = PaperPhaseEncoder(
+        in_channels=int(encoder_cfg["in_channels"]),
+        input_hw=tuple(encoder_cfg["input_hw"]),
+        target_hw=input_hw,
+        base_channels=int(encoder_cfg["base_channels"]),
+        hidden_channels=int(encoder_cfg["hidden_channels"]),
+        interpolation_mode=str(encoder_cfg["interpolation_mode"]),
+        align_corners=bool(encoder_cfg["align_corners"]),
+        phase_mapping=str(encoder_cfg["phase_mapping"]),
+        phase_range=tuple(float(value) for value in encoder_cfg["phase_range"]),
+    ).to(device)
+
+    depth_cfg = optics_cfg["depths"][str(depth)]
+    decoder = DiffractiveDecoder(
+        num_diffractive_layers=int(depth_cfg["num_diffractive_layers"]),
+        wavelength=float(optics_cfg["units"]["wavelength"]),
+        pixel_pitch=float(optics_cfg["units"]["pixel_pitch_lambda"]),
+        grid_config=optics_cfg["grid"],
+        distance_schedule=depth_cfg["distance_schedule"],
+        readout_config={"output_crop_hw": optics_cfg["readout"]["output_crop_hw"]},
+        phase_mask_config=dict(optics_cfg.get("phase_mask_config", {})),
+    ).to(device)
+    return encoder, decoder
+
+
+def build_loss(loss_cfg: dict[str, Any], *, device: torch.device) -> Stage5SuperResolutionLoss:
+    efficiency_cfg = loss_cfg["efficiency_term"]
+    return Stage5SuperResolutionLoss(
+        epsilon=float(loss_cfg["epsilon"]),
+        sigma_mode=str(loss_cfg["sigma_mode"]),
+        gamma_by_depth=efficiency_cfg["gamma_by_depth"],
+        enable_efficiency_term=bool(efficiency_cfg["enabled"]),
+        eta_scale=float(efficiency_cfg["eta_scale"]),
+    ).to(device)
+
+
+def build_optimizer(
+    encoder: PaperPhaseEncoder,
+    decoder: DiffractiveDecoder,
+    trainer_cfg: dict[str, Any],
+) -> Adam:
+    encoder_params = [parameter for parameter in encoder.parameters() if parameter.requires_grad]
+    decoder_params = [parameter for parameter in decoder.parameters() if parameter.requires_grad]
+    if not encoder_params or not decoder_params:
+        raise RuntimeError("Stage 5 trainer expects both encoder and decoder to be trainable.")
+    return Adam(
+        [
+            {"params": encoder_params, "lr": float(trainer_cfg["optimizer"]["lr_encoder"])},
+            {"params": decoder_params, "lr": float(trainer_cfg["optimizer"]["lr_decoder"])},
+        ]
+    )
+
+
+def build_train_loader(
+    dataset: Any,
+    *,
+    batch_size: int,
+    num_workers: int,
+    shuffle: bool,
+    seed: int,
+    epoch: int,
+) -> DataLoader:
+    generator = torch.Generator()
+    generator.manual_seed(seed + epoch)
+    return DataLoader(
+        dataset,
+        batch_size=batch_size,
+        shuffle=shuffle,
+        num_workers=num_workers,
+        generator=generator if shuffle else None,
+    )
+
+
+def compute_input_power_from_u0(U0: torch.Tensor) -> torch.Tensor:
+    intensity = U0.real.square() + U0.imag.square()
+    return intensity.sum(dim=_non_batch_dims(intensity))
+
+
+def run_stage5_batch(
+    encoder: PaperPhaseEncoder,
+    decoder: DiffractiveDecoder,
+    loss_fn: Stage5SuperResolutionLoss,
+    batch: dict[str, Any],
+    *,
+    depth: int,
+    target_adapter: Stage4RoiTargetAdapter,
+    device: torch.device,
+) -> dict[str, Any]:
+    moved_batch = move_batch_to_device(batch, device)
+    x_hr = moved_batch["x_hr"]
+    target_hr = moved_batch["target_hr"]
+    if not isinstance(x_hr, torch.Tensor) or not isinstance(target_hr, torch.Tensor):
+        raise TypeError("Batch must contain tensor fields 'x_hr' and 'target_hr'.")
+
+    raw_phase = encoder.encode_raw_phase(x_hr)
+    phi_lr = encoder.map_raw_phase(raw_phase)
+    optical_output = decoder.forward_from_phase(phi_lr, return_intermediates=False)
+    target_roi = target_adapter(target_hr)
+    prediction_roi = optical_output["I_out_roi"]
+    U0 = optical_output["U0"]
+    if not isinstance(prediction_roi, torch.Tensor) or not isinstance(U0, torch.Tensor):
+        raise TypeError("Decoder output is missing tensor fields 'I_out_roi' or 'U0'.")
+
+    input_power = compute_input_power_from_u0(U0)
+    loss_dict = loss_fn(
+        prediction_roi,
+        target_roi,
+        depth=depth,
+        input_power=input_power,
+    )
+
+    _assert_finite("x_hr", x_hr)
+    _assert_finite("target_roi", target_roi)
+    _assert_finite("raw_phase", raw_phase)
+    _assert_finite("phi_lr", phi_lr)
+    _assert_finite("I_out_roi", prediction_roi)
+    _assert_finite("loss", loss_dict["loss"].reshape(1))
+
+    return {
+        "x_hr": x_hr,
+        "target_hr": target_hr,
+        "target_roi": target_roi,
+        "raw_phase": raw_phase,
+        "phi_lr": phi_lr,
+        "output": optical_output,
+        "pred_roi": prediction_roi,
+        "loss_dict": loss_dict,
+        "input_power": input_power,
+    }
+
+
+def summarize_batch_metrics(batch_output: dict[str, Any]) -> dict[str, float | None]:
+    loss_dict = batch_output["loss_dict"]
+    eta = loss_dict["eta"]
+    output_power = loss_dict["output_power"]
+    return {
+        "loss": float(loss_dict["loss"].item()),
+        "mae_term": float(loss_dict["mae_term"].item()),
+        "efficiency_term": float(loss_dict["efficiency_term"].item()),
+        "sigma_mean": float(loss_dict["sigma"].mean().item()),
+        "eta_mean": None if eta is None else float(eta.mean().item()),
+        "input_power_mean": float(batch_output["input_power"].mean().item()),
+        "output_power_mean": (
+            None if output_power is None else float(output_power.mean().item())
+        ),
+    }
+
+
+@torch.no_grad()
+def evaluate_loader(
+    encoder: PaperPhaseEncoder,
+    decoder: DiffractiveDecoder,
+    loss_fn: Stage5SuperResolutionLoss,
+    loader: DataLoader,
+    *,
+    depth: int,
+    target_adapter: Stage4RoiTargetAdapter,
+    device: torch.device,
+) -> dict[str, float | None]:
+    encoder.eval()
+    decoder.eval()
+    total_loss = 0.0
+    total_mae = 0.0
+    total_efficiency = 0.0
+    total_sigma = 0.0
+    total_eta = 0.0
+    total_input_power = 0.0
+    total_output_power = 0.0
+    eta_count = 0
+    output_power_count = 0
+    sample_count = 0
+
+    for batch in loader:
+        batch_output = run_stage5_batch(
+            encoder,
+            decoder,
+            loss_fn,
+            batch,
+            depth=depth,
+            target_adapter=target_adapter,
+            device=device,
+        )
+        metrics = summarize_batch_metrics(batch_output)
+        batch_size = batch_output["x_hr"].shape[0]
+        total_loss += metrics["loss"] * batch_size
+        total_mae += metrics["mae_term"] * batch_size
+        total_efficiency += metrics["efficiency_term"] * batch_size
+        total_sigma += metrics["sigma_mean"] * batch_size
+        total_input_power += metrics["input_power_mean"] * batch_size
+        if metrics["eta_mean"] is not None:
+            total_eta += float(metrics["eta_mean"]) * batch_size
+            eta_count += batch_size
+        if metrics["output_power_mean"] is not None:
+            total_output_power += float(metrics["output_power_mean"]) * batch_size
+            output_power_count += batch_size
+        sample_count += batch_size
+
+    if sample_count < 1:
+        raise RuntimeError("Validation loader is empty.")
+
+    return {
+        "val_loss": total_loss / sample_count,
+        "val_mae_term": total_mae / sample_count,
+        "val_efficiency_term": total_efficiency / sample_count,
+        "val_sigma_mean": total_sigma / sample_count,
+        "val_eta_mean": None if eta_count == 0 else total_eta / eta_count,
+        "val_input_power_mean": total_input_power / sample_count,
+        "val_output_power_mean": (
+            None if output_power_count == 0 else total_output_power / output_power_count
+        ),
+    }
+
+
+def _to_gray_numpy(image: torch.Tensor) -> np.ndarray:
+    tensor = image.detach().cpu().float()
+    if tensor.ndim == 2:
+        return tensor.numpy()
+    if tensor.ndim == 3 and tensor.shape[0] == 1:
+        return tensor[0].numpy()
+    raise ValueError(f"Expected grayscale tensor, got shape {tuple(tensor.shape)}.")
+
+
+def save_preview_grid(output_path: Path, batch_output: dict[str, Any], *, preview_limit: int) -> None:
+    row_count = min(preview_limit, batch_output["x_hr"].shape[0])
+    x_hr = batch_output["x_hr"][:row_count].detach().cpu()
+    target_roi = batch_output["target_roi"][:row_count].detach().cpu()
+    pred_roi = batch_output["pred_roi"][:row_count].detach().cpu()
+    abs_error = torch.abs(target_roi - pred_roi)
+
+    fig, axes = plt.subplots(row_count, 4, figsize=(12, max(3.0, 3.0 * row_count)))
+    if row_count == 1:
+        axes = np.expand_dims(axes, axis=0)
+
+    titles = ("x_hr", "target_roi", "pred_roi", "abs_error")
+    for row_index in range(row_count):
+        panels = (
+            _to_gray_numpy(x_hr[row_index]),
+            _to_gray_numpy(target_roi[row_index]),
+            _to_gray_numpy(pred_roi[row_index]),
+            _to_gray_numpy(abs_error[row_index]),
+        )
+        ranges = (
+            (0.0, 1.0),
+            (0.0, 1.0),
+            (0.0, 1.0),
+            (0.0, float(abs_error.max().item()) + 1e-8),
+        )
+        for col_index, axis in enumerate(axes[row_index]):
+            vmin, vmax = ranges[col_index]
+            axis.imshow(panels[col_index], cmap="gray", vmin=vmin, vmax=vmax)
+            if row_index == 0:
+                axis.set_title(titles[col_index])
+            axis.axis("off")
+    fig.tight_layout()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output_path, dpi=180, bbox_inches="tight")
+    plt.close(fig)
+
+
+def save_phase_preview(output_path: Path, batch_output: dict[str, Any], *, preview_limit: int) -> None:
+    row_count = min(preview_limit, batch_output["phi_lr"].shape[0])
+    raw_phase = batch_output["raw_phase"][:row_count].detach().cpu()
+    phi_lr = batch_output["phi_lr"][:row_count].detach().cpu()
+
+    fig, axes = plt.subplots(row_count, 2, figsize=(6, max(3.0, 3.0 * row_count)))
+    if row_count == 1:
+        axes = np.expand_dims(axes, axis=0)
+
+    for row_index in range(row_count):
+        panels = (
+            _to_gray_numpy(raw_phase[row_index]),
+            _to_gray_numpy(phi_lr[row_index]),
+        )
+        ranges = (
+            (float(raw_phase.min().item()), float(raw_phase.max().item())),
+            (float(phi_lr.min().item()), float(phi_lr.max().item())),
+        )
+        for col_index, axis in enumerate(axes[row_index]):
+            vmin, vmax = ranges[col_index]
+            axis.imshow(panels[col_index], cmap="viridis", vmin=vmin, vmax=vmax)
+            if row_index == 0:
+                axis.set_title(("raw_phase", "phi_lr")[col_index])
+            axis.axis("off")
+    fig.tight_layout()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output_path, dpi=180, bbox_inches="tight")
+    plt.close(fig)
+
+
+def save_loss_curve(output_path: Path, history: list[dict[str, Any]]) -> None:
+    train_steps = [entry["step"] for entry in history]
+    train_loss = [entry["train_loss"] for entry in history]
+    val_points = [
+        (entry["step"], entry["val_loss"]) for entry in history if entry["val_loss"] is not None
+    ]
+
+    fig, axis = plt.subplots(figsize=(7, 4))
+    axis.plot(train_steps, train_loss, label="train_loss", color="tab:blue", marker="o")
+    if val_points:
+        axis.plot(
+            [item[0] for item in val_points],
+            [item[1] for item in val_points],
+            label="val_loss",
+            color="tab:orange",
+            marker="s",
+        )
+    axis.set_xlabel("step")
+    axis.set_ylabel("loss")
+    axis.set_title("Stage 5 Trainer Loss History")
+    axis.grid(True, alpha=0.3)
+    axis.legend()
+    fig.tight_layout()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output_path, dpi=180, bbox_inches="tight")
+    plt.close(fig)
+
+
+def save_checkpoint(
+    path: Path,
+    *,
+    step: int,
+    steps_per_epoch: int,
+    best_val_loss: float,
+    best_step: int | None,
+    history: list[dict[str, Any]],
+    grad_history: list[dict[str, Any]],
+    encoder: PaperPhaseEncoder,
+    decoder: DiffractiveDecoder,
+    optimizer: Adam,
+    config_snapshot: dict[str, Any],
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    torch.save(
+        {
+            "step": step,
+            "steps_per_epoch": steps_per_epoch,
+            "best_val_loss": best_val_loss,
+            "best_step": best_step,
+            "history": history,
+            "grad_stats_history": grad_history,
+            "encoder_state_dict": encoder.state_dict(),
+            "decoder_state_dict": decoder.state_dict(),
+            "optimizer_state_dict": optimizer.state_dict(),
+            "config_snapshot": config_snapshot,
+        },
+        path,
+    )
+
+
+def main() -> None:
+    args = parse_args()
+    trainer_root = load_yaml(args.config)
+    trainer_cfg = require_mapping(trainer_root, "trainer", "stage5_paper")
+    dataset_cfg = require_mapping(
+        load_yaml(trainer_cfg["config_paths"]["dataset"]), "data", "stage5_display"
+    )
+    optics_cfg = require_mapping(
+        load_yaml(trainer_cfg["config_paths"]["optics"]), "optics", "stage5_paper_aligned"
+    )
+    encoder_cfg = require_mapping(
+        load_yaml(trainer_cfg["config_paths"]["encoder"]), "encoder", "stage5_paper_aligned"
+    )
+    loss_cfg = require_mapping(load_yaml(trainer_cfg["config_paths"]["loss"]), "loss", "stage5_sr")
+
+    runtime_cfg = dict(trainer_cfg["runtime"])
+    total_steps = int(args.steps if args.steps is not None else runtime_cfg["steps"])
+    if total_steps < 1:
+        raise ValueError("Total steps must be >= 1.")
+    preview_limit = int(
+        args.preview_limit if args.preview_limit is not None else runtime_cfg["preview_limit"]
+    )
+    if preview_limit < 1:
+        raise ValueError("preview_limit must be >= 1.")
+
+    device = normalize_device(str(args.device or runtime_cfg["device"]))
+    seed = int(runtime_cfg["seed"])
+    set_seed(seed)
+    depth = int(trainer_cfg["model"]["depth"])
+
+    output_root = Path(trainer_cfg["output_root"])
+    if args.resume:
+        checkpoint_path = Path(args.resume)
+        run_dir = checkpoint_path.parent.parent
+        run_name = run_dir.name
+    else:
+        run_name = args.run_name or trainer_cfg.get("run_name") or datetime.now(
+            timezone.utc
+        ).strftime("%Y%m%dT%H%M%SZ")
+        run_dir = output_root / run_name
+
+    download = bool(args.download or runtime_cfg.get("download", False))
+    train_base = build_dataset(dataset_cfg, split="train", download=download)
+    val_base = build_dataset(dataset_cfg, split="val", download=download)
+    train_dataset = maybe_subset(
+        train_base, trainer_cfg.get("dataset_selection", {}).get("train_subset_size")
+    )
+    val_dataset = maybe_subset(
+        val_base, trainer_cfg.get("dataset_selection", {}).get("val_subset_size")
+    )
+
+    encoder, decoder = build_encoder_decoder(
+        encoder_cfg,
+        optics_cfg,
+        depth=depth,
+        device=device,
+    )
+    target_adapter = Stage4RoiTargetAdapter(output_crop_hw=decoder.readout_config)
+    loss_fn = build_loss(loss_cfg, device=device)
+    optimizer = build_optimizer(encoder, decoder, trainer_cfg)
+
+    batch_size = int(runtime_cfg["batch_size"])
+    num_workers = int(runtime_cfg["num_workers"])
+    train_shuffle = bool(runtime_cfg["train_shuffle"])
+    steps_per_epoch = math.ceil(len(train_dataset) / batch_size)
+    validate_every = int(runtime_cfg["validate_every"])
+
+    config_snapshot = {
+        "trainer_config_path": str(Path(args.config).resolve()),
+        "mode": trainer_cfg["mode"],
+        "protocol_note": trainer_cfg["protocol_note"],
+        "run_name": run_name,
+        "depth": depth,
+        "device": str(device),
+        "runtime": {
+            **runtime_cfg,
+            "steps": total_steps,
+            "preview_limit": preview_limit,
+            "download": download,
+        },
+        "optimizer": trainer_cfg["optimizer"],
+        "optimizer_parameter_groups": [
+            {"name": "encoder", "lr": float(trainer_cfg["optimizer"]["lr_encoder"])},
+            {"name": "decoder", "lr": float(trainer_cfg["optimizer"]["lr_decoder"])},
+        ],
+        "loss_wiring": {
+            **trainer_cfg["loss_wiring"],
+            "implemented_formula": "input_power = sum(|U0|^2) over full propagation grid per sample",
+            "efficiency_enabled": bool(loss_cfg["efficiency_term"]["enabled"]),
+        },
+        "dataset_protocol": {
+            "train": train_base.get_protocol_summary(),
+            "val": val_base.get_protocol_summary(),
+            "train_subset_size": len(train_dataset),
+            "val_subset_size": len(val_dataset),
+            "subset_note": (
+                "Subset sizes are short-run trainer budget choices only; "
+                "they do not redefine the Stage 5 dataset protocol."
+            ),
+        },
+        "optics_config": optics_cfg,
+        "encoder_config": encoder_cfg,
+        "loss_config": loss_cfg,
+        "resume_from": None if not args.resume else str(Path(args.resume).resolve()),
+        "created_at_utc": datetime.now(timezone.utc).isoformat(),
+    }
+
+    history: list[dict[str, Any]] = []
+    grad_history: list[dict[str, Any]] = []
+    best_val_loss = math.inf
+    best_step: int | None = None
+    start_step = 0
+
+    if args.resume:
+        checkpoint = torch.load(args.resume, map_location=device)
+        encoder.load_state_dict(checkpoint["encoder_state_dict"])
+        decoder.load_state_dict(checkpoint["decoder_state_dict"])
+        optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
+        start_step = int(checkpoint["step"])
+        best_val_loss = float(checkpoint.get("best_val_loss", math.inf))
+        best_step = checkpoint.get("best_step")
+        history = list(checkpoint.get("history", []))
+        grad_history = list(checkpoint.get("grad_stats_history", []))
+
+    run_dir.mkdir(parents=True, exist_ok=True)
+    save_json(run_dir / "config_snapshot.json", config_snapshot)
+
+    val_loader = DataLoader(val_dataset, batch_size=batch_size, shuffle=False, num_workers=num_workers)
+    preview_batch = next(iter(val_loader))
+    encoder.eval()
+    decoder.eval()
+    with torch.no_grad():
+        preview_output = run_stage5_batch(
+            encoder,
+            decoder,
+            loss_fn,
+            preview_batch,
+            depth=depth,
+            target_adapter=target_adapter,
+            device=device,
+        )
+    if args.resume:
+        save_preview_grid(run_dir / "preview_resume_start.png", preview_output, preview_limit=preview_limit)
+        save_phase_preview(
+            run_dir / "phi_preview_resume_start.png",
+            preview_output,
+            preview_limit=preview_limit,
+        )
+    else:
+        save_preview_grid(run_dir / "preview_step0.png", preview_output, preview_limit=preview_limit)
+        save_phase_preview(run_dir / "phi_preview_step0.png", preview_output, preview_limit=preview_limit)
+
+    latest_checkpoint_path = run_dir / "checkpoints" / "checkpoint_latest.pt"
+    best_checkpoint_path = run_dir / "checkpoints" / "checkpoint_best.pt"
+
+    current_epoch = start_step // steps_per_epoch
+    step_in_epoch = start_step % steps_per_epoch
+    train_loader = build_train_loader(
+        train_dataset,
+        batch_size=batch_size,
+        num_workers=num_workers,
+        shuffle=train_shuffle,
+        seed=seed,
+        epoch=current_epoch,
+    )
+    train_iterator = iter(train_loader)
+    for _ in range(step_in_epoch):
+        next(train_iterator)
+
+    global_step = start_step
+    while global_step < total_steps:
+        try:
+            batch = next(train_iterator)
+        except StopIteration:
+            current_epoch += 1
+            train_loader = build_train_loader(
+                train_dataset,
+                batch_size=batch_size,
+                num_workers=num_workers,
+                shuffle=train_shuffle,
+                seed=seed,
+                epoch=current_epoch,
+            )
+            train_iterator = iter(train_loader)
+            batch = next(train_iterator)
+
+        encoder.train()
+        decoder.train()
+        optimizer.zero_grad(set_to_none=True)
+        batch_output = run_stage5_batch(
+            encoder,
+            decoder,
+            loss_fn,
+            batch,
+            depth=depth,
+            target_adapter=target_adapter,
+            device=device,
+        )
+        loss = batch_output["loss_dict"]["loss"]
+        loss.backward()
+
+        encoder_grad = collect_module_grad_stats(encoder)
+        decoder_grad = collect_module_grad_stats(decoder)
+        optimizer.step()
+        global_step += 1
+
+        train_metrics = summarize_batch_metrics(batch_output)
+        history_entry: dict[str, Any] = {
+            "step": global_step,
+            "epoch": current_epoch,
+            "train_loss": train_metrics["loss"],
+            "train_mae_term": train_metrics["mae_term"],
+            "train_efficiency_term": train_metrics["efficiency_term"],
+            "train_sigma_mean": train_metrics["sigma_mean"],
+            "train_eta_mean": train_metrics["eta_mean"],
+            "train_input_power_mean": train_metrics["input_power_mean"],
+            "train_output_power_mean": train_metrics["output_power_mean"],
+            "val_loss": None,
+            "val_mae_term": None,
+            "val_efficiency_term": None,
+            "val_sigma_mean": None,
+            "val_eta_mean": None,
+        }
+        history.append(history_entry)
+        grad_history.append(
+            {
+                "step": global_step,
+                "encoder": encoder_grad,
+                "decoder": decoder_grad,
+            }
+        )
+
+        if global_step % validate_every == 0 or global_step == total_steps:
+            val_metrics = evaluate_loader(
+                encoder,
+                decoder,
+                loss_fn,
+                val_loader,
+                depth=depth,
+                target_adapter=target_adapter,
+                device=device,
+            )
+            history_entry.update(val_metrics)
+            if float(val_metrics["val_loss"]) < best_val_loss:
+                best_val_loss = float(val_metrics["val_loss"])
+                best_step = global_step
+                with torch.no_grad():
+                    best_preview = run_stage5_batch(
+                        encoder,
+                        decoder,
+                        loss_fn,
+                        preview_batch,
+                        depth=depth,
+                        target_adapter=target_adapter,
+                        device=device,
+                    )
+                save_preview_grid(run_dir / "preview_best.png", best_preview, preview_limit=preview_limit)
+                save_phase_preview(
+                    run_dir / "phi_preview_best.png",
+                    best_preview,
+                    preview_limit=preview_limit,
+                )
+                save_checkpoint(
+                    best_checkpoint_path,
+                    step=global_step,
+                    steps_per_epoch=steps_per_epoch,
+                    best_val_loss=best_val_loss,
+                    best_step=best_step,
+                    history=history,
+                    grad_history=grad_history,
+                    encoder=encoder,
+                    decoder=decoder,
+                    optimizer=optimizer,
+                    config_snapshot=config_snapshot,
+                )
+
+        save_checkpoint(
+            latest_checkpoint_path,
+            step=global_step,
+            steps_per_epoch=steps_per_epoch,
+            best_val_loss=best_val_loss,
+            best_step=best_step,
+            history=history,
+            grad_history=grad_history,
+            encoder=encoder,
+            decoder=decoder,
+            optimizer=optimizer,
+            config_snapshot=config_snapshot,
+        )
+
+    encoder.eval()
+    decoder.eval()
+    with torch.no_grad():
+        final_preview = run_stage5_batch(
+            encoder,
+            decoder,
+            loss_fn,
+            preview_batch,
+            depth=depth,
+            target_adapter=target_adapter,
+            device=device,
+        )
+    save_preview_grid(run_dir / "preview_final.png", final_preview, preview_limit=preview_limit)
+    save_phase_preview(run_dir / "phi_preview_final.png", final_preview, preview_limit=preview_limit)
+
+    save_json(run_dir / "history.json", history)
+    save_json(run_dir / "grad_stats.json", grad_history)
+    save_loss_curve(run_dir / "loss_curve.png", history)
+
+    run_summary = {
+        "mode": trainer_cfg["mode"],
+        "run_name": run_name,
+        "completed_steps": global_step,
+        "steps_per_epoch": steps_per_epoch,
+        "depth": depth,
+        "device": str(device),
+        "optimizer_parameter_groups": config_snapshot["optimizer_parameter_groups"],
+        "input_power_source": config_snapshot["loss_wiring"]["input_power_source"],
+        "input_power_formula": config_snapshot["loss_wiring"]["implemented_formula"],
+        "efficiency_term_enabled": config_snapshot["loss_wiring"]["efficiency_enabled"],
+        "best_val_loss": None if best_step is None else best_val_loss,
+        "best_step": best_step,
+        "final_train_loss": history[-1]["train_loss"],
+        "final_val_loss": history[-1]["val_loss"],
+        "output_shapes": {
+            "encoder_input": list(final_preview["x_hr"].shape),
+            "phi_lr": list(final_preview["phi_lr"].shape),
+            "U0": list(final_preview["output"]["U0"].shape),
+            "I_out_full": list(final_preview["output"]["I_out_full"].shape),
+            "I_out_roi": list(final_preview["pred_roi"].shape),
+        },
+        "artifacts": {
+            "config_snapshot": str((run_dir / "config_snapshot.json").resolve()),
+            "history": str((run_dir / "history.json").resolve()),
+            "grad_stats": str((run_dir / "grad_stats.json").resolve()),
+            "loss_curve": str((run_dir / "loss_curve.png").resolve()),
+            "preview_best": str((run_dir / "preview_best.png").resolve()),
+            "preview_final": str((run_dir / "preview_final.png").resolve()),
+            "phi_preview_best": str((run_dir / "phi_preview_best.png").resolve()),
+            "phi_preview_final": str((run_dir / "phi_preview_final.png").resolve()),
+            "checkpoint_latest": str(latest_checkpoint_path.resolve()),
+            "checkpoint_best": str(best_checkpoint_path.resolve()),
+        },
+    }
+    if (run_dir / "preview_step0.png").exists():
+        run_summary["artifacts"]["preview_step0"] = str((run_dir / "preview_step0.png").resolve())
+        run_summary["artifacts"]["phi_preview_step0"] = str(
+            (run_dir / "phi_preview_step0.png").resolve()
+        )
+    if (run_dir / "preview_resume_start.png").exists():
+        run_summary["artifacts"]["preview_resume_start"] = str(
+            (run_dir / "preview_resume_start.png").resolve()
+        )
+        run_summary["artifacts"]["phi_preview_resume_start"] = str(
+            (run_dir / "phi_preview_resume_start.png").resolve()
+        )
+
+    save_json(run_dir / "run_summary.json", run_summary)
+    print(json.dumps(run_summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
why:
land a stage5-specific end-to-end trainer before smoke and main runs so the frozen dataset, optics, encoder, and loss configs can be consumed by a reproducible path with explicit resume and artifact behavior

what:
add a stage5 paper trainer script and short-run config, wire dataset, encoder, decoder, target adapter, and stage5 sr loss together, use U0_full_grid_intensity_sum as the explicit input_power source, and save checkpoints, history, summaries, and previews for sanity and resume validation