### PR TITLE
feat(eval | stage5-7): add stage5 regular eval runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ More orders are listed in docs/run_order.md. Here are some frequently used comma
   `python scripts/check_stage5_sr_loss.py --config configs/stage5/stage5_sr_loss.yaml`
 - Run the Stage 5 paper-aligned short trainer sanity:
   `python scripts/train_stage5_paper.py --config configs/stage5/stage5_trainer_short.yaml`
+- Run the Stage 5 regular eval with bicubic baseline:
+  `python scripts/eval_stage5_paper.py --config configs/stage5/stage5_eval.yaml --checkpoint outputs/stage5/paper_trainer/issue5_6_resume_demo/checkpoints/checkpoint_best.pt --split val`
 - Preview the Stage 5 Issue 5.2 EMNIST 96x96 display dataset:
   `python scripts/preview_stage5_emnist_display.py --config configs/stage5/stage5_emnist_display.yaml`
 

--- a/configs/stage5/stage5_eval.yaml
+++ b/configs/stage5/stage5_eval.yaml
@@ -1,0 +1,29 @@
+eval:
+  stage5_paper:
+    output_root: outputs/stage5/eval
+    run_name: null
+    dataset_config_path: configs/stage5/stage5_emnist_display.yaml
+    runtime:
+      split: val
+      batch_size: 2
+      num_workers: 0
+      seed: 57
+      device: cpu
+      download: false
+      subset_size: null
+      preview_limit: 4
+    bicubic_baseline:
+      note: >
+        Stage 5 default bicubic baseline uses a downsample-then-upsample path
+        from the ROI-aligned target, with anti-aliasing enabled on the
+        downsample step. The 32x32 LR size matches the current Stage 5
+        encoder/optics alignment default, not paper-unique truth.
+      source_tensor: target_roi
+      input_lr_hw: [32, 32]
+      scale_factor: 3
+      implementation: downsample_then_upsample
+      downsample_mode: bicubic
+      upsample_mode: bicubic
+      align_corners: false
+      antialias_downsample: true
+      antialias_upsample: false

--- a/docs/ai/CodexFeedback/stage5/feedback_stage5-7.md
+++ b/docs/ai/CodexFeedback/stage5/feedback_stage5-7.md
@@ -1,0 +1,75 @@
+实现了一个 Stage 5 专用 regular eval 路径，职责只覆盖 `PSNR / SSIM + bicubic baseline`，没有把 blind line-pair、trainer refactor 或 Stage 6 对比实验掺进来。核心落地是新增 `scripts/eval_stage5_paper.py` 与 `configs/stage5/stage5_eval.yaml`，并让它能够直接加载 `5.6` 的 checkpoint、复用冻结的 ROI target 语义、输出可审计的 summary 与 preview artifact。
+
+精确变更文件：
+- [scripts/eval_stage5_paper.py](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/scripts/eval_stage5_paper.py)
+- [configs/stage5/stage5_eval.yaml](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/configs/stage5/stage5_eval.yaml)
+- [README.md](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/README.md)
+
+Stage 5 regular eval 路径如何工作：
+- 从 `--checkpoint` 加载 `5.6` 训练器保存的 `encoder_state_dict`、`decoder_state_dict` 和 `config_snapshot`
+- 用 checkpoint 内嵌的 `encoder_config / optics_config / depth` 还原模型，不依赖外部 trainer refactor
+- 从 [stage5_emnist_display.yaml](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/configs/stage5/stage5_emnist_display.yaml) 构造 `val` 或 `test` 数据集
+- 复用 `Stage4RoiTargetAdapter` 生成 `target_roi`
+- 用当前模型路径计算 `prediction_roi = I_out_roi`
+- 用现有 [evaluator.py](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/src/eval/evaluator.py) / [metrics.py](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/src/eval/metrics.py) 计算 PSNR / SSIM
+- 同时生成 bicubic baseline 并对同一个 `target_roi` 记分
+
+bicubic baseline 的实现口径：
+- baseline source tensor：`target_roi`
+- 默认 LR 尺寸：`32x32`
+- 默认 scale factor：`3`
+- 实现方式：`96x96 target_roi -> bicubic downsample -> 32x32 -> bicubic upsample -> 96x96`
+- anti-aliasing：
+  - downsample：`true`
+  - upsample：`false`
+- 插值模式：
+  - downsample：`bicubic`
+  - upsample：`bicubic`
+- 这些假设已写入：
+  - [stage5_eval.yaml](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/configs/stage5/stage5_eval.yaml)
+  - `outputs/stage5/eval/.../summary.json`
+
+本次执行的 sanity 命令：
+- `python -m py_compile scripts/eval_stage5_paper.py`
+- `python scripts/eval_stage5_paper.py --config configs/stage5/stage5_eval.yaml --checkpoint outputs/stage5/paper_trainer/issue5_6_resume_demo/checkpoints/checkpoint_best.pt --split val --subset-size 4 --run-name issue5_7_val_sanity`
+- `python scripts/eval_stage5_paper.py --config configs/stage5/stage5_eval.yaml --checkpoint outputs/stage5/paper_trainer/issue5_6_resume_demo/checkpoints/checkpoint_best.pt --split test --subset-size 4 --run-name issue5_7_test_sanity`
+
+已产出的 eval artifacts：
+- [val summary](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/eval/issue5_7_val_sanity/summary.json)
+- [val preview](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/eval/issue5_7_val_sanity/preview_comparison.png)
+- [test summary](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/eval/issue5_7_test_sanity/summary.json)
+- [test preview](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/eval/issue5_7_test_sanity/preview_comparison.png)
+
+这次 sanity 的结果摘要：
+- val 子集 4 样本：
+  - model `PSNR = 16.2660`
+  - model `SSIM = 0.8443`
+  - bicubic `PSNR = 28.4709`
+  - bicubic `SSIM = 0.9608`
+- test 子集 4 样本：
+  - model `PSNR = 9.6900`
+  - model `SSIM = 0.4261`
+  - bicubic `PSNR = 19.3473`
+  - bicubic `SSIM = 0.8122`
+
+有意留给 Issue 5.8 的内容：
+- blind line-pair / resolution-target 生成
+- blind test 的 artifact 结构与报告格式
+- regular eval 之外的 blind-eval hook
+
+推荐的 commit 三段式信息：
+
+```text
+feat(eval | stage5-7): add stage5 regular eval runner
+
+why:
+land a stage5-specific regular evaluation path before blind-test work so
+paper-path checkpoints can be scored reproducibly on val/test with
+explicit crop, normalization, and bicubic-baseline assumptions
+
+what:
+add a stage5 eval script and config, load stage5 checkpoints directly,
+score I_out_roi against target_roi with PSNR/SSIM, generate a bicubic
+downsample-then-upsample baseline with anti-aliasing, and save summaries
+plus comparison previews under outputs/stage5/eval
+```

--- a/docs/ai/prompt/stage5/prompt_stage5-8.md
+++ b/docs/ai/prompt/stage5/prompt_stage5-8.md
@@ -1,0 +1,273 @@
+You are working in a research-engineering repository for reproducing
+"Super-resolution image display using diffractive decoders".
+
+Your task is to complete GitHub Issue 5.8:
+
+Issue title:
+Add Stage 5 blind line-pair generator and evaluation hook
+
+This is a Stage-5-scoped blind-eval task.
+Do not turn it into a rewrite of the regular eval runner, a trainer task, or a
+Stage 6 robustness study.
+
+==================================================
+0. MUST-READ CONTEXT FIRST
+==================================================
+
+Before doing anything, you MUST read and follow these files in order:
+
+1. `AGENTS.md`
+2. `docs/ai/PROJECT_CONTEXT.md`
+3. `docs/paper/paper_notes.md`
+4. `docs/plan/stage_plan/stage5/stage5_protocol_freeze.md`
+5. `docs/plan/stage_plan/stage5/stage5_plan.md`
+6. `docs/plan/stage_plan/stage5/stage5_issue_plan.md`
+7. `configs/stage5/stage5_optics_paper_aligned.yaml`
+8. `configs/stage5/stage5_paper_encoder.yaml`
+9. `configs/stage5/stage5_eval.yaml`
+
+Then inspect these implementation-reference files before editing:
+
+10. `scripts/eval_stage5_paper.py`
+11. `scripts/train_stage5_paper.py`
+12. `src/eval/metrics.py`
+13. `src/eval/evaluator.py`
+14. `src/datasets/target_adapter.py`
+
+Important scope rules:
+
+- If `paper_notes.md` is broader than the Stage 5 schedule, follow the Stage 5 docs.
+- For unresolved items, obey the ownership rules in `stage5_protocol_freeze.md`.
+- This issue owns blind line-pair / resolution-target generation plus a narrow
+  eval hook only.
+- Regular PSNR / SSIM eval and bicubic baseline were already handled by Issue 5.7.
+
+==================================================
+1. ISSUE 5.8 GOAL
+==================================================
+
+Implement a Stage 5 blind line-pair / resolution-target path that can:
+
+1. generate deterministic blind-test targets not used in the training dataset
+2. run the current Stage 5 model path on those targets
+3. save auditable artifacts for visual inspection and later reporting
+4. plug into the Stage 5 eval workflow without rewriting the regular eval path
+
+The result should provide a narrow blind-test capability that complements, but
+does not replace, the regular eval runner from Issue 5.7.
+
+==================================================
+2. NON-GOALS - DO NOT DRIFT
+==================================================
+
+Do NOT do any of the following:
+
+- do not redesign `scripts/eval_stage5_paper.py` into a broad benchmark framework
+- do not reopen PSNR / SSIM or bicubic-baseline design from Issue 5.7
+- do not change Stage 5 dataset split rules or EMNIST protocol
+- do not add quantization, misalignment, robustness, or ablation studies
+- do not silently change crop / normalization semantics
+- do not invent a heavy paper-final scalar metric if the documents do not freeze one
+- do not mix this with smoke-run or main-run orchestration
+
+This issue is successful only if it lands a narrow, reproducible blind-test path
+with clear target-generation assumptions and saved artifacts.
+
+==================================================
+3. BRANCH EXPECTATION
+==================================================
+
+Suggested branch:
+- `feat/eval`
+
+Stay on an evaluation-oriented branch.
+Do not absorb trainer or Stage 6 scope here.
+
+==================================================
+4. REQUIRED INHERITANCE
+==================================================
+
+From `stage5_protocol_freeze.md`, this issue must inherit and obey:
+
+1. Frozen optical contract:
+   `phi_lr -> U0 -> U_out_full -> I_out_full -> I_out_roi`
+2. Stage 5 regular eval already exists and must remain the base path.
+3. Crop / FOV alignment semantics are already frozen by Issue 5.3.
+4. Encoder-facing `phi_lr` semantics are already frozen by Issue 5.4.
+5. Trainer / checkpoint loading path is already frozen by Issue 5.6.
+6. Blind eval must reuse those paths rather than silently redefining them.
+
+Important inheritance detail:
+
+- Blind targets are separate from the EMNIST training/eval dataset.
+- The blind-test hook should reuse the existing Stage 5 checkpoint-loading and
+  forward path where practical.
+- If a scalar blind-test score is not well specified by the docs, do not fake
+  certainty. Prefer reproducible artifacts + explicit metadata.
+
+==================================================
+5. WHAT YOU ARE ALLOWED TO FINALIZE HERE
+==================================================
+
+This issue MAY finalize:
+
+1. the Stage 5 blind-target generator path and config interface
+2. the artifact directory structure for blind-test outputs
+3. the reporting schema for blind-test metadata
+4. the narrow hook connecting blind targets to the existing Stage 5 eval/model path
+5. the default Stage 5 blind-target parameter set, if kept configurable and logged
+
+This issue MUST keep the following explicit and auditable:
+
+1. target canvas size
+2. line width / spacing / orientation assumptions
+3. whether targets are binary or smoothed before display
+4. how targets are fed into the Stage 5 model path
+5. what outputs are saved and how they are organized
+
+This issue MUST NOT finalize:
+
+1. a repo-wide eval framework
+2. new regular-eval semantics
+3. new crop semantics
+4. Stage 6 experiment scope
+
+==================================================
+6. IMPLEMENTATION REQUIREMENTS
+==================================================
+
+Implement the smallest real blind-test path needed for Stage 5.
+
+Prefer a narrow structure such as:
+
+- a blind-target utility under `src/eval/` or another narrow, local module
+- a Stage 5 blind-eval config under `configs/stage5/`
+- either:
+  - a small dedicated script such as `scripts/eval_stage5_blind_linepair.py`, or
+  - a very small additive hook to `scripts/eval_stage5_paper.py`
+
+Prefer separation over entanglement.
+If a separate script is cleaner, use a separate script.
+
+The implementation should likely include:
+
+- deterministic line-pair / resolution-target generation
+- explicit config for target geometry and target count
+- checkpoint loading and model forward reuse
+- saved visual artifacts for:
+  - generated blind target
+  - model output
+  - optional comparison view / profile view if narrowly justified
+- a summary file with target metadata and output paths
+
+==================================================
+7. BLIND-TARGET GENERATION REQUIREMENT
+==================================================
+
+The paper notes mention blind testing with line pairs / resolution targets, but
+the exact engineering form may not be fully frozen.
+
+You must therefore:
+
+1. make target generation deterministic
+2. make key geometry parameters configurable
+3. pick a clear Stage 5 default set
+4. log those defaults in config and summary
+
+If the docs do not uniquely settle details such as:
+
+- exact line widths
+- exact spacing ladder
+- exact orientation set
+- exact number of targets
+
+then do NOT present one choice as paper-unique truth.
+
+Instead:
+
+- implement a reasonable Stage 5 default
+- keep it configurable
+- document it as a Stage 5 engineering choice
+
+Do NOT:
+
+- generate targets with hidden randomness
+- bury target geometry only in code
+- make blind targets depend on the EMNIST dataset path
+
+==================================================
+8. REQUIRED ARTIFACTS
+==================================================
+
+You must produce enough artifacts to verify that the blind-test path is real and inspectable.
+
+At minimum, provide:
+
+- the blind-target generator utility or module
+- a Stage 5 blind-eval config if needed
+- a blind-test output directory under `outputs/stage5/`
+- a saved summary containing:
+  - checkpoint path
+  - blind-target generation config / metadata
+  - output artifact paths
+  - any narrow reporting fields you define
+
+Prefer also saving preview artifacts such as:
+
+- a grid of generated blind targets
+- the corresponding model outputs
+- optional line-profile or side-by-side comparison figures if that is small and clear
+
+If you add any scalar reporting, keep it narrow and explain what it means.
+Do not over-claim it as the paper's final blind metric unless the docs clearly support that.
+
+==================================================
+9. FILE SCOPE
+==================================================
+
+Primary files likely to be changed or added:
+
+- a new blind-eval script under `scripts/`
+- a Stage 5 blind-eval config under `configs/stage5/`
+- a narrow helper module under `src/eval/` or another small local path
+
+Supporting edits are allowed in:
+
+- `README.md`
+- `scripts/eval_stage5_paper.py`
+
+but only for a small, well-scoped hook or command reference.
+
+Avoid:
+
+- trainer refactors
+- optics-core edits
+- dataset rewrites
+- broad metric-framework changes
+
+==================================================
+10. ACCEPTANCE CRITERIA
+==================================================
+
+Issue 5.8 is complete only if:
+
+1. Blind line-pair / resolution targets can be generated deterministically
+2. The current Stage 5 model path can be executed on those targets
+3. Blind-test artifacts are saved in a reproducible format
+4. Target-generation assumptions are explicit and logged
+5. The implementation stays separate from regular eval concerns
+6. No frozen Stage 5 crop / normalization semantics are silently changed
+
+==================================================
+11. FINAL RESPONSE FORMAT
+==================================================
+
+After finishing, respond with:
+
+- short summary of what was implemented
+- exact files changed
+- how blind targets are generated
+- how the blind-test hook reuses the Stage 5 model/eval path
+- what command(s) were executed for sanity
+- what artifacts were produced
+- what was intentionally left unresolved for later issues

--- a/scripts/eval_stage5_paper.py
+++ b/scripts/eval_stage5_paper.py
@@ -1,0 +1,521 @@
+#!/usr/bin/env python
+"""Evaluate the Stage 5 paper-aligned checkpoint with a bicubic baseline."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+import torch.nn.functional as F
+import yaml
+from torch.utils.data import DataLoader, Subset
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.datasets import Stage4RoiTargetAdapter, build_stage5_emnist_display_dataset
+from src.eval.evaluator import evaluate_batch
+from src.models.encoders import PaperPhaseEncoder
+from src.models.optics.diffractive_decoder import DiffractiveDecoder
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Evaluate a Stage 5 paper-aligned checkpoint with bicubic baseline."
+    )
+    parser.add_argument("--config", type=str, required=True)
+    parser.add_argument("--checkpoint", type=str, required=True)
+    parser.add_argument("--split", type=str, default=None, choices=("val", "test"))
+    parser.add_argument("--subset-size", type=int, default=None)
+    parser.add_argument("--run-name", type=str, default=None)
+    parser.add_argument("--device", type=str, default=None)
+    parser.add_argument("--preview-limit", type=int, default=None)
+    parser.add_argument("--download", action="store_true")
+    return parser.parse_args()
+
+
+def load_yaml(path: str | Path) -> dict[str, Any]:
+    with Path(path).open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle)
+    if not isinstance(data, dict):
+        raise TypeError(f"Config at {path} must load to a dict, got {type(data)!r}.")
+    return data
+
+
+def require_mapping(root: dict[str, Any], *keys: str) -> dict[str, Any]:
+    current: Any = root
+    for key in keys:
+        if not isinstance(current, dict) or key not in current:
+            raise KeyError(f"Missing config path: {'/'.join(keys)}")
+        current = current[key]
+    if not isinstance(current, dict):
+        raise TypeError(f"Config path {'/'.join(keys)} must be a mapping.")
+    return current
+
+
+def normalize_device(device_arg: str) -> torch.device:
+    normalized = device_arg.lower()
+    if normalized == "auto":
+        return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if normalized == "cuda" and not torch.cuda.is_available():
+        raise RuntimeError("Requested CUDA but it is not available.")
+    if normalized not in {"cpu", "cuda"}:
+        raise ValueError(f"Unsupported device value: {device_arg}.")
+    return torch.device(normalized)
+
+
+def save_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, ensure_ascii=False)
+
+
+def move_batch_to_device(batch: dict[str, Any], device: torch.device) -> dict[str, Any]:
+    moved: dict[str, Any] = {}
+    for key, value in batch.items():
+        if isinstance(value, torch.Tensor):
+            moved[key] = value.to(device, non_blocking=device.type == "cuda")
+        else:
+            moved[key] = value
+    return moved
+
+
+def _to_gray_numpy(image: torch.Tensor) -> np.ndarray:
+    tensor = image.detach().cpu().float()
+    if tensor.ndim == 2:
+        return tensor.numpy()
+    if tensor.ndim == 3 and tensor.shape[0] == 1:
+        return tensor[0].numpy()
+    raise ValueError(f"Expected grayscale tensor, got shape {tuple(tensor.shape)}.")
+
+
+def build_dataset(
+    dataset_cfg: dict[str, Any],
+    *,
+    split: str,
+    subset_size: int | None,
+    download: bool,
+) -> Any:
+    dataset = build_stage5_emnist_display_dataset(
+        split=split,
+        dataset_root=dataset_cfg["dataset_root"],
+        emnist_split=dataset_cfg["emnist_split"],
+        sample_count=int(dataset_cfg["sample_counts"][split]),
+        letter_count_choices=list(dataset_cfg["letter_count_choices"][split]),
+        seed=int(dataset_cfg["seed"]),
+        canvas_hw=tuple(dataset_cfg["canvas_hw"]),
+        cell_hw=tuple(dataset_cfg["cell_hw"]),
+        grid_shape=tuple(dataset_cfg["grid_shape"]),
+        augmentation=dataset_cfg["augmentation"][split],
+        fix_emnist_orientation=bool(dataset_cfg.get("fix_emnist_orientation", True)),
+        download=download,
+    )
+    if subset_size is None:
+        return dataset
+    subset_size = int(subset_size)
+    if subset_size < 1:
+        raise ValueError("subset_size must be >= 1.")
+    if subset_size > len(dataset):
+        raise ValueError(f"subset_size {subset_size} exceeds dataset length {len(dataset)}.")
+    return Subset(dataset, list(range(subset_size)))
+
+
+def build_encoder_decoder(
+    encoder_cfg: dict[str, Any],
+    optics_cfg: dict[str, Any],
+    *,
+    depth: int,
+    device: torch.device,
+) -> tuple[PaperPhaseEncoder, DiffractiveDecoder]:
+    target_hw = tuple(encoder_cfg["target_hw"])
+    optics_input_hw = tuple(optics_cfg["grid"]["input_pattern_hw"])
+    if target_hw != optics_input_hw:
+        raise ValueError(
+            "Stage 5 encoder target_hw must match optics input_pattern_hw, "
+            f"got {target_hw} vs {optics_input_hw}."
+        )
+
+    encoder = PaperPhaseEncoder(
+        in_channels=int(encoder_cfg["in_channels"]),
+        input_hw=tuple(encoder_cfg["input_hw"]),
+        target_hw=target_hw,
+        base_channels=int(encoder_cfg["base_channels"]),
+        hidden_channels=int(encoder_cfg["hidden_channels"]),
+        interpolation_mode=str(encoder_cfg["interpolation_mode"]),
+        align_corners=bool(encoder_cfg["align_corners"]),
+        phase_mapping=str(encoder_cfg["phase_mapping"]),
+        phase_range=tuple(float(value) for value in encoder_cfg["phase_range"]),
+    ).to(device)
+
+    depth_cfg = optics_cfg["depths"][str(depth)]
+    decoder = DiffractiveDecoder(
+        num_diffractive_layers=int(depth_cfg["num_diffractive_layers"]),
+        wavelength=float(optics_cfg["units"]["wavelength"]),
+        pixel_pitch=float(optics_cfg["units"]["pixel_pitch_lambda"]),
+        grid_config=optics_cfg["grid"],
+        distance_schedule=depth_cfg["distance_schedule"],
+        readout_config={"output_crop_hw": optics_cfg["readout"]["output_crop_hw"]},
+        phase_mask_config=dict(optics_cfg.get("phase_mask_config", {})),
+    ).to(device)
+    return encoder, decoder
+
+
+def load_model_from_checkpoint(
+    checkpoint_path: str | Path,
+    *,
+    device: torch.device,
+) -> tuple[PaperPhaseEncoder, DiffractiveDecoder, dict[str, Any], int]:
+    checkpoint = torch.load(checkpoint_path, map_location=device)
+    config_snapshot = checkpoint.get("config_snapshot")
+    if not isinstance(config_snapshot, dict):
+        raise KeyError("Checkpoint is missing config_snapshot required for Stage 5 eval.")
+
+    encoder_cfg = config_snapshot.get("encoder_config")
+    optics_cfg = config_snapshot.get("optics_config")
+    depth = config_snapshot.get("depth")
+    if not isinstance(encoder_cfg, dict) or not isinstance(optics_cfg, dict) or depth is None:
+        raise KeyError(
+            "Checkpoint config_snapshot must contain encoder_config, optics_config, and depth."
+        )
+
+    encoder, decoder = build_encoder_decoder(
+        encoder_cfg,
+        optics_cfg,
+        depth=int(depth),
+        device=device,
+    )
+    encoder.load_state_dict(checkpoint["encoder_state_dict"])
+    decoder.load_state_dict(checkpoint["decoder_state_dict"])
+    encoder.eval()
+    decoder.eval()
+    return encoder, decoder, config_snapshot, int(depth)
+
+
+def interpolate_single_channel(
+    tensor: torch.Tensor,
+    *,
+    size: tuple[int, int],
+    mode: str,
+    align_corners: bool,
+    antialias: bool,
+) -> torch.Tensor:
+    kwargs: dict[str, Any] = {
+        "size": size,
+        "mode": mode,
+    }
+    if mode in {"linear", "bilinear", "bicubic", "trilinear"}:
+        kwargs["align_corners"] = align_corners
+    if antialias and mode in {"bilinear", "bicubic"}:
+        kwargs["antialias"] = True
+    return F.interpolate(tensor.float(), **kwargs)
+
+
+def build_bicubic_baseline(target_roi: torch.Tensor, baseline_cfg: dict[str, Any]) -> torch.Tensor:
+    lr_hw = tuple(int(value) for value in baseline_cfg["input_lr_hw"])
+    downsample = interpolate_single_channel(
+        target_roi,
+        size=lr_hw,
+        mode=str(baseline_cfg["downsample_mode"]),
+        align_corners=bool(baseline_cfg["align_corners"]),
+        antialias=bool(baseline_cfg["antialias_downsample"]),
+    )
+    return interpolate_single_channel(
+        downsample,
+        size=tuple(int(value) for value in target_roi.shape[-2:]),
+        mode=str(baseline_cfg["upsample_mode"]),
+        align_corners=bool(baseline_cfg["align_corners"]),
+        antialias=bool(baseline_cfg["antialias_upsample"]),
+    )
+
+
+@torch.no_grad()
+def run_model_batch(
+    encoder: PaperPhaseEncoder,
+    decoder: DiffractiveDecoder,
+    batch: dict[str, Any],
+    *,
+    target_adapter: Stage4RoiTargetAdapter,
+    device: torch.device,
+) -> dict[str, Any]:
+    moved_batch = move_batch_to_device(batch, device)
+    x_hr = moved_batch["x_hr"]
+    target_hr = moved_batch["target_hr"]
+    if not isinstance(x_hr, torch.Tensor) or not isinstance(target_hr, torch.Tensor):
+        raise TypeError("Batch must contain tensor fields 'x_hr' and 'target_hr'.")
+
+    phi_lr = encoder(x_hr)
+    output = decoder.forward_from_phase(phi_lr, return_intermediates=False)
+    prediction_roi = output["I_out_roi"]
+    target_roi = target_adapter(target_hr)
+    if not isinstance(prediction_roi, torch.Tensor):
+        raise TypeError("Decoder output is missing tensor field 'I_out_roi'.")
+
+    return {
+        "x_hr": x_hr,
+        "target_hr": target_hr,
+        "target_roi": target_roi,
+        "phi_lr": phi_lr,
+        "prediction_roi": prediction_roi,
+        "output": output,
+        "dataset_index": moved_batch.get("dataset_index"),
+        "letter_count": moved_batch.get("letter_count"),
+    }
+
+
+def weighted_average(metric_summaries: list[dict[str, float | int]]) -> dict[str, float]:
+    total_count = sum(int(item["num_samples"]) for item in metric_summaries)
+    if total_count < 1:
+        raise RuntimeError("No metric summaries were collected.")
+    return {
+        "psnr_mean": sum(float(item["psnr_mean"]) * int(item["num_samples"]) for item in metric_summaries)
+        / total_count,
+        "ssim_mean": sum(float(item["ssim_mean"]) * int(item["num_samples"]) for item in metric_summaries)
+        / total_count,
+        "num_samples": float(total_count),
+    }
+
+
+def save_eval_preview(
+    output_path: Path,
+    batch_output: dict[str, Any],
+    bicubic_prediction: torch.Tensor,
+    *,
+    preview_limit: int,
+) -> None:
+    row_count = min(preview_limit, batch_output["x_hr"].shape[0])
+    x_hr = batch_output["x_hr"][:row_count].detach().cpu()
+    target_roi = batch_output["target_roi"][:row_count].detach().cpu()
+    model_prediction = batch_output["prediction_roi"][:row_count].detach().cpu()
+    bicubic_prediction = bicubic_prediction[:row_count].detach().cpu()
+    model_abs_error = torch.abs(target_roi - model_prediction)
+    bicubic_abs_error = torch.abs(target_roi - bicubic_prediction)
+
+    fig, axes = plt.subplots(row_count, 6, figsize=(18, max(3.0, 3.0 * row_count)))
+    if row_count == 1:
+        axes = np.expand_dims(axes, axis=0)
+
+    titles = ("input", "target_roi", "model", "bicubic", "|model-target|", "|bicubic-target|")
+    for row_index in range(row_count):
+        panels = (
+            _to_gray_numpy(x_hr[row_index]),
+            _to_gray_numpy(target_roi[row_index]),
+            _to_gray_numpy(model_prediction[row_index]),
+            _to_gray_numpy(bicubic_prediction[row_index]),
+            _to_gray_numpy(model_abs_error[row_index]),
+            _to_gray_numpy(bicubic_abs_error[row_index]),
+        )
+        error_max = float(max(model_abs_error.max().item(), bicubic_abs_error.max().item())) + 1e-8
+        ranges = (
+            (0.0, 1.0),
+            (0.0, 1.0),
+            (0.0, 1.0),
+            (0.0, 1.0),
+            (0.0, error_max),
+            (0.0, error_max),
+        )
+        for col_index, axis in enumerate(axes[row_index]):
+            vmin, vmax = ranges[col_index]
+            axis.imshow(panels[col_index], cmap="gray", vmin=vmin, vmax=vmax)
+            if row_index == 0:
+                axis.set_title(titles[col_index])
+            axis.axis("off")
+    fig.tight_layout()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output_path, dpi=180, bbox_inches="tight")
+    plt.close(fig)
+
+
+def main() -> None:
+    args = parse_args()
+    eval_root = load_yaml(args.config)
+    eval_cfg = require_mapping(eval_root, "eval", "stage5_paper")
+    dataset_cfg = require_mapping(load_yaml(eval_cfg["dataset_config_path"]), "data", "stage5_display")
+
+    runtime_cfg = dict(eval_cfg["runtime"])
+    split = str(args.split or runtime_cfg["split"])
+    subset_size = args.subset_size if args.subset_size is not None else runtime_cfg["subset_size"]
+    preview_limit = int(
+        args.preview_limit if args.preview_limit is not None else runtime_cfg["preview_limit"]
+    )
+    if preview_limit < 1:
+        raise ValueError("preview_limit must be >= 1.")
+
+    device = normalize_device(str(args.device or runtime_cfg["device"]))
+    checkpoint_path = Path(args.checkpoint).resolve()
+    output_root = Path(eval_cfg["output_root"])
+    run_name = args.run_name or eval_cfg.get("run_name") or datetime.now(timezone.utc).strftime(
+        "%Y%m%dT%H%M%SZ"
+    )
+    run_dir = output_root / run_name
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    encoder, decoder, checkpoint_snapshot, depth = load_model_from_checkpoint(
+        checkpoint_path,
+        device=device,
+    )
+    dataset = build_dataset(
+        dataset_cfg,
+        split=split,
+        subset_size=subset_size,
+        download=bool(args.download or runtime_cfg.get("download", False)),
+    )
+    dataloader = DataLoader(
+        dataset,
+        batch_size=int(runtime_cfg["batch_size"]),
+        shuffle=False,
+        num_workers=int(runtime_cfg["num_workers"]),
+    )
+    target_adapter = Stage4RoiTargetAdapter(output_crop_hw=decoder.readout_config)
+    baseline_cfg = dict(eval_cfg["bicubic_baseline"])
+
+    config_snapshot = {
+        "eval_config_path": str(Path(args.config).resolve()),
+        "checkpoint_path": str(checkpoint_path),
+        "run_name": run_name,
+        "split": split,
+        "device": str(device),
+        "runtime": {
+            **runtime_cfg,
+            "subset_size": subset_size,
+            "preview_limit": preview_limit,
+            "download": bool(args.download or runtime_cfg.get("download", False)),
+        },
+        "bicubic_baseline": baseline_cfg,
+        "checkpoint_snapshot_excerpt": {
+            "depth": depth,
+            "optics_readout": checkpoint_snapshot["optics_config"]["readout"],
+            "encoder_target_hw": checkpoint_snapshot["encoder_config"]["target_hw"],
+        },
+        "created_at_utc": datetime.now(timezone.utc).isoformat(),
+    }
+    save_json(run_dir / "config_snapshot.json", config_snapshot)
+
+    model_metric_summaries: list[dict[str, float | int]] = []
+    bicubic_metric_summaries: list[dict[str, float | int]] = []
+    preview_batch_output: dict[str, Any] | None = None
+    preview_bicubic: torch.Tensor | None = None
+
+    for batch in dataloader:
+        batch_output = run_model_batch(
+            encoder,
+            decoder,
+            batch,
+            target_adapter=target_adapter,
+            device=device,
+        )
+        bicubic_prediction = build_bicubic_baseline(batch_output["target_roi"], baseline_cfg)
+
+        model_metric_summaries.append(
+            evaluate_batch(batch_output["prediction_roi"], batch_output["target_roi"])
+        )
+        bicubic_metric_summaries.append(
+            evaluate_batch(bicubic_prediction, batch_output["target_roi"])
+        )
+
+        if preview_batch_output is None:
+            preview_batch_output = batch_output
+            preview_bicubic = bicubic_prediction.detach().cpu()
+
+    if preview_batch_output is None or preview_bicubic is None:
+        raise RuntimeError("Evaluation dataloader is empty.")
+
+    model_metrics = weighted_average(model_metric_summaries)
+    bicubic_metrics = weighted_average(bicubic_metric_summaries)
+    save_eval_preview(
+        run_dir / "preview_comparison.png",
+        preview_batch_output,
+        preview_bicubic,
+        preview_limit=preview_limit,
+    )
+
+    readout_cfg = checkpoint_snapshot["optics_config"]["readout"]
+    crop_hw = list(readout_cfg["output_crop_hw"])
+    preview_dataset_index = preview_batch_output["dataset_index"]
+    preview_letter_count = preview_batch_output["letter_count"]
+    summary = {
+        "checkpoint_path": str(checkpoint_path),
+        "evaluated_split": split,
+        "evaluated_num_samples": int(model_metrics["num_samples"]),
+        "model_metrics": {
+            "psnr_mean": float(model_metrics["psnr_mean"]),
+            "ssim_mean": float(model_metrics["ssim_mean"]),
+        },
+        "bicubic_baseline_metrics": {
+            "psnr_mean": float(bicubic_metrics["psnr_mean"]),
+            "ssim_mean": float(bicubic_metrics["ssim_mean"]),
+        },
+        "scored_tensor_pair": {
+            "prediction": "I_out_roi",
+            "target": "target_roi",
+        },
+        "crop_assumptions": {
+            "output_crop_hw": crop_hw,
+            "crop_policy": readout_cfg.get("crop_policy", "center_crop"),
+            "center_offset_hw": readout_cfg.get("center_offset_hw"),
+            "fov_alignment_note": readout_cfg.get("fov_alignment_note"),
+            "target_adapter": {
+                "resize_mode": target_adapter.resize_mode,
+                "align_corners": target_adapter.align_corners,
+                "clamp_range": list(target_adapter.clamp_range),
+            },
+        },
+        "normalization_assumptions": {
+            "metrics_helper": "src.eval.evaluator.evaluate_batch",
+            "metric_value_range_policy": (
+                "src.eval.metrics._normalize_to_unit normalizes to [0,1], "
+                "including /255 for uint-like inputs and clipping otherwise."
+            ),
+        },
+        "bicubic_baseline_assumptions": {
+            "source_tensor": baseline_cfg["source_tensor"],
+            "implementation": baseline_cfg["implementation"],
+            "input_lr_hw": list(baseline_cfg["input_lr_hw"]),
+            "scale_factor": baseline_cfg["scale_factor"],
+            "downsample_mode": baseline_cfg["downsample_mode"],
+            "upsample_mode": baseline_cfg["upsample_mode"],
+            "align_corners": bool(baseline_cfg["align_corners"]),
+            "antialias_downsample": bool(baseline_cfg["antialias_downsample"]),
+            "antialias_upsample": bool(baseline_cfg["antialias_upsample"]),
+            "note": baseline_cfg["note"],
+        },
+        "output_shapes": {
+            "x_hr": list(preview_batch_output["x_hr"].shape),
+            "target_roi": list(preview_batch_output["target_roi"].shape),
+            "prediction_roi": list(preview_batch_output["prediction_roi"].shape),
+            "phi_lr": list(preview_batch_output["phi_lr"].shape),
+        },
+        "preview_batch_metadata": {
+            "dataset_index": (
+                None
+                if preview_dataset_index is None
+                else [int(value) for value in preview_dataset_index.tolist()]
+            ),
+            "letter_count": (
+                None
+                if preview_letter_count is None
+                else [int(value) for value in preview_letter_count.tolist()]
+            ),
+        },
+        "artifacts": {
+            "config_snapshot": str((run_dir / "config_snapshot.json").resolve()),
+            "summary": str((run_dir / "summary.json").resolve()),
+            "preview_comparison": str((run_dir / "preview_comparison.png").resolve()),
+        },
+    }
+    save_json(run_dir / "summary.json", summary)
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
why:
land a stage5-specific regular evaluation path before blind-test work so paper-path checkpoints can be scored reproducibly on val/test with explicit crop, normalization, and bicubic-baseline assumptions

what:
add a stage5 eval script and config, load stage5 checkpoints directly, score I_out_roi against target_roi with PSNR/SSIM, generate a bicubic downsample-then-upsample baseline with anti-aliasing, and save summaries plus comparison previews under outputs/stage5/eval