### PR TITLE
feat(eval | stage5-8): add blind line-pair eval hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ More orders are listed in docs/run_order.md. Here are some frequently used comma
   `python scripts/train_stage5_paper.py --config configs/stage5/stage5_trainer_short.yaml`
 - Run the Stage 5 regular eval with bicubic baseline:
   `python scripts/eval_stage5_paper.py --config configs/stage5/stage5_eval.yaml --checkpoint outputs/stage5/paper_trainer/issue5_6_resume_demo/checkpoints/checkpoint_best.pt --split val`
+- Run the Stage 5 blind line-pair hook:
+  `python scripts/eval_stage5_blind_linepair.py --config configs/stage5/stage5_blind_eval.yaml --checkpoint outputs/stage5/paper_trainer/issue5_6_resume_demo/checkpoints/checkpoint_best.pt`
 - Preview the Stage 5 Issue 5.2 EMNIST 96x96 display dataset:
   `python scripts/preview_stage5_emnist_display.py --config configs/stage5/stage5_emnist_display.yaml`
-

--- a/configs/stage5/stage5_blind_eval.yaml
+++ b/configs/stage5/stage5_blind_eval.yaml
@@ -1,0 +1,25 @@
+﻿eval:
+  stage5_blind_linepair:
+    output_root: outputs/stage5/blind_eval
+    run_name: null
+    runtime:
+      device: cpu
+      batch_size: 4
+      preview_limit: 8
+    target_generation:
+      note: >
+        Stage 5 blind targets are implemented here as deterministic centered
+        line-pair patterns on a 96x96 canvas. This is a Stage 5 engineering
+        default for blind inspection, not paper-unique truth.
+      target_family: line_pair
+      canvas_hw: [96, 96]
+      background_value: 0.0
+      line_value: 1.0
+      margin_px: 12
+      line_length_px: 72
+      line_widths_px: [1, 2]
+      gap_px: [1, 2, 3, 4, 6, 8]
+      orientations: [horizontal, vertical]
+      render_mode: binary
+      blur_sigma: 0.0
+      blur_kernel_size: 5

--- a/docs/ai/CodexFeedback/stage5/feedback_stage5-8.md
+++ b/docs/ai/CodexFeedback/stage5/feedback_stage5-8.md
@@ -1,0 +1,75 @@
+﻿实现了一个独立于 regular eval 的 Stage 5 blind line-pair 路径，职责只覆盖 deterministic blind target 生成、复用现有 Stage 5 checkpoint/model forward，以及保存可审计的 blind artifact；没有把 5.7 的 PSNR/SSIM + bicubic baseline 逻辑和 5.8 混成一个大脚本，也没有碰 trainer、crop 语义或 Stage 6 研究项。
+
+精确变更文件：
+- [src/eval/stage5_blind_targets.py](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/src/eval/stage5_blind_targets.py)
+- [scripts/eval_stage5_blind_linepair.py](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/scripts/eval_stage5_blind_linepair.py)
+- [configs/stage5/stage5_blind_eval.yaml](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/configs/stage5/stage5_blind_eval.yaml)
+- [README.md](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/README.md)
+
+blind targets 如何生成：
+- 默认 target family 为 `line_pair`
+- 画布固定为 `96x96`
+- 生成方式是 centered binary line-pair，不依赖 EMNIST dataset path
+- 默认参数集：
+  - `orientations = [horizontal, vertical]`
+  - `line_widths_px = [1, 2]`
+  - `gap_px = [1, 2, 3, 4, 6, 8]`
+  - `margin_px = 12`
+  - `line_length_px = 72`
+  - `render_mode = binary`
+  - `blur_sigma = 0.0`
+- 因此默认会稳定生成 `2 x 2 x 6 = 24` 个 blind line-pair targets
+- 这些值在 [stage5_blind_eval.yaml](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/configs/stage5/stage5_blind_eval.yaml) 里可配置，并明确标注为 Stage 5 engineering default，而不是 paper-unique truth
+
+blind-test hook 如何复用 Stage 5 model/eval 路径：
+- 从 `5.6` 的 checkpoint 直接加载 `encoder_state_dict`、`decoder_state_dict` 和 `config_snapshot`
+- 用 checkpoint 内嵌的 `encoder_config / optics_config / depth` 还原 `PaperPhaseEncoder + DiffractiveDecoder`
+- 生成的 blind target 直接作为 `96x96` 单通道 HR 输入喂给 encoder
+- 继续复用冻结的 `encoder -> decoder -> I_out_roi` 前向链
+- 继续复用 `Stage4RoiTargetAdapter` 生成 `target_roi`，保证 crop/FOV 语义和 regular eval 一致
+- 本 issue 不引入新的 paper-final scalar blind metric，只保存 artifacts 与 per-target metadata 供后续复盘
+
+本次执行的 sanity 命令：
+- `python -m py_compile src/eval/stage5_blind_targets.py scripts/eval_stage5_blind_linepair.py`
+- `python scripts/eval_stage5_blind_linepair.py --config configs/stage5/stage5_blind_eval.yaml --checkpoint outputs/stage5/paper_trainer/issue5_6_resume_demo/checkpoints/checkpoint_best.pt --run-name issue5_8_blind_sanity`
+
+已生成的 artifacts：
+- [config snapshot](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/blind_eval/issue5_8_blind_sanity/config_snapshot.json)
+- [summary](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/blind_eval/issue5_8_blind_sanity/summary.json)
+- [blind target grid](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/blind_eval/issue5_8_blind_sanity/blind_targets_grid.png)
+- [blind output grid](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/blind_eval/issue5_8_blind_sanity/blind_outputs_grid.png)
+- [blind comparison grid](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/blind_eval/issue5_8_blind_sanity/blind_comparison_grid.png)
+
+这次 sanity 记录到的关键事实：
+- blind target bank 大小为 `24`
+- 输入 shape 为 `(24, 1, 96, 96)`
+- encoder 输出 `phi_lr` shape 为 `(24, 1, 32, 32)`
+- sample forward shape 记录为：
+  - `U0 = (4, 1, 400, 400)`
+  - `U_out_full = (4, 1, 400, 400)`
+  - `I_out_full = (4, 1, 400, 400)`
+  - `I_out_roi = (4, 1, 96, 96)`
+- crop 假设继续沿用 `5.3`：`output_crop_hw = [96, 96]`、`crop_policy = center_crop`、`center_offset_hw = [152, 152]`
+
+有意留给后续 issue 的内容：
+- regular eval 的 PSNR / SSIM / bicubic baseline 仍留在 `5.7`，没有在这里重写
+- blind line-pair 之外更宽的 blind resolution-target 族扩展没有在这里做成“大而全”框架
+- 任何量化、错位、鲁棒性、ablation 都仍归 Stage 6
+- smoke/main run 编排仍归 `5.9` / `5.10`
+
+推荐的 commit 三段式信息：
+
+```text
+feat(eval | stage5-8): add blind line-pair eval hook
+
+why:
+land a separate stage5 blind-test path after regular eval so line-pair
+artifacts can be generated and inspected reproducibly without rewriting
+PSNR/SSIM evaluation or pulling in stage6 study scope
+
+what:
+add a deterministic blind line-pair target generator, a stage5 blind
+checkpoint-eval script that reuses the existing encoder-decoder forward
+path, a configurable blind-eval config, and saved blind target/output
+artifacts plus metadata under outputs/stage5/blind_eval
+```

--- a/docs/ai/prompt/stage5/prompt_stage5-9.md
+++ b/docs/ai/prompt/stage5/prompt_stage5-9.md
@@ -1,0 +1,254 @@
+You are working in a research-engineering repository for reproducing
+"Super-resolution image display using diffractive decoders".
+
+Your task is to complete GitHub Issue 5.9:
+
+Issue title:
+Run paper-aligned smoke training and write Stage 5 smoke report
+
+This is a Stage-5-scoped smoke-run task.
+Do not turn it into main-run tuning, a trainer rewrite, or a Stage 6 experiment sweep.
+
+==================================================
+0. MUST-READ CONTEXT FIRST
+==================================================
+
+Before doing anything, you MUST read and follow these files in order:
+
+1. `AGENTS.md`
+2. `docs/ai/PROJECT_CONTEXT.md`
+3. `docs/plan/stage_plan/stage5/stage5_protocol_freeze.md`
+4. `docs/plan/stage_plan/stage5/stage5_plan.md`
+5. `docs/plan/stage_plan/stage5/stage5_issue_plan.md`
+6. `configs/stage5/stage5_emnist_display.yaml`
+7. `configs/stage5/stage5_optics_paper_aligned.yaml`
+8. `configs/stage5/stage5_paper_encoder.yaml`
+9. `configs/stage5/stage5_sr_loss.yaml`
+10. `configs/stage5/stage5_trainer_short.yaml`
+11. `configs/stage5/stage5_eval.yaml`
+12. `configs/stage5/stage5_blind_eval.yaml`
+
+Then inspect these implementation-reference files before editing:
+
+13. `scripts/train_stage5_paper.py`
+14. `scripts/eval_stage5_paper.py`
+15. `scripts/eval_stage5_blind_linepair.py`
+16. `docs/ai/CodexFeedback/stage5/feedback_stage5-6.md`
+17. `docs/ai/CodexFeedback/stage5/feedback_stage5-7.md`
+18. `docs/ai/CodexFeedback/stage5/feedback_stage5-8.md`
+
+Important scope rules:
+
+- If `paper_notes.md` is broader than the Stage 5 schedule, follow the Stage 5 docs.
+- This issue consumes the already-landed Stage 5 pipeline.
+- This issue does not reopen dataset, optics, encoder, loss, trainer, regular eval,
+  or blind-eval design questions unless a narrow blocker fix is strictly required.
+
+==================================================
+1. ISSUE 5.9 GOAL
+==================================================
+
+Run one short paper-aligned smoke training and write a concise report that
+confirms the end-to-end Stage 5 pipeline is stable and inspectable.
+
+The result should provide:
+
+1. a real smoke-run output directory under `outputs/stage5/`
+2. evidence that the Stage 5 path can train without NaN / Inf
+3. concise reporting of loss trend, artifacts, and evaluation hooks
+4. a clear boundary between smoke validation and later main-run work
+
+==================================================
+2. NON-GOALS - DO NOT DRIFT
+==================================================
+
+Do NOT do any of the following:
+
+- do not treat smoke as the final paper result
+- do not expand this into main-run tuning or hyperparameter search
+- do not rewrite the Stage 5 trainer unless a narrow blocker fix is unavoidable
+- do not reopen frozen Stage 5 protocol items
+- do not add Stage 6 ablations, robustness, or quantization work
+- do not silently replace the smoke budget with a long-run budget
+
+This issue is successful only if it lands one credible smoke run plus a clear report.
+
+==================================================
+3. BRANCH EXPECTATION
+==================================================
+
+Suggested branch:
+- `feat/train`
+
+Stay on a training/execution-oriented branch.
+Do not absorb Stage 5.10 main-run scope here.
+
+==================================================
+4. REQUIRED INHERITANCE
+==================================================
+
+From the Stage 5 docs and prior issues, this issue must inherit and obey:
+
+1. Frozen optical contract:
+   `phi_lr -> U0 -> U_out_full -> I_out_full -> I_out_roi`
+2. Dataset / optics / encoder / loss / trainer path is already frozen enough to run.
+3. Regular eval + bicubic baseline already exist from Issue 5.7.
+4. Blind line-pair hook already exists from Issue 5.8.
+5. Smoke run should consume these paths rather than redefining them.
+
+Important inheritance detail:
+
+- A smoke run may use a reduced budget, but it must be explicitly labeled as smoke.
+- Any reduced subset size / step count / epoch budget must be logged as a smoke-only choice.
+- If you need a dedicated smoke config, make it explicit rather than overloading
+  the short trainer sanity config invisibly.
+
+==================================================
+5. WHAT YOU ARE ALLOWED TO FINALIZE HERE
+==================================================
+
+This issue MAY finalize:
+
+1. the dedicated Stage 5 smoke-run config and command
+2. the Stage 5 smoke output directory naming
+3. the Stage 5 smoke report structure
+4. the minimal set of eval evidence attached to the smoke report
+
+This issue MUST keep the following explicit and auditable:
+
+1. smoke run budget
+2. depth / config choice used for smoke
+3. whether resume was used
+4. loss trend and stability observations
+5. where checkpoints / previews / summaries are stored
+6. whether regular eval and blind eval were invoked after the smoke run
+
+This issue MUST NOT finalize:
+
+1. main-run budget
+2. Stage 6 experiment plan
+3. new trainer semantics
+
+==================================================
+6. IMPLEMENTATION REQUIREMENTS
+==================================================
+
+Implement the smallest real smoke-run path needed for Stage 5 acceptance.
+
+Prefer a narrow structure such as:
+
+- one dedicated smoke config under `configs/stage5/`
+- one smoke output directory under `outputs/stage5/`
+- one concise execution report:
+  `docs/execution/stage5_smoke_report.md`
+
+The implementation should likely include:
+
+- a Stage 5 smoke training command using the existing trainer
+- explicit artifact collection from the run
+- at least one post-run regular eval call using the existing `5.7` path
+- optional blind-eval invocation using the existing `5.8` path if it is cheap enough
+- a report summarizing:
+  - config / command
+  - whether training was stable
+  - key loss numbers
+  - artifact paths
+  - whether the smoke run is sufficient to unblock 5.10
+
+If existing scripts already support the needed behavior, prefer adding config and
+reporting over editing code.
+
+==================================================
+7. SMOKE-RUN BUDGET REQUIREMENT
+==================================================
+
+This issue is specifically about smoke validation, not full reproduction.
+
+You must therefore:
+
+1. choose a modest smoke budget
+2. record it explicitly as smoke-only
+3. avoid presenting that budget as the final paper-aligned main budget
+
+If compute/time constraints force a very small smoke run, that is acceptable
+provided the report clearly says:
+
+- what was actually run
+- what remains for the main run
+- whether the observed behavior is stable enough to proceed
+
+Do NOT hide resource limits inside ambiguous wording.
+
+==================================================
+8. REQUIRED ARTIFACTS
+==================================================
+
+You must produce enough artifacts to verify the smoke run is real and inspectable.
+
+At minimum, provide:
+
+- smoke training outputs under `outputs/stage5/`
+- a config snapshot
+- run summary / history / checkpoints / previews
+- `docs/execution/stage5_smoke_report.md`
+
+The report should include at least:
+
+- smoke objective and scope boundary
+- exact command(s) used
+- config path(s)
+- artifact path(s)
+- key stability observations
+- loss-trend summary
+- any regular-eval / blind-eval follow-up that was run
+- what remains for Issue 5.10
+
+==================================================
+9. FILE SCOPE
+==================================================
+
+Primary files likely to be changed or added:
+
+- a smoke config under `configs/stage5/`
+- `docs/execution/stage5_smoke_report.md`
+- possibly `README.md` if a new user-facing smoke command should be documented
+
+Supporting edits are allowed in:
+
+- existing Stage 5 trainer/eval configs
+
+but only if the edits are narrow and clearly smoke-related.
+
+Avoid:
+
+- broad code refactors
+- regular eval rewrites
+- blind-eval rewrites
+- main-run report files
+
+==================================================
+10. ACCEPTANCE CRITERIA
+==================================================
+
+Issue 5.9 is complete only if:
+
+1. A real paper-aligned smoke run is executed and logged
+2. Training completes without NaN / Inf
+3. Loss shows at least modestly interpretable behavior
+4. Artifacts are complete and traceable
+5. A concise smoke report is written
+6. The report clearly distinguishes smoke validation from the later main run
+
+==================================================
+11. FINAL RESPONSE FORMAT
+==================================================
+
+After finishing, respond with:
+
+- short summary of what was executed
+- exact files changed
+- the smoke config / command used
+- what artifacts were produced
+- the key stability findings
+- whether any regular eval / blind eval was run after smoke
+- what remains for Issue 5.10

--- a/scripts/eval_stage5_blind_linepair.py
+++ b/scripts/eval_stage5_blind_linepair.py
@@ -1,0 +1,413 @@
+﻿#!/usr/bin/env python
+"""Run Stage 5 blind line-pair evaluation on a paper-path checkpoint."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.datasets import Stage4RoiTargetAdapter
+from src.eval.stage5_blind_targets import build_stage5_blind_line_pair_targets
+from src.models.encoders import PaperPhaseEncoder
+from src.models.optics.diffractive_decoder import DiffractiveDecoder
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run the Stage 5 blind line-pair hook on a paper-aligned checkpoint."
+    )
+    parser.add_argument("--config", type=str, required=True)
+    parser.add_argument("--checkpoint", type=str, required=True)
+    parser.add_argument("--run-name", type=str, default=None)
+    parser.add_argument("--device", type=str, default=None)
+    parser.add_argument("--preview-limit", type=int, default=None)
+    return parser.parse_args()
+
+
+def load_yaml(path: str | Path) -> dict[str, Any]:
+    with Path(path).open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle)
+    if not isinstance(data, dict):
+        raise TypeError(f"Config at {path} must load to a dict, got {type(data)!r}.")
+    return data
+
+
+def require_mapping(root: dict[str, Any], *keys: str) -> dict[str, Any]:
+    current: Any = root
+    for key in keys:
+        if not isinstance(current, dict) or key not in current:
+            raise KeyError(f"Missing config path: {'/'.join(keys)}")
+        current = current[key]
+    if not isinstance(current, dict):
+        raise TypeError(f"Config path {'/'.join(keys)} must be a mapping.")
+    return current
+
+
+def normalize_device(device_arg: str) -> torch.device:
+    normalized = device_arg.lower()
+    if normalized == "auto":
+        return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if normalized == "cuda" and not torch.cuda.is_available():
+        raise RuntimeError("Requested CUDA but it is not available.")
+    if normalized not in {"cpu", "cuda"}:
+        raise ValueError(f"Unsupported device value: {device_arg}.")
+    return torch.device(normalized)
+
+
+def save_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, ensure_ascii=False)
+
+
+def _to_gray_numpy(image: torch.Tensor) -> np.ndarray:
+    tensor = image.detach().cpu().float()
+    if tensor.ndim == 2:
+        return tensor.numpy()
+    if tensor.ndim == 3 and tensor.shape[0] == 1:
+        return tensor[0].numpy()
+    raise ValueError(f"Expected grayscale tensor, got shape {tuple(tensor.shape)}.")
+
+
+def build_encoder_decoder(
+    encoder_cfg: dict[str, Any],
+    optics_cfg: dict[str, Any],
+    *,
+    depth: int,
+    device: torch.device,
+) -> tuple[PaperPhaseEncoder, DiffractiveDecoder]:
+    target_hw = tuple(encoder_cfg["target_hw"])
+    optics_input_hw = tuple(optics_cfg["grid"]["input_pattern_hw"])
+    if target_hw != optics_input_hw:
+        raise ValueError(
+            "Stage 5 encoder target_hw must match optics input_pattern_hw, "
+            f"got {target_hw} vs {optics_input_hw}."
+        )
+
+    encoder = PaperPhaseEncoder(
+        in_channels=int(encoder_cfg["in_channels"]),
+        input_hw=tuple(encoder_cfg["input_hw"]),
+        target_hw=target_hw,
+        base_channels=int(encoder_cfg["base_channels"]),
+        hidden_channels=int(encoder_cfg["hidden_channels"]),
+        interpolation_mode=str(encoder_cfg["interpolation_mode"]),
+        align_corners=bool(encoder_cfg["align_corners"]),
+        phase_mapping=str(encoder_cfg["phase_mapping"]),
+        phase_range=tuple(float(value) for value in encoder_cfg["phase_range"]),
+    ).to(device)
+
+    depth_cfg = optics_cfg["depths"][str(depth)]
+    decoder = DiffractiveDecoder(
+        num_diffractive_layers=int(depth_cfg["num_diffractive_layers"]),
+        wavelength=float(optics_cfg["units"]["wavelength"]),
+        pixel_pitch=float(optics_cfg["units"]["pixel_pitch_lambda"]),
+        grid_config=optics_cfg["grid"],
+        distance_schedule=depth_cfg["distance_schedule"],
+        readout_config={"output_crop_hw": optics_cfg["readout"]["output_crop_hw"]},
+        phase_mask_config=dict(optics_cfg.get("phase_mask_config", {})),
+    ).to(device)
+    return encoder, decoder
+
+
+def load_model_from_checkpoint(
+    checkpoint_path: str | Path,
+    *,
+    device: torch.device,
+) -> tuple[PaperPhaseEncoder, DiffractiveDecoder, dict[str, Any], int]:
+    checkpoint = torch.load(checkpoint_path, map_location=device)
+    config_snapshot = checkpoint.get("config_snapshot")
+    if not isinstance(config_snapshot, dict):
+        raise KeyError("Checkpoint is missing config_snapshot required for Stage 5 blind eval.")
+
+    encoder_cfg = config_snapshot.get("encoder_config")
+    optics_cfg = config_snapshot.get("optics_config")
+    depth = config_snapshot.get("depth")
+    if not isinstance(encoder_cfg, dict) or not isinstance(optics_cfg, dict) or depth is None:
+        raise KeyError(
+            "Checkpoint config_snapshot must contain encoder_config, optics_config, and depth."
+        )
+
+    encoder, decoder = build_encoder_decoder(
+        encoder_cfg,
+        optics_cfg,
+        depth=int(depth),
+        device=device,
+    )
+    encoder.load_state_dict(checkpoint["encoder_state_dict"])
+    decoder.load_state_dict(checkpoint["decoder_state_dict"])
+    encoder.eval()
+    decoder.eval()
+    return encoder, decoder, config_snapshot, int(depth)
+
+
+def save_image_grid(
+    output_path: Path,
+    images: torch.Tensor,
+    metadata: list[dict[str, Any]],
+    *,
+    title_key: str,
+    max_items: int | None = None,
+) -> None:
+    item_count = images.shape[0] if max_items is None else min(images.shape[0], max_items)
+    if item_count < 1:
+        raise ValueError("save_image_grid requires at least one image.")
+    num_cols = min(4, item_count)
+    num_rows = int(np.ceil(item_count / num_cols))
+    fig, axes = plt.subplots(num_rows, num_cols, figsize=(4.0 * num_cols, 4.0 * num_rows))
+    axes_array = np.atleast_1d(axes).reshape(num_rows, num_cols)
+
+    for flat_index in range(num_rows * num_cols):
+        axis = axes_array.flat[flat_index]
+        if flat_index >= item_count:
+            axis.axis("off")
+            continue
+        axis.imshow(_to_gray_numpy(images[flat_index]), cmap="gray", vmin=0.0, vmax=1.0)
+        axis.set_title(str(metadata[flat_index][title_key]))
+        axis.axis("off")
+
+    fig.tight_layout()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output_path, dpi=180, bbox_inches="tight")
+    plt.close(fig)
+
+
+def save_comparison_grid(
+    output_path: Path,
+    blind_targets: torch.Tensor,
+    target_roi: torch.Tensor,
+    prediction_roi: torch.Tensor,
+    metadata: list[dict[str, Any]],
+    *,
+    preview_limit: int,
+) -> None:
+    row_count = min(preview_limit, blind_targets.shape[0])
+    if row_count < 1:
+        raise ValueError("preview_limit must allow at least one comparison row.")
+
+    blind_targets = blind_targets[:row_count].detach().cpu()
+    target_roi = target_roi[:row_count].detach().cpu()
+    prediction_roi = prediction_roi[:row_count].detach().cpu()
+    abs_error = torch.abs(target_roi - prediction_roi)
+
+    fig, axes = plt.subplots(row_count, 4, figsize=(12.0, max(3.0, 3.0 * row_count)))
+    if row_count == 1:
+        axes = np.expand_dims(axes, axis=0)
+
+    titles = ("blind_target_hr", "target_roi", "model I_out_roi", "|target-model|")
+    for row_index in range(row_count):
+        panels = (
+            _to_gray_numpy(blind_targets[row_index]),
+            _to_gray_numpy(target_roi[row_index]),
+            _to_gray_numpy(prediction_roi[row_index]),
+            _to_gray_numpy(abs_error[row_index]),
+        )
+        error_max = float(abs_error[row_index].max().item()) + 1e-8
+        ranges = ((0.0, 1.0), (0.0, 1.0), (0.0, 1.0), (0.0, error_max))
+        for col_index, axis in enumerate(axes[row_index]):
+            vmin, vmax = ranges[col_index]
+            axis.imshow(panels[col_index], cmap="gray", vmin=vmin, vmax=vmax)
+            if row_index == 0:
+                axis.set_title(titles[col_index])
+            axis.axis("off")
+        axes[row_index, 0].set_ylabel(str(metadata[row_index]["target_id"]), rotation=90, labelpad=10)
+
+    fig.tight_layout()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output_path, dpi=180, bbox_inches="tight")
+    plt.close(fig)
+
+
+@torch.no_grad()
+def run_blind_forward(
+    encoder: PaperPhaseEncoder,
+    decoder: DiffractiveDecoder,
+    blind_targets: torch.Tensor,
+    *,
+    batch_size: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, dict[str, list[int]]]:
+    prediction_parts: list[torch.Tensor] = []
+    phi_parts: list[torch.Tensor] = []
+    shape_summary: dict[str, list[int]] | None = None
+
+    for batch_start in range(0, blind_targets.shape[0], batch_size):
+        batch = blind_targets[batch_start : batch_start + batch_size].to(device)
+        phi_lr = encoder(batch)
+        output = decoder.forward_from_phase(phi_lr, return_intermediates=False)
+        prediction_roi = output["I_out_roi"]
+        prediction_parts.append(prediction_roi.detach().cpu())
+        phi_parts.append(phi_lr.detach().cpu())
+        if shape_summary is None:
+            shape_summary = {
+                "U0": list(output["U0"].shape),
+                "U_out_full": list(output["U_out_full"].shape),
+                "I_out_full": list(output["I_out_full"].shape),
+                "I_out_roi": list(output["I_out_roi"].shape),
+            }
+
+    if shape_summary is None:
+        raise RuntimeError("Blind target bank is empty.")
+    return torch.cat(prediction_parts, dim=0), torch.cat(phi_parts, dim=0), shape_summary
+
+
+def build_per_target_records(
+    metadata: list[dict[str, Any]],
+    target_roi: torch.Tensor,
+    prediction_roi: torch.Tensor,
+) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for item, target, prediction in zip(metadata, target_roi, prediction_roi, strict=True):
+        records.append(
+            {
+                **item,
+                "target_roi_mean": float(target.mean().item()),
+                "target_roi_sum": float(target.sum().item()),
+                "prediction_min": float(prediction.min().item()),
+                "prediction_max": float(prediction.max().item()),
+                "prediction_mean": float(prediction.mean().item()),
+                "prediction_sum": float(prediction.sum().item()),
+            }
+        )
+    return records
+
+
+def main() -> None:
+    args = parse_args()
+    blind_root = load_yaml(args.config)
+    blind_cfg = require_mapping(blind_root, "eval", "stage5_blind_linepair")
+    runtime_cfg = dict(blind_cfg["runtime"])
+    target_generation_cfg = dict(blind_cfg["target_generation"])
+
+    preview_limit = int(
+        args.preview_limit if args.preview_limit is not None else runtime_cfg["preview_limit"]
+    )
+    if preview_limit < 1:
+        raise ValueError("preview_limit must be >= 1.")
+
+    device = normalize_device(str(args.device or runtime_cfg["device"]))
+    checkpoint_path = Path(args.checkpoint).resolve()
+    output_root = Path(blind_cfg["output_root"])
+    run_name = args.run_name or blind_cfg.get("run_name") or datetime.now(timezone.utc).strftime(
+        "%Y%m%dT%H%M%SZ"
+    )
+    run_dir = output_root / run_name
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    encoder, decoder, checkpoint_snapshot, depth = load_model_from_checkpoint(
+        checkpoint_path,
+        device=device,
+    )
+
+    blind_targets, metadata = build_stage5_blind_line_pair_targets(target_generation_cfg)
+    target_adapter = Stage4RoiTargetAdapter(output_crop_hw=decoder.readout_config)
+    target_roi = target_adapter(blind_targets)
+    prediction_roi, phi_lr, sample_forward_shapes = run_blind_forward(
+        encoder,
+        decoder,
+        blind_targets,
+        batch_size=int(runtime_cfg["batch_size"]),
+        device=device,
+    )
+
+    save_image_grid(run_dir / "blind_targets_grid.png", blind_targets, metadata, title_key="target_id")
+    save_image_grid(run_dir / "blind_outputs_grid.png", prediction_roi, metadata, title_key="target_id")
+    save_comparison_grid(
+        run_dir / "blind_comparison_grid.png",
+        blind_targets,
+        target_roi,
+        prediction_roi,
+        metadata,
+        preview_limit=preview_limit,
+    )
+
+    config_snapshot = {
+        "blind_eval_config_path": str(Path(args.config).resolve()),
+        "checkpoint_path": str(checkpoint_path),
+        "run_name": run_name,
+        "device": str(device),
+        "runtime": runtime_cfg,
+        "target_generation": target_generation_cfg,
+        "checkpoint_snapshot_excerpt": {
+            "depth": depth,
+            "optics_readout": checkpoint_snapshot["optics_config"]["readout"],
+            "encoder_target_hw": checkpoint_snapshot["encoder_config"]["target_hw"],
+        },
+        "created_at_utc": datetime.now(timezone.utc).isoformat(),
+    }
+    save_json(run_dir / "config_snapshot.json", config_snapshot)
+
+    readout_cfg = checkpoint_snapshot["optics_config"]["readout"]
+    summary = {
+        "checkpoint_path": str(checkpoint_path),
+        "blind_target_family": target_generation_cfg["target_family"],
+        "blind_target_count": int(blind_targets.shape[0]),
+        "blind_target_generation": {
+            **target_generation_cfg,
+            "binary_or_smoothed": (
+                "binary" if float(target_generation_cfg.get("blur_sigma", 0.0)) == 0.0 else "smoothed"
+            ),
+        },
+        "forward_hook": {
+            "model_input": "generated_blind_target_hr",
+            "prediction_tensor": "I_out_roi",
+            "target_tensor_for_visual_reference": "target_roi",
+            "hook_note": (
+                "Issue 5.8 reuses the Stage 5 checkpoint-loading path and the same "
+                "encoder -> decoder -> I_out_roi forward contract as regular eval."
+            ),
+        },
+        "crop_assumptions": {
+            "output_crop_hw": list(readout_cfg["output_crop_hw"]),
+            "crop_policy": readout_cfg.get("crop_policy", "center_crop"),
+            "center_offset_hw": readout_cfg.get("center_offset_hw"),
+            "fov_alignment_note": readout_cfg.get("fov_alignment_note"),
+            "target_adapter": {
+                "resize_mode": target_adapter.resize_mode,
+                "align_corners": target_adapter.align_corners,
+                "clamp_range": list(target_adapter.clamp_range),
+            },
+        },
+        "scalar_metric_policy": {
+            "paper_final_blind_metric_claimed": False,
+            "note": (
+                "Issue 5.8 saves reproducible blind-test artifacts and per-target metadata "
+                "for visual inspection; it does not introduce a new paper-final scalar blind score."
+            ),
+        },
+        "output_shapes": {
+            "blind_target_hr": list(blind_targets.shape),
+            "target_roi": list(target_roi.shape),
+            "phi_lr": list(phi_lr.shape),
+            "sample_forward": sample_forward_shapes,
+        },
+        "per_target_records": build_per_target_records(metadata, target_roi, prediction_roi),
+        "artifacts": {
+            "config_snapshot": str((run_dir / "config_snapshot.json").resolve()),
+            "summary": str((run_dir / "summary.json").resolve()),
+            "blind_targets_grid": str((run_dir / "blind_targets_grid.png").resolve()),
+            "blind_outputs_grid": str((run_dir / "blind_outputs_grid.png").resolve()),
+            "blind_comparison_grid": str((run_dir / "blind_comparison_grid.png").resolve()),
+        },
+    }
+    save_json(run_dir / "summary.json", summary)
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/eval/stage5_blind_targets.py
+++ b/src/eval/stage5_blind_targets.py
@@ -1,0 +1,217 @@
+﻿"""Deterministic blind line-pair target generation for Stage 5."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+
+
+def _normalize_hw(hw: Sequence[int] | int, *, name: str) -> tuple[int, int]:
+    if isinstance(hw, int):
+        if hw < 1:
+            raise ValueError(f"{name} must be >= 1, got {hw}.")
+        return (hw, hw)
+    if not isinstance(hw, Sequence) or isinstance(hw, (str, bytes)) or len(hw) != 2:
+        raise TypeError(f"{name} must be an int or a length-2 sequence, got {hw!r}.")
+    height = int(hw[0])
+    width = int(hw[1])
+    if height < 1 or width < 1:
+        raise ValueError(f"{name} values must be >= 1, got {(height, width)}.")
+    return (height, width)
+
+
+def _gaussian_kernel1d(kernel_size: int, sigma: float) -> torch.Tensor:
+    if kernel_size < 1 or kernel_size % 2 == 0:
+        raise ValueError(f"kernel_size must be a positive odd integer, got {kernel_size}.")
+    if sigma <= 0.0:
+        raise ValueError(f"sigma must be > 0, got {sigma}.")
+    radius = kernel_size // 2
+    coords = torch.arange(-radius, radius + 1, dtype=torch.float32)
+    kernel = torch.exp(-(coords.square()) / (2.0 * sigma * sigma))
+    return kernel / kernel.sum()
+
+
+def _apply_gaussian_blur(
+    image: torch.Tensor,
+    *,
+    sigma: float,
+    kernel_size: int,
+) -> torch.Tensor:
+    if sigma <= 0.0:
+        return image
+    kernel_1d = _gaussian_kernel1d(kernel_size, sigma).to(device=image.device, dtype=image.dtype)
+    kernel_2d = torch.outer(kernel_1d, kernel_1d)
+    kernel_2d = kernel_2d.view(1, 1, kernel_size, kernel_size)
+    padding = kernel_size // 2
+    blurred = F.conv2d(image.unsqueeze(0), kernel_2d, padding=padding)
+    return blurred.squeeze(0)
+
+
+@dataclass(frozen=True)
+class BlindLinePairSpec:
+    """Single deterministic blind line-pair target specification."""
+
+    target_id: str
+    orientation: str
+    line_width_px: int
+    gap_px: int
+    margin_px: int
+    line_length_px: int
+    render_mode: str
+    blur_sigma: float
+    blur_kernel_size: int
+
+    def to_summary(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _validate_orientation(orientation: str) -> str:
+    normalized = str(orientation).lower()
+    if normalized not in {"horizontal", "vertical"}:
+        raise ValueError(
+            "orientation must be one of {'horizontal', 'vertical'}, "
+            f"got {orientation!r}."
+        )
+    return normalized
+
+
+def build_blind_line_pair_image(
+    spec: BlindLinePairSpec,
+    *,
+    canvas_hw: tuple[int, int],
+    line_value: float,
+    background_value: float,
+) -> torch.Tensor:
+    """Render a centered line-pair target as a single-channel tensor."""
+    height, width = canvas_hw
+    line_value = float(line_value)
+    background_value = float(background_value)
+    image = torch.full((1, height, width), background_value, dtype=torch.float32)
+
+    orientation = _validate_orientation(spec.orientation)
+    line_width = int(spec.line_width_px)
+    gap_px = int(spec.gap_px)
+    margin_px = int(spec.margin_px)
+    line_length_px = int(spec.line_length_px)
+
+    if line_width < 1:
+        raise ValueError(f"line_width_px must be >= 1, got {line_width}.")
+    if gap_px < 1:
+        raise ValueError(f"gap_px must be >= 1, got {gap_px}.")
+    if margin_px < 0:
+        raise ValueError(f"margin_px must be >= 0, got {margin_px}.")
+
+    total_span = (2 * line_width) + gap_px
+    if orientation == "horizontal":
+        if line_length_px > width - (2 * margin_px):
+            raise ValueError(
+                "line_length_px must fit inside the horizontal canvas span, "
+                f"got line_length_px={line_length_px}, canvas_hw={canvas_hw}, margin_px={margin_px}."
+            )
+        if total_span > height:
+            raise ValueError(
+                f"line pair total span {total_span} exceeds canvas height {height}."
+            )
+        top = (height - total_span) // 2
+        left = (width - line_length_px) // 2
+        image[:, top : top + line_width, left : left + line_length_px] = line_value
+        lower_top = top + line_width + gap_px
+        image[:, lower_top : lower_top + line_width, left : left + line_length_px] = line_value
+    else:
+        if line_length_px > height - (2 * margin_px):
+            raise ValueError(
+                "line_length_px must fit inside the vertical canvas span, "
+                f"got line_length_px={line_length_px}, canvas_hw={canvas_hw}, margin_px={margin_px}."
+            )
+        if total_span > width:
+            raise ValueError(
+                f"line pair total span {total_span} exceeds canvas width {width}."
+            )
+        left = (width - total_span) // 2
+        top = (height - line_length_px) // 2
+        image[:, top : top + line_length_px, left : left + line_width] = line_value
+        right_left = left + line_width + gap_px
+        image[:, top : top + line_length_px, right_left : right_left + line_width] = line_value
+
+    if spec.render_mode != "binary":
+        raise ValueError(
+            f"Only render_mode='binary' is currently supported, got {spec.render_mode!r}."
+        )
+    return torch.clamp(
+        _apply_gaussian_blur(
+            image,
+            sigma=float(spec.blur_sigma),
+            kernel_size=int(spec.blur_kernel_size),
+        ),
+        min=min(background_value, line_value),
+        max=max(background_value, line_value),
+    )
+
+
+def build_stage5_blind_line_pair_targets(
+    config: Mapping[str, Any],
+) -> tuple[torch.Tensor, list[dict[str, Any]]]:
+    """Build the full deterministic Stage 5 blind line-pair target bank."""
+    canvas_hw = _normalize_hw(config["canvas_hw"], name="canvas_hw")
+    render_mode = str(config.get("render_mode", "binary"))
+    blur_sigma = float(config.get("blur_sigma", 0.0))
+    blur_kernel_size = int(config.get("blur_kernel_size", 5))
+    margin_px = int(config["margin_px"])
+    line_widths_px = [int(value) for value in config["line_widths_px"]]
+    gap_values_px = [int(value) for value in config["gap_px"]]
+    orientations = [_validate_orientation(value) for value in config["orientations"]]
+
+    if margin_px < 0:
+        raise ValueError(f"margin_px must be >= 0, got {margin_px}.")
+    if not line_widths_px:
+        raise ValueError("line_widths_px must not be empty.")
+    if not gap_values_px:
+        raise ValueError("gap_px must not be empty.")
+    if not orientations:
+        raise ValueError("orientations must not be empty.")
+
+    line_length_px = int(config.get("line_length_px", min(canvas_hw) - (2 * margin_px)))
+    max_length = min(canvas_hw[0] - (2 * margin_px), canvas_hw[1] - (2 * margin_px))
+    if line_length_px < 1 or line_length_px > max_length:
+        raise ValueError(
+            "line_length_px must be in [1, max_length], "
+            f"got {line_length_px} with max_length={max_length}."
+        )
+
+    images: list[torch.Tensor] = []
+    metadata: list[dict[str, Any]] = []
+    for orientation in orientations:
+        for line_width_px in line_widths_px:
+            for gap_px in gap_values_px:
+                spec = BlindLinePairSpec(
+                    target_id=f"{orientation}_w{line_width_px}_g{gap_px}",
+                    orientation=orientation,
+                    line_width_px=line_width_px,
+                    gap_px=gap_px,
+                    margin_px=margin_px,
+                    line_length_px=line_length_px,
+                    render_mode=render_mode,
+                    blur_sigma=blur_sigma,
+                    blur_kernel_size=blur_kernel_size,
+                )
+                image = build_blind_line_pair_image(
+                    spec,
+                    canvas_hw=canvas_hw,
+                    line_value=float(config.get("line_value", 1.0)),
+                    background_value=float(config.get("background_value", 0.0)),
+                )
+                images.append(image)
+                metadata.append(spec.to_summary())
+
+    return torch.stack(images, dim=0), metadata
+
+
+__all__ = [
+    "BlindLinePairSpec",
+    "build_blind_line_pair_image",
+    "build_stage5_blind_line_pair_targets",
+]


### PR DESCRIPTION
why:
land a separate stage5 blind-test path after regular eval so line-pair artifacts can be generated and inspected reproducibly without rewriting PSNR/SSIM evaluation or pulling in stage6 study scope

what:
add a deterministic blind line-pair target generator, a stage5 blind checkpoint-eval script that reuses the existing encoder-decoder forward path, a configurable blind-eval config, and saved blind target/output artifacts plus metadata under outputs/stage5/blind_eval