### PR TITLE
feat(train | stage5-9): run paper-aligned smoke training

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ More orders are listed in docs/run_order.md. Here are some frequently used comma
   `python scripts/check_stage5_sr_loss.py --config configs/stage5/stage5_sr_loss.yaml`
 - Run the Stage 5 paper-aligned short trainer sanity:
   `python scripts/train_stage5_paper.py --config configs/stage5/stage5_trainer_short.yaml`
+- Run the Stage 5 smoke training config:
+  `python scripts/train_stage5_paper.py --config configs/stage5/stage5_trainer_smoke.yaml --run-name issue5_9_l5_smoke`
 - Run the Stage 5 regular eval with bicubic baseline:
   `python scripts/eval_stage5_paper.py --config configs/stage5/stage5_eval.yaml --checkpoint outputs/stage5/paper_trainer/issue5_6_resume_demo/checkpoints/checkpoint_best.pt --split val`
 - Run the Stage 5 blind line-pair hook:

--- a/configs/stage5/stage5_trainer_smoke.yaml
+++ b/configs/stage5/stage5_trainer_smoke.yaml
@@ -1,0 +1,35 @@
+﻿trainer:
+  stage5_paper:
+    mode: smoke
+    protocol_note: >
+      Stage 5 smoke run. This config keeps the frozen paper-aligned dataset,
+      optics, encoder, and loss path unchanged, but uses a reduced smoke-only
+      budget to validate end-to-end stability before Issue 5.10 main-run work.
+    output_root: outputs/stage5/smoke
+    run_name: l5_smoke_cpu
+    config_paths:
+      dataset: configs/stage5/stage5_emnist_display.yaml
+      optics: configs/stage5/stage5_optics_paper_aligned.yaml
+      encoder: configs/stage5/stage5_paper_encoder.yaml
+      loss: configs/stage5/stage5_sr_loss.yaml
+    runtime:
+      steps: 4
+      batch_size: 2
+      validate_every: 1
+      preview_limit: 2
+      seed: 59
+      device: cpu
+      num_workers: 0
+      download: false
+      train_shuffle: true
+    dataset_selection:
+      train_subset_size: 12
+      val_subset_size: 4
+    model:
+      depth: 5
+    optimizer:
+      name: Adam
+      lr_encoder: 0.0005
+      lr_decoder: 0.001
+    loss_wiring:
+      input_power_source: U0_full_grid_intensity_sum

--- a/docs/ai/CodexFeedback/stage5/feedback_stage5-9.md
+++ b/docs/ai/CodexFeedback/stage5/feedback_stage5-9.md
@@ -1,0 +1,90 @@
+﻿执行了一个真实的 Stage 5 paper-aligned smoke run，并把 smoke-only 预算、训练稳定性、artifact 路径、regular eval 跟进和 blind eval 跟进都收口成了单独报告，没有把这次短跑伪装成 main run，也没有重开 trainer / eval 协议。
+
+精确变更文件：
+- [configs/stage5/stage5_trainer_smoke.yaml](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/configs/stage5/stage5_trainer_smoke.yaml)
+- [docs/execution/stage5_smoke_report.md](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/docs/execution/stage5_smoke_report.md)
+- [README.md](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/README.md)
+- [docs/ai/CodexFeedback/stage5/feedback_stage5-9.md](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/docs/ai/CodexFeedback/stage5/feedback_stage5-9.md)
+
+smoke config 与命令：
+- smoke config: [configs/stage5/stage5_trainer_smoke.yaml](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/configs/stage5/stage5_trainer_smoke.yaml)
+- smoke-only budget:
+  - `depth = 5`
+  - `device = cpu`
+  - `steps = 4`
+  - `batch_size = 2`
+  - `train_subset_size = 12`
+  - `val_subset_size = 4`
+  - `validate_every = 1`
+  - `preview_limit = 2`
+  - `resume = no`
+- training command:
+  - `python scripts/train_stage5_paper.py --config configs/stage5/stage5_trainer_smoke.yaml --run-name issue5_9_l5_smoke`
+
+实际产出的 smoke artifacts：
+- smoke run root:
+  - [outputs/stage5/smoke/issue5_9_l5_smoke](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/smoke/issue5_9_l5_smoke)
+- key files:
+  - [config_snapshot.json](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/smoke/issue5_9_l5_smoke/config_snapshot.json)
+  - [history.json](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/smoke/issue5_9_l5_smoke/history.json)
+  - [grad_stats.json](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/smoke/issue5_9_l5_smoke/grad_stats.json)
+  - [run_summary.json](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/smoke/issue5_9_l5_smoke/run_summary.json)
+  - [loss_curve.png](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/smoke/issue5_9_l5_smoke/loss_curve.png)
+  - [preview_step0.png](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/smoke/issue5_9_l5_smoke/preview_step0.png)
+  - [preview_best.png](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/smoke/issue5_9_l5_smoke/preview_best.png)
+  - [preview_final.png](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/smoke/issue5_9_l5_smoke/preview_final.png)
+  - [checkpoint_best.pt](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/smoke/issue5_9_l5_smoke/checkpoints/checkpoint_best.pt)
+  - [checkpoint_latest.pt](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/smoke/issue5_9_l5_smoke/checkpoints/checkpoint_latest.pt)
+
+关键稳定性结论：
+- 训练在 `L=5`、`4` 步、CPU smoke 预算下顺利完成，无 NaN / Inf
+- encoder 和 decoder 在 `1~4` 步都存在非零梯度
+- `val_loss` 从 `0.0702461712` 下降到 `0.0702020377`
+- `train_loss` 从 `0.1281592697` 下降到 `0.0876854211`，中间有小幅波动，但始终有限且可解释
+- `best_step = 4`，`best_val_loss = 0.0702020377`
+- 因为冻结的 Stage 5 `gamma_by_depth[5] = 0.0`，本次 smoke 的 efficiency term 记录为 `0.0`，这是沿用 `5.5`，不是本 issue 新决定
+
+smoke 之后是否执行 eval：
+- regular eval：已执行
+  - command:
+    - `python scripts/eval_stage5_paper.py --config configs/stage5/stage5_eval.yaml --checkpoint outputs/stage5/smoke/issue5_9_l5_smoke/checkpoints/checkpoint_best.pt --split val --subset-size 4 --run-name issue5_9_smoke_val_eval`
+  - outputs:
+    - [summary.json](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/eval/issue5_9_smoke_val_eval/summary.json)
+    - [preview_comparison.png](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/eval/issue5_9_smoke_val_eval/preview_comparison.png)
+  - metrics:
+    - model `PSNR = 13.0716336177`
+    - model `SSIM = 0.2514762123`
+    - bicubic `PSNR = 28.4709274795`
+    - bicubic `SSIM = 0.9607577262`
+- blind eval：已执行
+  - command:
+    - `python scripts/eval_stage5_blind_linepair.py --config configs/stage5/stage5_blind_eval.yaml --checkpoint outputs/stage5/smoke/issue5_9_l5_smoke/checkpoints/checkpoint_best.pt --run-name issue5_9_smoke_blind_eval`
+  - outputs:
+    - [summary.json](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/blind_eval/issue5_9_smoke_blind_eval/summary.json)
+    - [blind_targets_grid.png](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/blind_eval/issue5_9_smoke_blind_eval/blind_targets_grid.png)
+    - [blind_outputs_grid.png](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/blind_eval/issue5_9_smoke_blind_eval/blind_outputs_grid.png)
+    - [blind_comparison_grid.png](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/blind_eval/issue5_9_smoke_blind_eval/blind_comparison_grid.png)
+  - blind target bank size: `24`
+
+留给 Issue 5.10 的内容：
+- 单独定义 main-run budget，不能复用这次 smoke config
+- 更长训练和正式 val/test 记录
+- main-run 层面的结果报告与复盘
+- 继续消费现有 trainer / regular eval / blind eval 路径，而不是改写它们
+
+推荐的 commit 三段式信息：
+
+```text
+feat(train | stage5-9): run paper-aligned smoke training
+
+why:
+validate that the frozen stage5 paper-path can train end to end under a
+small smoke-only budget before main-run work, and record stability plus
+artifact completeness without confusing smoke with final results
+
+what:
+add a dedicated stage5 smoke config, execute an L=5 smoke training run,
+record checkpoints, history, previews, and a smoke report, and attach
+post-run regular eval and blind eval evidence using the existing stage5
+paths
+```

--- a/docs/ai/prompt/stage5/prompt_stage5-10.md
+++ b/docs/ai/prompt/stage5/prompt_stage5-10.md
@@ -1,0 +1,252 @@
+You are working in a research-engineering repository for reproducing
+"Super-resolution image display using diffractive decoders".
+
+Your task is to complete GitHub Issue 5.10:
+
+Issue title:
+Run paper-aligned main training (phase-only, L=5) and write report
+
+Important execution constraint:
+
+- The real full-budget main run will be executed later on a Linux server.
+- In this workspace, do NOT launch a long full-dataset main run locally.
+- Your job here is to make the main run launch-ready:
+  - finalize the main-run config/code path
+  - write the exact Linux-server run commands into `docs/run_order.md`
+  - add any narrow report/template docs needed for later result collection
+
+This is a Stage-5-scoped main-run-prep task under a remote-execution constraint.
+Do not turn it into a local long-run execution task or a Stage 6 sweep.
+
+==================================================
+0. MUST-READ CONTEXT FIRST
+==================================================
+
+Before doing anything, you MUST read and follow these files in order:
+
+1. `AGENTS.md`
+2. `docs/ai/PROJECT_CONTEXT.md`
+3. `docs/plan/stage_plan/stage5/stage5_protocol_freeze.md`
+4. `docs/plan/stage_plan/stage5/stage5_plan.md`
+5. `docs/plan/stage_plan/stage5/stage5_issue_plan.md`
+6. `docs/execution/stage5_smoke_report.md`
+7. `docs/run_order.md`
+8. `configs/stage5/stage5_trainer_smoke.yaml`
+9. `configs/stage5/stage5_eval.yaml`
+10. `configs/stage5/stage5_blind_eval.yaml`
+
+Then inspect these implementation-reference files before editing:
+
+11. `scripts/train_stage5_paper.py`
+12. `scripts/eval_stage5_paper.py`
+13. `scripts/eval_stage5_blind_linepair.py`
+14. `docs/ai/CodexFeedback/stage5/feedback_stage5-9.md`
+
+Important scope rules:
+
+- If `paper_notes.md` is broader than the Stage 5 schedule, follow the Stage 5 docs.
+- This issue should prepare the main run, not silently execute it locally.
+- The deliverable must be launch-ready for Linux-server execution.
+
+==================================================
+1. ISSUE 5.10 GOAL
+==================================================
+
+Prepare the paper-aligned main-run path for phase-only `L=5` so that the user
+can execute it on a Linux server with clear commands and traceable artifacts.
+
+The result should provide:
+
+1. a dedicated main-run config
+2. exact Linux-server training / eval / blind-eval commands in `docs/run_order.md`
+3. a clear separation between:
+   - code/config path is ready
+   - full long-run results are pending server execution
+4. any minimal report scaffold needed for later result capture
+
+==================================================
+2. NON-GOALS - DO NOT DRIFT
+==================================================
+
+Do NOT do any of the following:
+
+- do not launch a real long full-budget main run locally in this workspace
+- do not rewrite trainer / eval / blind-eval architecture
+- do not reopen frozen Stage 5 protocol items
+- do not add Stage 6 ablations, robustness, or quantization work
+- do not present smoke results as main-run results
+- do not hide the Linux-server constraint
+
+This issue is successful only if it makes the main run ready to launch on the
+Linux server and documents that launch path clearly.
+
+==================================================
+3. BRANCH EXPECTATION
+==================================================
+
+Suggested branch:
+- `feat/train`
+
+Stay on a training/execution-oriented branch.
+Do not absorb Stage 5.11 doc-consolidation scope beyond what this issue strictly needs.
+
+==================================================
+4. REQUIRED INHERITANCE
+==================================================
+
+From the Stage 5 docs and prior issues, this issue must inherit and obey:
+
+1. Frozen optical contract:
+   `phi_lr -> U0 -> U_out_full -> I_out_full -> I_out_roi`
+2. Smoke run already demonstrated local pipeline stability.
+3. Regular eval + bicubic baseline already exist from Issue 5.7.
+4. Blind eval hook already exists from Issue 5.8.
+5. Main run should consume those paths, not redesign them.
+
+Important inheritance detail:
+
+- The main-run target is phase-only `L=5`.
+- The actual heavy execution belongs on the Linux server.
+- This issue must therefore emphasize launch readiness, command clarity, and
+  artifact conventions over local long-run results.
+
+==================================================
+5. WHAT YOU ARE ALLOWED TO FINALIZE HERE
+==================================================
+
+This issue MAY finalize:
+
+1. the dedicated Stage 5 main-run config
+2. the exact Linux-server command sequence in `docs/run_order.md`
+3. any narrow main-run naming / output-root convention
+4. a report template or placeholder doc for later server results
+
+This issue MUST keep the following explicit and auditable:
+
+1. main-run config path
+2. expected output root
+3. training command
+4. resume command
+5. regular-eval command
+6. blind-eval command
+7. what is prepared now vs what must happen later on Linux
+
+This issue MUST NOT finalize:
+
+1. actual long-run result claims without execution evidence
+2. Stage 6 experimental scope
+3. new trainer semantics
+
+==================================================
+6. IMPLEMENTATION REQUIREMENTS
+==================================================
+
+Implement the smallest real main-run-prep path needed for Linux-server launch.
+
+Prefer a narrow structure such as:
+
+- `configs/stage5/stage5_trainer_main.yaml`
+- updates to `docs/run_order.md`
+- optional `docs/execution/stage5_main_run_report.md` as a template / placeholder
+
+The implementation should likely include:
+
+- a dedicated main-run config for phase-only `L=5`
+- explicit output-root and run-name convention
+- exact Linux commands for:
+  - training
+  - resuming
+  - regular eval
+  - blind eval
+- any minimal local dry-run or config-validation step if cheap enough
+
+If a very small local validation is useful, keep it strictly lightweight:
+
+- config parse / script help / one-step dry-run only if needed
+- no hidden full main run
+
+==================================================
+7. RUN-ORDER REQUIREMENT
+==================================================
+
+Because the user will run the full main training on a Linux server, you must
+write the operational command recipe into:
+
+- `docs/run_order.md`
+
+This is required.
+
+The added section should be easy to follow and should include:
+
+1. the main training command
+2. the resume command
+3. the regular-eval command
+4. the blind-eval command
+5. expected output directories
+6. any first-run notes such as dataset download behavior or GPU device choice
+
+Do NOT hide the commands only in `README.md`.
+`docs/run_order.md` is the required operational handoff document for this issue.
+
+==================================================
+8. REQUIRED ARTIFACTS
+==================================================
+
+At minimum, provide:
+
+- a dedicated main-run config under `configs/stage5/`
+- an updated `docs/run_order.md` with Linux-server commands
+- optionally a main-run report template doc if useful
+
+If you add a report template, it must clearly say that:
+
+- this workspace prepared the launch path
+- full results are pending actual Linux-server execution
+
+==================================================
+9. FILE SCOPE
+==================================================
+
+Primary files likely to be changed or added:
+
+- `configs/stage5/stage5_trainer_main.yaml`
+- `docs/run_order.md`
+- optionally `docs/execution/stage5_main_run_report.md`
+
+Supporting edits are allowed in:
+
+- `README.md`
+
+but only if a short reference is helpful. The authoritative operational commands
+must still go into `docs/run_order.md`.
+
+Avoid:
+
+- broad code refactors
+- local long-run execution artifacts
+- smoke-report rewrites
+
+==================================================
+10. ACCEPTANCE CRITERIA
+==================================================
+
+Issue 5.10 is complete only if:
+
+1. A real main-run config for phase-only `L=5` exists
+2. `docs/run_order.md` contains clear Linux-server commands for train / resume / eval
+3. The repo clearly distinguishes launch readiness from actual executed results
+4. No frozen Stage 5 semantics are silently changed
+5. The handoff is sufficient for the user to run the main job on the Linux server
+
+==================================================
+11. FINAL RESPONSE FORMAT
+==================================================
+
+After finishing, respond with:
+
+- short summary of what was prepared
+- exact files changed
+- the main-run config path
+- the exact sections/commands added to `docs/run_order.md`
+- any lightweight local validation that was performed
+- what remains to be executed later on the Linux server

--- a/docs/execution/stage5_smoke_report.md
+++ b/docs/execution/stage5_smoke_report.md
@@ -1,0 +1,194 @@
+﻿# Stage 5 Smoke Report
+
+## 1. Objective And Scope Boundary
+
+This report records one real Stage 5 paper-aligned smoke run.
+
+The purpose of this issue is narrow:
+- validate that the frozen Stage 5 pipeline can train end to end
+- confirm that artifacts and post-run evaluation hooks are usable
+- keep smoke clearly separate from the later Stage 5.10 main run
+
+This report does **not** claim a final paper result, a tuned budget, or a main-run-quality metric.
+
+---
+
+## 2. Smoke Config And Budget
+
+Smoke config:
+- `configs/stage5/stage5_trainer_smoke.yaml`
+
+Smoke-only budget choices:
+- depth: `L=5`
+- device: `cpu`
+- total steps: `4`
+- batch size: `2`
+- validate every: `1`
+- train subset size: `12`
+- val subset size: `4`
+- preview limit: `2`
+- resume used: `no`
+
+Important boundary note:
+- this reduced budget is a **smoke-only validation choice**
+- it is not the Stage 5 main-run budget and does not replace the frozen paper-aligned main target of longer training
+
+---
+
+## 3. Commands Executed
+
+Smoke training:
+
+```bash
+python scripts/train_stage5_paper.py --config configs/stage5/stage5_trainer_smoke.yaml --run-name issue5_9_l5_smoke
+```
+
+Post-run regular eval:
+
+```bash
+python scripts/eval_stage5_paper.py --config configs/stage5/stage5_eval.yaml --checkpoint outputs/stage5/smoke/issue5_9_l5_smoke/checkpoints/checkpoint_best.pt --split val --subset-size 4 --run-name issue5_9_smoke_val_eval
+```
+
+Post-run blind eval:
+
+```bash
+python scripts/eval_stage5_blind_linepair.py --config configs/stage5/stage5_blind_eval.yaml --checkpoint outputs/stage5/smoke/issue5_9_l5_smoke/checkpoints/checkpoint_best.pt --run-name issue5_9_smoke_blind_eval
+```
+
+---
+
+## 4. Smoke Run Outputs
+
+Smoke run directory:
+- `outputs/stage5/smoke/issue5_9_l5_smoke`
+
+Key artifacts:
+- `outputs/stage5/smoke/issue5_9_l5_smoke/config_snapshot.json`
+- `outputs/stage5/smoke/issue5_9_l5_smoke/history.json`
+- `outputs/stage5/smoke/issue5_9_l5_smoke/grad_stats.json`
+- `outputs/stage5/smoke/issue5_9_l5_smoke/loss_curve.png`
+- `outputs/stage5/smoke/issue5_9_l5_smoke/run_summary.json`
+- `outputs/stage5/smoke/issue5_9_l5_smoke/preview_step0.png`
+- `outputs/stage5/smoke/issue5_9_l5_smoke/preview_best.png`
+- `outputs/stage5/smoke/issue5_9_l5_smoke/preview_final.png`
+- `outputs/stage5/smoke/issue5_9_l5_smoke/phi_preview_step0.png`
+- `outputs/stage5/smoke/issue5_9_l5_smoke/phi_preview_best.png`
+- `outputs/stage5/smoke/issue5_9_l5_smoke/phi_preview_final.png`
+- `outputs/stage5/smoke/issue5_9_l5_smoke/checkpoints/checkpoint_latest.pt`
+- `outputs/stage5/smoke/issue5_9_l5_smoke/checkpoints/checkpoint_best.pt`
+
+Regular-eval follow-up artifacts:
+- `outputs/stage5/eval/issue5_9_smoke_val_eval/config_snapshot.json`
+- `outputs/stage5/eval/issue5_9_smoke_val_eval/summary.json`
+- `outputs/stage5/eval/issue5_9_smoke_val_eval/preview_comparison.png`
+
+Blind-eval follow-up artifacts:
+- `outputs/stage5/blind_eval/issue5_9_smoke_blind_eval/config_snapshot.json`
+- `outputs/stage5/blind_eval/issue5_9_smoke_blind_eval/summary.json`
+- `outputs/stage5/blind_eval/issue5_9_smoke_blind_eval/blind_targets_grid.png`
+- `outputs/stage5/blind_eval/issue5_9_smoke_blind_eval/blind_outputs_grid.png`
+- `outputs/stage5/blind_eval/issue5_9_smoke_blind_eval/blind_comparison_grid.png`
+
+---
+
+## 5. Stability And Loss Trend
+
+### 5.1 Training Stability
+
+Observed outcome:
+- training completed without NaN / Inf
+- checkpoints, previews, history, and summaries were all written successfully
+- encoder and decoder gradients were present and non-zero at every recorded step
+
+Gradient evidence from `grad_stats.json`:
+- encoder: `grad_tensor_count = 14 / nonzero_grad_tensor_count = 14` for steps `1~4`
+- decoder: `grad_tensor_count = 1 / nonzero_grad_tensor_count = 1` for steps `1~4`
+
+### 5.2 Loss Trend
+
+Recorded losses from `history.json`:
+- step 1: `train_loss = 0.1281592697`, `val_loss = 0.0702461712`
+- step 2: `train_loss = 0.0773873404`, `val_loss = 0.0702302046`
+- step 3: `train_loss = 0.0935746357`, `val_loss = 0.0702152960`
+- step 4: `train_loss = 0.0876854211`, `val_loss = 0.0702020377`
+
+Interpretation:
+- train loss is noisy at this tiny smoke budget, but remains finite and within a narrow, interpretable range
+- val loss improves monotonically across the 4 recorded validation points
+- best checkpoint is the final checkpoint at step `4`
+
+### 5.3 Efficiency-Term Observation
+
+Current smoke config consumes the frozen Stage 5 loss path with `efficiency_term.enabled = true`, but under the frozen Stage 5 default for `L=5`:
+- `gamma_by_depth[5] = 0.0`
+
+So in this smoke run:
+- `train_efficiency_term = 0.0`
+- `val_efficiency_term = 0.0`
+
+This is expected Stage 5 behavior, not a smoke-specific redefinition.
+
+---
+
+## 6. Post-Run Eval Follow-Up
+
+### 6.1 Regular Eval
+
+Runner:
+- `scripts/eval_stage5_paper.py`
+
+Checkpoint:
+- `outputs/stage5/smoke/issue5_9_l5_smoke/checkpoints/checkpoint_best.pt`
+
+Evaluated split:
+- `val`
+
+Evaluated subset size:
+- `4`
+
+Recorded metrics:
+- model PSNR: `13.0716336177`
+- model SSIM: `0.2514762123`
+- bicubic PSNR: `28.4709274795`
+- bicubic SSIM: `0.9607577262`
+
+Interpretation:
+- this smoke checkpoint is far from a competitive result, which is expected after only 4 smoke steps
+- the value of this follow-up is protocol validation: the checkpoint loads, the frozen ROI-aligned target path scores correctly, and the bicubic baseline comparison is reproducible
+
+### 6.2 Blind Eval
+
+Runner:
+- `scripts/eval_stage5_blind_linepair.py`
+
+Checkpoint:
+- `outputs/stage5/smoke/issue5_9_l5_smoke/checkpoints/checkpoint_best.pt`
+
+Recorded facts:
+- blind target family: `line_pair`
+- blind target count: `24`
+- blind input shape: `(24, 1, 96, 96)`
+- blind `phi_lr` shape: `(24, 1, 32, 32)`
+- sample forward shape: `U0 / U_out_full / I_out_full / I_out_roi = (4,1,400,400) / (4,1,400,400) / (4,1,400,400) / (4,1,96,96)`
+
+Interpretation:
+- blind-eval hook works on the smoke checkpoint without changing crop or model semantics
+- Issue 5.8's intended artifact path is usable for later reporting
+
+---
+
+## 7. Conclusion For Issue 5.9
+
+Conclusion:
+- this smoke run is sufficient to show that the Stage 5 paper-aligned pipeline is launchable, stable, and inspectable under a modest smoke-only budget
+- it unblocks Issue 5.10 from an engineering-readiness perspective
+
+What remains for Issue 5.10:
+- launch a clearly separate main-run budget
+- keep main-run config / command / report distinct from this smoke config
+- run longer training and record main-run val/test results
+- compare main-run outputs against the existing regular-eval and blind-eval paths, without redefining them
+
+In short:
+- **5.9 validates pipeline stability and artifact completeness**
+- **5.10 is still required for a real paper-aligned main run**


### PR DESCRIPTION
why:
validate that the frozen stage5 paper-path can train end to end under a small smoke-only budget before main-run work, and record stability plus artifact completeness without confusing smoke with final results

what:
add a dedicated stage5 smoke config, execute an L=5 smoke training run, record checkpoints, history, previews, and a smoke report, and attach post-run regular eval and blind eval evidence using the existing stage5 paths