### PR TITLE
docs(execution | stage5-10): finalize main-run report and eval audit

### DIFF
--- a/configs/stage5/stage5_trainer_main.yaml
+++ b/configs/stage5/stage5_trainer_main.yaml
@@ -1,0 +1,40 @@
+﻿trainer:
+  stage5_paper:
+    mode: main_run
+    protocol_note: >
+      Stage 5 phase-only L=5 main-run config. This path is launch-ready for
+      Linux-server execution, but the full long run is intentionally not
+      executed in this local workspace. The trainer is step-based, so the
+      paper-aligned 500-epoch target is represented as 750000 steps
+      (= 60000 / 40 * 500).
+    output_root: outputs/stage5/main_run
+    run_name: stage5_l5_phase_main
+    config_paths:
+      dataset: configs/stage5/stage5_emnist_display.yaml
+      optics: configs/stage5/stage5_optics_paper_aligned.yaml
+      encoder: configs/stage5/stage5_paper_encoder.yaml
+      loss: configs/stage5/stage5_sr_loss.yaml
+    runtime:
+      steps: 750000
+      batch_size: 40
+      validate_every: 1500
+      log_every: 25
+      checkpoint_every: 100
+      keep_history_in_memory: false
+      preview_limit: 4
+      seed: 60
+      device: cuda
+      num_workers: 4
+      download: false
+      train_shuffle: true
+    dataset_selection:
+      train_subset_size: null
+      val_subset_size: null
+    model:
+      depth: 5
+    optimizer:
+      name: Adam
+      lr_encoder: 0.0005
+      lr_decoder: 0.001
+    loss_wiring:
+      input_power_source: U0_full_grid_intensity_sum

--- a/configs/stage5/stage5_trainer_short.yaml
+++ b/configs/stage5/stage5_trainer_short.yaml
@@ -17,6 +17,9 @@ trainer:
       steps: 2
       batch_size: 2
       validate_every: 1
+      log_every: 1
+      checkpoint_every: 1
+      keep_history_in_memory: true
       preview_limit: 2
       seed: 56
       device: cpu

--- a/configs/stage5/stage5_trainer_smoke.yaml
+++ b/configs/stage5/stage5_trainer_smoke.yaml
@@ -16,6 +16,9 @@
       steps: 4
       batch_size: 2
       validate_every: 1
+      log_every: 1
+      checkpoint_every: 1
+      keep_history_in_memory: true
       preview_limit: 2
       seed: 59
       device: cpu

--- a/docs/ai/CodexFeedback/stage5/feedback_stage5-10.md
+++ b/docs/ai/CodexFeedback/stage5/feedback_stage5-10.md
@@ -1,0 +1,94 @@
+基于你从 Linux 服务器回传的完整 Stage 5 主训练与评估产物，Issue 5.10 现在已经完成到“主训练 + regular eval + blind eval 都有真实 artifact 和正式报告”的状态。本次工作不仅补全了主报告，也顺手修正了 eval / blind eval 的一个小审计一致性问题：未来生成的 `config_snapshot.json` 会记录实际生效的 runtime 参数，而不再出现顶部 `device = cuda` 但 `runtime.device = cpu` 这种由 config 默认值残留导致的混淆。
+
+精确变更文件：
+- [stage5_main_run_report.md](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/docs/execution/stage5_main_run_report.md)
+- [feedback_stage5-10.md](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/docs/ai/CodexFeedback/stage5/feedback_stage5-10.md)
+- [eval_stage5_paper.py](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/scripts/eval_stage5_paper.py)
+- [eval_stage5_blind_linepair.py](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/scripts/eval_stage5_blind_linepair.py)
+
+本次确认并写入正式报告的主训练事实：
+- run name：`stage5_l5_phase_main`
+- main config：`configs/stage5/stage5_trainer_main.yaml`
+- 训练命令：
+  - `python scripts/train_stage5_paper.py --config configs/stage5/stage5_trainer_main.yaml --run-name stage5_l5_phase_main --device cuda`
+- 实际完成：
+  - `completed_steps = 750000`
+  - `steps_per_epoch = 1500`
+  - 对应 `500` epochs
+- 核心数值：
+  - `best_step = 745500`
+  - `best_val_loss = 0.0188692901`
+  - `final_train_loss = 0.0201732814`
+  - `final_val_loss = 0.0188748985`
+- 运行状态：
+  - `resume_from = null`
+  - `phase = completed`
+  - 未看到 NaN / Inf 终止痕迹
+- 时间范围：
+  - start: `2026-03-19T07:00:40.685304+00:00`
+  - end: `2026-03-19T13:19:59.703498+00:00`
+  - wall-clock: `6h 19m 19s`
+
+本次确认到的 regular eval 结果：
+- val eval root：
+  - [stage5_l5_phase_main_val_eval](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/eval/stage5_l5_phase_main_val_eval)
+- val metrics：
+  - model `PSNR = 14.9180516516`
+  - model `SSIM = 0.8126175770`
+  - bicubic `PSNR = 25.6875014105`
+  - bicubic `SSIM = 0.9447924524`
+- test eval root：
+  - [stage5_l5_phase_main_test_eval](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/eval/stage5_l5_phase_main_test_eval)
+- test metrics：
+  - model `PSNR = 9.5773711626`
+  - model `SSIM = 0.4385546151`
+  - bicubic `PSNR = 20.2487178734`
+  - bicubic `SSIM = 0.8392536711`
+- 这两次 eval 都对齐到同一个主训练 best checkpoint：
+  - `outputs/stage5/main_run/stage5_l5_phase_main/checkpoints/checkpoint_best.pt`
+
+本次确认到的 blind eval 结果：
+- blind eval root：
+  - [stage5_l5_phase_main_blind_eval](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/blind_eval/stage5_l5_phase_main_blind_eval)
+- blind target family：`line_pair`
+- blind target count：`24`
+- 关键 blind artifact：
+  - [blind_targets_grid.png](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/blind_eval/stage5_l5_phase_main_blind_eval/blind_targets_grid.png)
+  - [blind_outputs_grid.png](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/blind_eval/stage5_l5_phase_main_blind_eval/blind_outputs_grid.png)
+  - [blind_comparison_grid.png](d:/AI project/ONN research/sdn-for-super-resolution-reproduction/outputs/stage5/blind_eval/stage5_l5_phase_main_blind_eval/blind_comparison_grid.png)
+- 审计结论：
+  - blind hook 已对同一个 best checkpoint 跑通
+  - `24` 个 deterministic line-pair targets 都有输出
+  - 但 `per_target_records` 里模型输出能量整体远低于二值目标能量，因此不应把这次 blind eval 解释成“已经证明了强 blind-resolution 表现”；仍应以保存下来的 grids 做人工检查与 Stage 5 总结
+
+这次顺手修掉的审计一致性问题：
+- 之前的 `eval_stage5_paper.py` 和 `eval_stage5_blind_linepair.py` 会在 `config_snapshot.json` 里保留 config 默认 runtime 值
+- 所以会出现：
+  - 顶层 `device = cuda`
+  - 但 `runtime.device = cpu`
+- 现在已经改成记录“实际生效的 runtime 参数”
+- 这不会改变你这次已经上传回来的数值结果，但会避免后续再出现同类歧义
+
+当前还剩什么工作：
+- 从 `5.10` 自身来看，主训练和对应评估链条已经齐套，不再缺主干 artifact
+- 留给 `5.11` 的主要是 consolidation：
+  - 汇总 Stage 5 训练、regular eval、blind eval 的结论
+  - 把工程事实和论文对齐结论收口成阶段总结
+
+推荐的 commit 三段式信息：
+
+```text
+docs(execution | stage5-10): finalize main-run report and eval audit
+
+why:
+close out stage5 main-run reporting after the full linux-server
+training, regular eval, and blind eval artifacts were uploaded, and fix
+the remaining eval snapshot ambiguity so future audits record effective
+runtime settings clearly
+
+what:
+fill the stage5 main run report with the uploaded L=5 training and eval
+results, add the final stage5-10 feedback note, and update the eval and
+blind-eval scripts so config snapshots store effective runtime values
+instead of stale config defaults
+```

--- a/docs/ai/prompt/stage5/prompt_stage5-11.md
+++ b/docs/ai/prompt/stage5/prompt_stage5-11.md
@@ -1,0 +1,224 @@
+You are working in a research-engineering repository for reproducing
+"Super-resolution image display using diffractive decoders".
+
+Your task is to complete GitHub Issue 5.11:
+
+Issue title:
+Consolidate Stage 5 results and make Stage-6 go/no-go decision
+
+This is a Stage-5-scoped documentation and consolidation task.
+Do not turn it into new model/trainer/eval implementation work.
+
+==================================================
+0. MUST-READ CONTEXT FIRST
+==================================================
+
+Before doing anything, you MUST read and follow these files in order:
+
+1. `AGENTS.md`
+2. `docs/ai/PROJECT_CONTEXT.md`
+3. `docs/plan/stage_plan/stage5/stage5_protocol_freeze.md`
+4. `docs/plan/stage_plan/stage5/stage5_plan.md`
+5. `docs/plan/stage_plan/stage5/stage5_issue_plan.md`
+6. `docs/execution/stage5_smoke_report.md`
+7. `docs/execution/stage5_main_run_report.md`
+8. `docs/execution/results_summary.md`
+9. `docs/execution/experiment_log.md`
+
+Then inspect these evidence-bearing files before editing:
+
+10. `outputs/stage5/main_run/stage5_l5_phase_main/run_summary.json`
+11. `outputs/stage5/eval/stage5_l5_phase_main_val_eval/summary.json`
+12. `outputs/stage5/eval/stage5_l5_phase_main_test_eval/summary.json`
+13. `outputs/stage5/blind_eval/stage5_l5_phase_main_blind_eval/summary.json`
+14. `docs/ai/CodexFeedback/stage5/feedback_stage5-10.md`
+
+Important scope rules:
+
+- This issue consolidates already-existing Stage 5 facts.
+- Do not create new experimental claims without evidence in the existing artifacts.
+- Do not rewrite history to make the current results sound better than they are.
+
+==================================================
+1. ISSUE 5.11 GOAL
+==================================================
+
+Consolidate the now-complete Stage 5 execution evidence into the repo's
+summary-layer documents and make an explicit Stage 6 go/no-go decision.
+
+The result should clearly answer:
+
+1. Did Stage 5 engineering completion succeed?
+2. What did Stage 5 actually demonstrate?
+3. What did Stage 5 not demonstrate?
+4. Is the repo ready to enter Stage 6, and why?
+
+==================================================
+2. NON-GOALS - DO NOT DRIFT
+==================================================
+
+Do NOT do any of the following:
+
+- do not add new training or evaluation code
+- do not silently revise main-run metrics
+- do not over-claim paper reproduction success
+- do not hide that bicubic currently outperforms the model on the reported PSNR/SSIM summaries
+- do not convert artifact-first blind eval into a stronger claim than the evidence supports
+- do not start Stage 6 experiments here
+
+This issue is successful only if it makes the current Stage 5 state clear,
+honest, and useful for the next stage.
+
+==================================================
+3. BRANCH EXPECTATION
+==================================================
+
+Suggested branch:
+- `docs/update`
+
+Stay on a documentation-oriented branch.
+Avoid implementation drift.
+
+==================================================
+4. REQUIRED INHERITANCE
+==================================================
+
+From the current Stage 5 evidence, this issue must inherit and reflect:
+
+1. Stage 5 pipeline is now fully landed:
+   - dataset
+   - optics configs
+   - encoder
+   - loss
+   - trainer
+   - regular eval
+   - blind eval hook
+2. A real smoke run exists.
+3. A real full `phase-only / L=5` main run exists.
+4. Matching regular eval and blind eval artifacts exist for that main run.
+5. Stage 4 remains the trusted learnability baseline, not something to erase.
+
+Important inheritance detail:
+
+- Stage 5 engineering completion and paper-quality success are not the same claim.
+- Stage 6 go/no-go should be based on whether the repo now has a credible,
+  reproducible paper-aligned starting point for systematic follow-up work.
+
+==================================================
+5. WHAT YOU ARE ALLOWED TO FINALIZE HERE
+==================================================
+
+This issue MAY finalize:
+
+1. the Stage 5 final repo-level verdict
+2. the explicit Stage 6 go/no-go decision
+3. the consolidated wording for what Stage 5 did and did not prove
+4. the list of key Stage 5 assumptions and outcomes worth preserving
+
+This issue MUST keep the following explicit and auditable:
+
+1. whether Stage 5 engineering completion passed
+2. whether reported model quality reached paper-level success
+3. whether current evidence supports entering Stage 6
+4. which documents now serve as the final Stage 5 summary layer
+
+==================================================
+6. IMPLEMENTATION REQUIREMENTS
+==================================================
+
+Prefer updating existing summary-layer docs instead of creating redundant new docs.
+
+At minimum, consider updating:
+
+- `docs/execution/results_summary.md`
+- `docs/execution/experiment_log.md`
+- `docs/ai/PROJECT_CONTEXT.md`
+
+You may add one concise consolidation doc only if it materially improves clarity,
+but prefer not to duplicate information that already belongs in the summary docs.
+
+Important quality requirement:
+
+- Some existing summary docs may be stale or garbled.
+- Clean them into readable UTF-8 content if needed.
+- After your update, a new reader should be able to understand the current repo
+  state without cross-referencing old, stale Stage 4-only summaries.
+
+==================================================
+7. REQUIRED DECISION LOGIC
+==================================================
+
+Your final documentation must clearly separate at least these three layers:
+
+1. Stage 5 engineering completion:
+   - whether the paper-aligned pipeline exists end to end
+2. Stage 5 empirical outcome:
+   - what the main run and evals actually showed
+3. Stage 6 entry decision:
+   - whether the repo is ready for systematic follow-up experiments
+
+The docs should explicitly address the likely outcome that:
+
+- Stage 5 engineering completion is `PASS`
+- paper-final quality reproduction is `NOT yet demonstrated`
+- Stage 6 entry may still be `GO` because the pipeline and evidence base are now real
+
+Do not hide these distinctions.
+
+==================================================
+8. REQUIRED ARTIFACT REFERENCES
+==================================================
+
+At minimum, the updated docs should reference:
+
+- `docs/execution/stage5_smoke_report.md`
+- `docs/execution/stage5_main_run_report.md`
+- `outputs/stage5/main_run/stage5_l5_phase_main/run_summary.json`
+- `outputs/stage5/eval/stage5_l5_phase_main_val_eval/summary.json`
+- `outputs/stage5/eval/stage5_l5_phase_main_test_eval/summary.json`
+- `outputs/stage5/blind_eval/stage5_l5_phase_main_blind_eval/summary.json`
+
+If you summarize metrics, keep them faithful to the existing artifact values.
+
+==================================================
+9. FILE SCOPE
+==================================================
+
+Primary files likely to be changed:
+
+- `docs/execution/results_summary.md`
+- `docs/execution/experiment_log.md`
+- `docs/ai/PROJECT_CONTEXT.md`
+
+Optional:
+
+- one concise Stage 5 consolidation doc only if strictly justified
+
+Avoid:
+
+- trainer/eval code edits unless a tiny documentation-related correction is unavoidable
+- planning-doc rewrites unrelated to final consolidation
+
+==================================================
+10. ACCEPTANCE CRITERIA
+==================================================
+
+Issue 5.11 is complete only if:
+
+1. The repo clearly states whether Stage 5 passed at the engineering level
+2. The repo clearly states what current model quality results do and do not show
+3. The Stage 6 go/no-go decision is explicit
+4. Summary docs are readable, current, and no longer stuck at Stage 4-only status
+5. Key Stage 5 artifact references are preserved
+
+==================================================
+11. FINAL RESPONSE FORMAT
+==================================================
+
+After finishing, respond with:
+
+- short summary of the consolidation outcome
+- exact files changed
+- the final Stage 5 engineering verdict
+- the final Stage 6 go/no-go decision
+- the key empirical caveats that remain true after Stage 5

--- a/docs/execution/stage5_main_run_report.md
+++ b/docs/execution/stage5_main_run_report.md
@@ -1,0 +1,155 @@
+# Stage 5 Main Run Report
+
+Status:
+- full Stage 5 `phase-only / L=5` main training has been executed on a Linux server
+- this report records the uploaded long-run training artifacts under `outputs/stage5/main_run/stage5_l5_phase_main`
+- companion regular eval and blind eval artifacts for this exact main run were also uploaded and are now included below
+
+## 1. Run Identity
+
+- run name: `stage5_l5_phase_main`
+- execution host: `Linux server (host name not recorded in the uploaded artifacts)`
+- GPU / device: `cuda (exact GPU model not recorded in the uploaded artifacts)`
+- start time: `2026-03-19T07:00:40.685304+00:00`
+- end time: `2026-03-19T13:19:59.703498+00:00`
+- wall-clock duration: `6h 19m 19s`
+- status: `completed`
+
+## 2. Config And Commands
+
+Main config:
+- `configs/stage5/stage5_trainer_main.yaml`
+
+Training command actually used:
+
+```bash
+python scripts/train_stage5_paper.py \
+  --config configs/stage5/stage5_trainer_main.yaml \
+  --run-name stage5_l5_phase_main \
+  --device cuda
+```
+
+Resume command actually used, if any:
+
+```bash
+N/A
+```
+
+Regular eval command(s) actually used:
+
+```bash
+python scripts/eval_stage5_paper.py \
+  --config configs/stage5/stage5_eval.yaml \
+  --checkpoint outputs/stage5/main_run/stage5_l5_phase_main/checkpoints/checkpoint_best.pt \
+  --split val \
+  --run-name stage5_l5_phase_main_val_eval \
+  --device cuda
+
+python scripts/eval_stage5_paper.py \
+  --config configs/stage5/stage5_eval.yaml \
+  --checkpoint outputs/stage5/main_run/stage5_l5_phase_main/checkpoints/checkpoint_best.pt \
+  --split test \
+  --run-name stage5_l5_phase_main_test_eval \
+  --device cuda
+```
+
+Blind eval command actually used:
+
+```bash
+python scripts/eval_stage5_blind_linepair.py \
+  --config configs/stage5/stage5_blind_eval.yaml \
+  --checkpoint outputs/stage5/main_run/stage5_l5_phase_main/checkpoints/checkpoint_best.pt \
+  --run-name stage5_l5_phase_main_blind_eval \
+  --device cuda
+```
+
+## 3. Output Roots
+
+- training root: `outputs/stage5/main_run/stage5_l5_phase_main`
+- val eval root: `outputs/stage5/eval/stage5_l5_phase_main_val_eval`
+- test eval root: `outputs/stage5/eval/stage5_l5_phase_main_test_eval`
+- blind eval root: `outputs/stage5/blind_eval/stage5_l5_phase_main_blind_eval`
+
+## 4. Training Summary
+
+- planned main budget: `L=5`, `batch_size=40`, `steps=750000`, `validate_every=1500`
+- actual completed steps: `750000`
+- equivalent epoch budget: `500` epochs (`steps_per_epoch = 1500`)
+- best step: `745500`
+- best val loss: `0.0188692901`
+- final train loss: `0.0201732814`
+- final val loss: `0.0188748985`
+- resume used: `no`
+- NaN / Inf observed: `no visible NaN / Inf; status.json records completed and no failure artifact was uploaded`
+
+Notes:
+- the run reached the full target budget rather than stopping at a reduced smoke budget
+- `history_storage_mode = jsonl_incremental`, so the full per-step trace lives in `history.jsonl` / `grad_stats.jsonl`
+- final status shows `current_epoch = 499` because epochs are zero-indexed internally; this corresponds to the intended 500-epoch budget
+- final logged throughput near completion was about `32.96 steps/s`
+
+## 5. Regular Eval Summary
+
+Val metrics:
+- model PSNR: `14.9180516516`
+- model SSIM: `0.8126175770`
+- bicubic PSNR: `25.6875014105`
+- bicubic SSIM: `0.9447924524`
+
+Test metrics:
+- model PSNR: `9.5773711626`
+- model SSIM: `0.4385546151`
+- bicubic PSNR: `20.2487178734`
+- bicubic SSIM: `0.8392536711`
+
+Note:
+- both eval summaries score `I_out_roi` against the frozen `target_roi`
+- both eval summaries use the Stage 5 bicubic baseline path with `32x32` downsample-then-upsample and anti-aliasing on the downsample step
+
+## 6. Blind Eval Summary
+
+- blind target family: `line_pair`
+- blind target count: `24`
+- key artifact path(s): `outputs/stage5/blind_eval/stage5_l5_phase_main_blind_eval/blind_targets_grid.png`, `outputs/stage5/blind_eval/stage5_l5_phase_main_blind_eval/blind_outputs_grid.png`, `outputs/stage5/blind_eval/stage5_l5_phase_main_blind_eval/blind_comparison_grid.png`
+- qualitative observation: `line-pair blind outputs were successfully generated for all 24 deterministic targets, but the recorded prediction sums remain far below the binary target sums, so qualitative interpretation should rely on the saved grids rather than claiming a strong blind-resolution result.`
+
+Note:
+- the blind hook remains artifact-first and does not claim a paper-final scalar blind metric
+
+## 7. Key Artifacts To Keep
+
+- `outputs/stage5/main_run/stage5_l5_phase_main/train.log`
+- `outputs/stage5/main_run/stage5_l5_phase_main/status.json`
+- `outputs/stage5/main_run/stage5_l5_phase_main/config_snapshot.json`
+- `outputs/stage5/main_run/stage5_l5_phase_main/history.jsonl`
+- `outputs/stage5/main_run/stage5_l5_phase_main/history.json`
+- `outputs/stage5/main_run/stage5_l5_phase_main/grad_stats.jsonl`
+- `outputs/stage5/main_run/stage5_l5_phase_main/grad_stats.json`
+- `outputs/stage5/main_run/stage5_l5_phase_main/run_summary.json`
+- `outputs/stage5/main_run/stage5_l5_phase_main/loss_curve.png`
+- `outputs/stage5/main_run/stage5_l5_phase_main/loss_curve_points.json`
+- `outputs/stage5/main_run/stage5_l5_phase_main/preview_step0.png`
+- `outputs/stage5/main_run/stage5_l5_phase_main/preview_best.png`
+- `outputs/stage5/main_run/stage5_l5_phase_main/preview_final.png`
+- `outputs/stage5/main_run/stage5_l5_phase_main/phi_preview_step0.png`
+- `outputs/stage5/main_run/stage5_l5_phase_main/phi_preview_best.png`
+- `outputs/stage5/main_run/stage5_l5_phase_main/phi_preview_final.png`
+- `outputs/stage5/main_run/stage5_l5_phase_main/checkpoints/checkpoint_best.pt`
+- `outputs/stage5/main_run/stage5_l5_phase_main/checkpoints/checkpoint_latest.pt`
+- `outputs/stage5/eval/stage5_l5_phase_main_val_eval/summary.json`
+- `outputs/stage5/eval/stage5_l5_phase_main_val_eval/preview_comparison.png`
+- `outputs/stage5/eval/stage5_l5_phase_main_test_eval/summary.json`
+- `outputs/stage5/eval/stage5_l5_phase_main_test_eval/preview_comparison.png`
+- `outputs/stage5/blind_eval/stage5_l5_phase_main_blind_eval/summary.json`
+- `outputs/stage5/blind_eval/stage5_l5_phase_main_blind_eval/blind_targets_grid.png`
+- `outputs/stage5/blind_eval/stage5_l5_phase_main_blind_eval/blind_outputs_grid.png`
+- `outputs/stage5/blind_eval/stage5_l5_phase_main_blind_eval/blind_comparison_grid.png`
+
+Notes:
+- for this long main run, `history.jsonl` and `grad_stats.jsonl` are the authoritative full per-step traces
+- `history.json` and `grad_stats.json` are compact index artifacts that point back to the JSONL traces
+
+## 8. Conclusion
+
+- does the main run complete the Stage 5 launch path with real long-run evidence? `Yes: the full 750000-step L=5 run completed, and matching regular eval plus blind eval artifacts are now present for the same best checkpoint.`
+- what remains for Stage 5.11 consolidation? `Consolidate the now-complete Stage 5 training + regular eval + blind eval evidence into the final summary layer, and optionally note the small eval-config snapshot consistency fix landed after this audit.`

--- a/docs/plan/stage_plan/stage5/stage5_remaining_issue_drafts.md
+++ b/docs/plan/stage_plan/stage5/stage5_remaining_issue_drafts.md
@@ -1,0 +1,204 @@
+# Stage 5 收口 Issue 草案
+
+## 1. 文档定位
+
+本文档不是重新拆分全部 Stage 5，而是基于当前仓库状态，为 **尚未真正收口** 的 Stage 5 issue 提供可直接粘贴到 GitHub 的标题和正文草案。
+
+当前判断依据来自：
+
+- `docs/ai/PROJECT_CONTEXT.md`
+- `docs/plan/stage_plan/stage5/stage5_protocol_freeze.md`
+- `docs/plan/stage_plan/stage5/stage5_issue_plan.md`
+- `docs/execution/stage5_smoke_report.md`
+- `docs/execution/stage5_main_run_report.md`
+- `docs/run_order.md`
+- `docs/execution/experiment_log.md`
+- `docs/execution/results_summary.md`
+
+截至当前状态：
+
+- `5.1 ~ 5.9` 已有明确协议、实现或运行证据
+- `5.10` 的 launch path 已准备，但真实 Linux-server 主运行证据仍待补齐
+- `5.11` 尚未完成，且承担 Stage 5 收口与 Stage 6 入口判定责任
+
+---
+
+## 2. Issue 5.10
+
+Title:
+
+`Run paper-aligned main training (phase-only, L=5) and write report`
+
+Body:
+
+```md
+## Background
+Stage 5.1~5.9 have already frozen the protocol and landed the paper-aligned
+dataset, optics config, encoder, loss, trainer, regular eval, blind eval, and
+smoke validation path.
+
+The remaining Stage 5 main task is no longer “make the path exist”.
+The path already exists. The remaining work is to execute the real `L=5`
+phase-only main run on the Linux server and record the evidence honestly.
+
+## Suggested Branch
+`feat/train`
+
+## Goal
+Execute the Stage 5 paper-aligned `L=5` main run using the already prepared
+launch path, then fill the main-run report with actual run evidence.
+
+## Current State
+- `configs/stage5/stage5_trainer_main.yaml` already exists
+- `docs/run_order.md` already contains the Linux-server train / resume / eval commands
+- `docs/execution/stage5_main_run_report.md` already exists as a result template
+- `docs/execution/stage5_smoke_report.md` already shows smoke-level readiness
+
+This issue should consume those artifacts rather than redesigning them.
+
+## Tasks
+- Launch the phase-only `L=5` main training on the Linux server using the prepared Stage 5 main config
+- If the run is resumed, record the exact resume command and checkpoint path
+- Run regular eval on both `val` and `test` using the existing Stage 5 eval path
+- Run blind line-pair eval using the existing Stage 5 blind-eval path
+- Fill `docs/execution/stage5_main_run_report.md` with:
+  - run identity
+  - actual commands used
+  - output roots
+  - completed steps / stop point
+  - best checkpoint information
+  - val / test metrics
+  - blind eval summary
+  - remaining gaps
+- If the run stops before the full target budget, record the exact stop point and reason explicitly
+
+## Resource Boundary
+- Distinguish clearly between:
+  - code/config path is ready
+  - long-run compute budget was or was not fully available
+- A partial, interrupted, or budget-limited run is still useful evidence, but it must not be reported as if it were a full-budget completed run
+- Do not treat the earlier smoke run as main-run evidence
+
+## Non-Goals
+- Do not rewrite `scripts/train_stage5_paper.py`
+- Do not redesign `scripts/eval_stage5_paper.py` or `scripts/eval_stage5_blind_linepair.py`
+- Do not reopen Stage 5 protocol defaults
+- Do not add Stage 6 sweeps, quantization, or robustness work here
+
+## Deliverable
+- Main training outputs under `outputs/stage5/main_run/`
+- Regular eval outputs under `outputs/stage5/eval/`
+- Blind eval outputs under `outputs/stage5/blind_eval/`
+- Completed `docs/execution/stage5_main_run_report.md`
+
+## Acceptance
+- A real Linux-server `L=5` paper-aligned main run is executed and logged
+- Val / test / blind-eval results are recorded in a comparable format
+- The report clearly separates implementation readiness from resource-limited execution state
+- No smoke-only evidence is misrepresented as main-run evidence
+
+## Reference Docs
+- `docs/plan/stage_plan/stage5/stage5_protocol_freeze.md`
+- `docs/execution/stage5_smoke_report.md`
+- `docs/execution/stage5_main_run_report.md`
+- `docs/run_order.md`
+```
+
+---
+
+## 3. Issue 5.11
+
+Title:
+
+`Consolidate Stage 5 results and make Stage-6 go/no-go decision`
+
+Body:
+
+```md
+## Background
+Stage 5 is only useful if its planning docs, implementation evidence, and run
+outputs are consolidated into one authoritative repo state.
+
+Right now, several execution-facing docs still reflect the earlier Stage 4 or
+Stage-5-planning-only state. After Issue 5.10, the repo needs one explicit
+close-out pass that states:
+- what Stage 5 actually completed
+- what remained resource-limited
+- whether Stage 6 may start
+
+## Suggested Branch
+`docs/update`
+
+## Goal
+Consolidate Stage 5 execution evidence and make an explicit Stage 6 `GO / NO-GO`
+decision with reasons.
+
+## Dependency
+This issue should start after Issue 5.10 has produced either:
+- a completed main-run record, or
+- a clearly documented budget-limited stop point with real evidence
+
+## Tasks
+- Update `docs/execution/experiment_log.md` so it no longer stops at Stage 4
+- Update `docs/execution/results_summary.md` so it reflects the actual Stage 5 state rather than “planning only”
+- Review `docs/execution/stage5_smoke_report.md` and `docs/execution/stage5_main_run_report.md` and summarize what they prove
+- Record which Stage 5 assumptions remained defaults and which were actually exercised by the real run
+- Classify remaining gaps into:
+  - engineering gap
+  - compute/resource gap
+  - paper-ambiguity gap
+- Make an explicit Stage 6 decision:
+  - `GO`
+  - `conditional GO`
+  - `NO-GO`
+- If the decision is `conditional GO` or `NO-GO`, list the exact blockers and the issue family that should resolve them
+- Link the approved Stage 6 plan so the next phase starts from a frozen document rather than ad-hoc discussion
+
+## Resource Boundary
+- Do not hide missing long-run budget inside vague wording like “results pending”
+- If Stage 5 is engineering-complete but budget-limited, say that directly
+- If Stage 5 is still technically incomplete, say that directly instead of blaming compute by default
+
+## Non-Goals
+- Do not reopen Stage 5 implementation scope
+- Do not silently start Stage 6 experiments inside this issue
+- Do not rewrite historical reports to claim evidence that was never produced
+
+## Deliverable
+- Updated `docs/execution/experiment_log.md`
+- Updated `docs/execution/results_summary.md`
+- Any necessary updates to:
+  - `docs/execution/troubleshooting.md`
+  - `docs/paper/paper_notes.md`
+  - `docs/plan/stage_plan/stage6/stage6_plan.md`
+- A clear Stage 6 decision recorded in repo docs
+
+## Acceptance
+- The repo states clearly what Stage 5 completed and what it did not complete
+- Stage 5 evidence is consolidated instead of being scattered across planning-only and execution-only documents
+- Stage 6 entry status is explicit, justified, and linked to concrete evidence
+- Remaining blockers, if any, are written as actionable next work rather than vague uncertainty
+
+## Reference Docs
+- `docs/execution/stage5_smoke_report.md`
+- `docs/execution/stage5_main_run_report.md`
+- `docs/execution/experiment_log.md`
+- `docs/execution/results_summary.md`
+- `docs/plan/stage_plan/stage6/stage6_plan.md`
+```
+
+---
+
+## 4. 使用建议
+
+如果只准备继续当前主线，建议先发：
+
+1. `Issue 5.10`
+2. `Issue 5.11`
+
+原因：
+
+- `5.10` 负责把 Stage 5 从“launch-ready”推进到“有真实主运行证据”
+- `5.11` 负责把仓库状态从“文档分散”推进到“可以正式进入 Stage 6”
+
+在 `5.11` 完成之前，不建议把 Stage 6 执行 issue 大规模开出来，因为那样很容易绕开 Stage 5 的最后收口。

--- a/docs/plan/stage_plan/stage6/stage6_plan.md
+++ b/docs/plan/stage_plan/stage6/stage6_plan.md
@@ -1,0 +1,568 @@
+# Stage 6 详细工程计划
+
+## 1. 文档定位
+
+本文档定义本仓库在 Stage 5 收口之后进入 `Stage 6 — 系统化实验、排错与总结` 的工程推进方案。
+
+它的目标不是重新设计 Stage 5，而是回答下面两个问题：
+
+1. 在已经冻结的 paper-aligned pipeline 之上，应该先做哪些系统化实验。
+2. 如何把实验矩阵控制在可解释、可复盘、可收口的范围内，而不是重新掉回“边写边试”的状态。
+
+本文档优先级低于：
+
+1. `AGENTS.md`
+2. `docs/ai/PROJECT_CONTEXT.md`
+3. `docs/paper/paper_notes.md`
+4. `docs/plan/stage_plan/stage5/stage5_protocol_freeze.md`
+5. `docs/execution/stage5_smoke_report.md`
+6. `docs/execution/stage5_main_run_report.md`
+
+若 Stage 5 收口文档与本计划冲突，以 Stage 5 收口结论为准；Stage 6 不得反向篡改 Stage 5 已冻结的主线协议。
+
+---
+
+## 2. 当前上下文与 Stage 6 触发条件
+
+截至当前仓库状态，已知事实是：
+
+- Stage 3 optical contract 已冻结：`phi_lr -> U0 -> U_out_full -> I_out_full -> I_out_roi`
+- Stage 4 learnability gate 已通过
+- Stage 5 数据、optics config、encoder、loss、trainer、regular eval、blind eval、smoke run 路径已经落地
+- Stage 5 主线 `L=5 phase-only` main-run 路径已准备为可在 Linux server 上执行
+
+但 Stage 6 不能默认“立即全量开始”。进入 Stage 6 前，先区分三个入口级别：
+
+### 2.1 Entry Level E1: engineering-ready
+
+满足条件：
+
+- Stage 5 pipeline 可启动
+- smoke run 已通过
+- Stage 5 文档已把默认值、未决项和 artifact 路径写清楚
+
+允许开始：
+
+- Stage 6 文档规划
+- 轻量级结果注册表搭建
+- 不依赖新训练的 eval-only 预备工作
+
+不允许开始：
+
+- 把跨 depth / 跨 modulation / 跨 quantization 的大矩阵训练直接跑起来
+
+### 2.2 Entry Level E2: baseline-evidenced
+
+满足条件：
+
+- 至少一次真实的 `L=5 phase-only` Stage 5 main run 已在 Linux server 上执行
+- `val / test / blind eval` 至少形成一套可复盘记录
+- `docs/execution/stage5_main_run_report.md` 已写入真实结果或真实中断点
+
+允许开始：
+
+- 依赖已训练 checkpoint 的 Stage 6 eval-only 工作
+- 以 `L=5 phase-only` 为锚点的 Stage 6 P0 实验
+
+### 2.3 Entry Level E3: baseline-settled
+
+满足条件：
+
+- Stage 5.11 已完成
+- Stage 5 主线结果与资源边界已经被清楚区分
+- 仓库已明确 Stage 6 `GO`
+
+允许开始：
+
+- 全量 Stage 6 训练型对照和系统化 ablation
+
+结论：
+
+- 没有 E2 证据时，不应把 Stage 6 写成真正的执行阶段
+- 没有 E3 决策时，不应启动大规模训练矩阵
+
+---
+
+## 3. Stage 6 核心目标
+
+Stage 6 的主任务不是“继续把 Stage 5 做完”，而是围绕论文主张建立系统化证据。
+
+本阶段要回答的核心问题是：
+
+1. `L=1/3/5` 的 paper-aligned optical depth 是否在统一协议下呈现论文声称的趋势。
+2. efficiency term 的开关是否对结果有稳定、可解释的影响。
+3. phase-only 与 complex-valued 的差距在本复现系统里是否成立。
+4. 量化对 blind 高频恢复的影响是否复现论文趋势。
+5. 系统对错位 / 失配是否敏感，敏感性主要来自哪里。
+6. 如果结果与论文不一致，问题更可能来自数据频谱、训练预算、读出定义还是物理实现细节。
+
+---
+
+## 4. Stage 6 非目标
+
+以下内容不应在 Stage 6 开始时一次性塞满：
+
+- 大而全的超参搜索
+- 重新设计 Stage 5 trainer / eval framework
+- 修改 Stage 5 的 crop、normalization、dataset split 作为“隐含修复”
+- 没有主线基线时就并发跑一整套训练矩阵
+- 把 THz 实验硬件链路复现与数值系统化实验混成一个阶段
+
+---
+
+## 5. 规划原则
+
+### 5.1 先冻结比较基线，再做变量控制
+
+Stage 6 每一类实验都必须有一个明确的 anchor baseline：
+
+- 默认 anchor：Stage 5 `L=5 phase-only` main run
+- 除非某个 issue 明确声明要改变量，否则：
+  - dataset protocol 不变
+  - eval splits 不变
+  - crop / FOV semantics 不变
+  - regular eval + blind eval 口径不变
+
+### 5.2 一次只改一个主要因素
+
+推荐控制方式：
+
+- depth study 只改 `L`
+- efficiency study 只改 efficiency-term 开关或 `gamma` policy
+- modulation study 只改 encoder/modulation representation
+- quantization study 只改 quantization bit-width
+- misalignment study 只改 displacement perturbation
+
+若一次改多个因素，必须单独标注为“组合实验”，不能混入主矩阵。
+
+### 5.3 先 eval-only，再 training-heavy
+
+能通过冻结 checkpoint 回答的问题，不先上重新训练。
+
+因此推荐顺序是：
+
+1. baseline 结果登记
+2. eval-only sweep
+3. 小规模训练型 ablation
+4. 成本最高的 full main-run 对照
+
+### 5.4 Stage 6 新变体不得污染 Stage 5 主线
+
+要求：
+
+- Stage 5 configs 保持只读
+- Stage 6 变体配置放在 `configs/stage6/`
+- Stage 6 输出放在 `outputs/stage6/`
+- Stage 6 报告单独写入 `docs/execution/` 或 `docs/plan/stage_plan/stage6/`
+
+---
+
+## 6. Stage 6 工作流总览
+
+按优先级，Stage 6 建议拆成 `P0 / P1 / P2` 三层。
+
+### 6.1 P0: 必做主线
+
+P0 直接对应论文主张和当前 repo 最需要补齐的系统化证据：
+
+1. baseline freeze 与 experiment registry
+2. `L=1/3/5` depth comparison
+3. efficiency on/off ablation
+
+### 6.2 P1: 高价值扩展
+
+P1 直接来源于论文或补充材料，但可以在 P0 之后排队：
+
+1. phase-only vs complex-valued
+2. optional amplitude-only supplemental check
+3. quantization inference sweep
+
+### 6.3 P2: 延后项
+
+P2 要么更贵，要么更偏 robustness / hardware-aware：
+
+1. misalignment robustness evaluation
+2. optional misalignment vaccination training
+3. targeted root-cause reruns for unresolved failures
+
+---
+
+## 7. 详细执行顺序
+
+### 7.1 Stage 6A — Freeze experiment registry and artifact protocol
+
+目标：
+
+- 在开始系统化实验前，先把 Stage 6 的结果登记方式固定下来
+
+任务：
+
+1. 定义 Stage 6 run family 命名规则
+2. 规定每次实验必须保存的最小工件
+3. 定义聚合表字段
+4. 明确哪些实验依赖训练、哪些只依赖已有 checkpoint
+
+建议产物：
+
+- `docs/plan/stage_plan/stage6/stage6_plan.md`
+- `docs/plan/stage_plan/stage6/stage6_experiment_registry.md`
+- `outputs/stage6/summary/stage6_matrix.csv` 或等价聚合文件
+
+最小工件要求：
+
+- `config_snapshot.json`
+- `run_summary.json` 或 `summary.json`
+- 关键 metrics
+- blind eval summary
+- 指向源 checkpoint 的路径或副本
+- 运行命令
+- 如涉及训练，还要有 `history`、`grad_stats`、checkpoint 信息
+
+验收：
+
+- 后续 Stage 6 issue 不需要各自重新定义 artifact 协议
+
+### 7.2 Stage 6B — Run paper-aligned depth comparison for `L=1/3/5`
+
+目标：
+
+- 在统一 Stage 5 主线协议下验证 `L=1/3/5` 的深度趋势
+
+固定项：
+
+- dataset protocol
+- encoder family
+- loss definition
+- eval protocol
+- blind line-pair target family
+
+变量：
+
+- optics depth `L`
+- 对应的 paper-aligned distance schedule
+
+执行策略：
+
+1. 先确定 `L=1/3/5` 各自 main config
+2. 至少跑到“可比较的 stop point”
+3. 对每个 depth 执行 val / test / blind eval
+4. 先做单 seed 比较
+5. 只有当结论接近或不稳定时，才增加第二个 seed
+
+要回答的问题：
+
+- 是否出现 `L=5 > L=3 > L=1` 的总体趋势
+- 差异主要体现在 PSNR / SSIM，还是 blind 高频恢复
+- 是否存在 depth 越深但训练更不稳的工程代价
+
+验收：
+
+- 同一报告中能横向比较 `L=1/3/5`
+- depth 结论与资源约束被明确分开
+
+### 7.3 Stage 6C — Efficiency-term on/off ablation
+
+目标：
+
+- 验证 efficiency penalty 是否显著影响输出质量或能量集中
+
+固定项：
+
+- 先固定一个主 depth，默认 `L=5`
+- 若资源允许，再扩展到 `L=1` / `L=3`
+
+变量：
+
+- `efficiency_term.enabled`
+- 必要时记录 `gamma_by_depth`
+
+执行策略：
+
+1. 先以 Stage 5 baseline 为 anchor
+2. 在相同训练预算下比较 on/off
+3. regular metrics 与 blind eval 一起记录
+4. 如果 quality 与 efficiency 出现 trade-off，单独写明，不混成“谁更好”的一句话
+
+要回答的问题：
+
+- efficiency term 是帮助了 ROI 内成像，还是主要改变了能量分布
+- 它改善的是 main metrics、blind 高频恢复，还是仅改善物理可解释性
+
+验收：
+
+- 有一份明确对比 on/off 的结果表
+- `gamma` 与 switch 状态均可追溯
+
+### 7.4 Stage 6D — Modulation-mode comparison
+
+目标：
+
+- 检查 paper notes 里“complex-valued 略优于 phase-only”的趋势是否在当前 repo 中成立
+
+建议优先级：
+
+1. phase-only vs complex-valued
+2. amplitude-only 只作为补充项，不提前升格为主线
+
+约束：
+
+- 不得借该 issue 重写 optical contract
+- 如果 complex-valued 路径要求大改 Stage 3 core，应先停下补 design note
+
+执行策略：
+
+1. 先实现最小 modulator representation 差异
+2. 用同一 depth、同一 dataset、同一 eval path 比较
+3. phase-only 继续作为 reference baseline
+4. amplitude-only 只在 complex-valued 路径可控后再补
+
+要回答的问题：
+
+- complex-valued 的收益是否稳定
+- 收益主要体现在哪类指标
+- 更高自由度带来的收益是否值得其实现复杂度
+
+验收：
+
+- 至少有 phase-only vs complex-valued 的直接对照
+- amplitude-only 若未做，也要在文档中明确记为延后项，而不是静默缺失
+
+### 7.5 Stage 6E — Quantization sweep
+
+目标：
+
+- 复现论文对 phase quantization 的定性趋势
+
+依据：
+
+- `docs/paper/paper_notes.md` 建议第一版先做 inference-time quantization
+
+推荐顺序：
+
+1. 用连续 / 高 bit checkpoint 作为源
+2. 在推理阶段测试 `16 / 8 / 6 / 4 / 2 bit`
+3. regular eval 只作为补充
+4. blind 高频结果作为主观察对象
+
+明确不默认做：
+
+- quantization-aware retraining
+
+只有当以下条件满足时才考虑追加：
+
+- inference sweep 已完成
+- 4-bit / 2-bit 明显退化
+- 用户明确希望继续追 QAT 改善
+
+要回答的问题：
+
+- 8-bit / 6-bit 是否基本可接受
+- 4-bit / 2-bit 是否出现论文描述的明显退化
+- 退化首先体现在 blind 高频，还是常规 PSNR / SSIM
+
+验收：
+
+- bit-width 趋势清楚
+- 每个 bit-width 的 quantization policy 被显式记录
+
+### 7.6 Stage 6F — Misalignment robustness evaluation
+
+目标：
+
+- 在不引入真实硬件链路的前提下，先做数值错位鲁棒性检查
+
+依据：
+
+- `paper_notes.md` 已记录 `Δx / Δy / Δz` 的参考量级
+
+推荐顺序：
+
+1. 先做 inference-time perturbation test
+2. 再决定是否需要 vaccination training
+
+变量：
+
+- lateral shift
+- axial shift
+- perturbation sampling distribution
+
+不应默认做：
+
+- 一上来就训练 misalignment-vaccinated 主模型
+
+要回答的问题：
+
+- 当前最佳 baseline 对错位有多敏感
+- 敏感性来自哪一层面：depth、quantization、modulation、blind target 类型
+
+验收：
+
+- 至少有一份 robustness 曲线或表格
+- training-free robustness 与 training-aware robustness 被清楚区分
+
+### 7.7 Stage 6G — Root-cause troubleshooting and targeted reruns
+
+目标：
+
+- 把“实验结果不符合论文”从现象层推进到原因层
+
+排查优先级建议：
+
+1. 数据频谱覆盖不足
+2. 主线训练预算不够
+3. crop / normalization / readout 口径不一致
+4. blind target 生成方式与论文不一致
+5. physics config 偏差
+
+工作方式：
+
+- 针对失败模式开窄 issue
+- 只做有假设支撑的 targeted rerun
+- 结论进入 `docs/execution/troubleshooting.md`
+
+验收：
+
+- 每个 rerun 都绑定明确假设
+- 不再出现“为了看看会不会好”式的无边界试验
+
+### 7.8 Stage 6H — Consolidation and stage summary
+
+目标：
+
+- 把 Stage 6 的系统化结果沉淀为可交付结论
+
+必须更新：
+
+- `docs/execution/experiment_log.md`
+- `docs/execution/results_summary.md`
+- `docs/execution/troubleshooting.md`
+- 相关 stage6 报告
+
+建议补充：
+
+- 一个 stage6 汇总表
+- 一个“论文结论复现状态”对照表
+
+验收：
+
+- 能清楚回答“哪些论文趋势复现了，哪些没有，原因最可能是什么”
+
+---
+
+## 8. Stage 6 推荐 issue 家族
+
+下面的 issue 家族不是强制一字不改，但建议作为 Stage 6 拆分起点：
+
+1. `Issue 6.1 — Freeze Stage 6 experiment registry and artifact protocol`
+2. `Issue 6.2 — Run paper-aligned depth comparison for L=1/3/5`
+3. `Issue 6.3 — Run efficiency-term on/off ablation on the frozen Stage 5 baseline`
+4. `Issue 6.4 — Compare phase-only and complex-valued modulation paths`
+5. `Issue 6.5 — Run inference-time phase quantization sweep with blind-eval reporting`
+6. `Issue 6.6 — Evaluate misalignment robustness on frozen baseline checkpoints`
+7. `Issue 6.7 — Summarize Stage 6 findings and update troubleshooting/results docs`
+
+如果资源不足，推荐优先顺序是：
+
+1. `6.1`
+2. `6.2`
+3. `6.3`
+4. `6.5`
+5. `6.4`
+6. `6.6`
+7. `6.7`
+
+这样排序的原因是：
+
+- `L=1/3/5` 与 efficiency ablation 直接对应论文主张
+- quantization 可优先用已有 checkpoint 做推理测试
+- complex/amplitude-only 需要额外实现成本
+- misalignment 更偏后期 robustness
+
+---
+
+## 9. 目录与工件约定
+
+建议 Stage 6 期间使用以下约定：
+
+### 9.1 Configs
+
+- `configs/stage6/`
+
+用途：
+
+- 存放所有 Stage 6 变体 config
+- 不覆盖 Stage 5 主线 config
+
+### 9.2 Outputs
+
+- `outputs/stage6/<family>/<run_name>/`
+
+其中 `<family>` 建议使用：
+
+- `depth_compare`
+- `efficiency_ablation`
+- `modulation_compare`
+- `quantization_eval`
+- `misalignment_eval`
+- `summary`
+
+### 9.3 Docs
+
+- `docs/plan/stage_plan/stage6/`
+- `docs/execution/`
+
+原则：
+
+- 计划与 issue 拆分放在 `docs/plan/stage_plan/stage6/`
+- 真实执行结果与报告放在 `docs/execution/`
+
+---
+
+## 10. 风险与资源边界
+
+### 10.1 主要风险
+
+1. 把 Stage 6 写成无限扩张的实验池
+2. 还没固定 baseline 就开始横向比较
+3. 训练型实验和 eval-only 实验混在一起，导致预算失控
+4. 结果表没有统一字段，后面无法做归纳
+5. 因为论文含糊，就在不同实验里偷偷改变 protocol
+
+### 10.2 资源控制规则
+
+1. 每个训练型 family 先跑单 seed
+2. 只有在排序接近或不稳定时才加 seed
+3. 优先跑能直接复用 checkpoint 的 eval-only family
+4. 对每个 family 先设定 stop point，再谈是否扩预算
+5. 任何未跑满预算的 run 都必须记录 exact stop point
+
+---
+
+## 11. Stage 6 完成标准
+
+Stage 6 最低完成标准：
+
+1. 至少一个 Stage 6 结果注册表已建立
+2. `L=1/3/5` depth comparison 已完成到可比较程度
+3. efficiency on/off ablation 已完成至少一组稳定对照
+4. quantization inference sweep 已完成
+5. 至少一份 troubleshooting 文档把失败模式和原因假设写清楚
+6. 结果摘要能够明确区分：
+   - 论文趋势已复现
+   - 论文趋势部分复现
+   - 尚未复现且原因未定
+
+更强完成标准：
+
+1. phase-only vs complex-valued 已完成
+2. amplitude-only 至少有补充说明
+3. misalignment robustness 已形成曲线或表格
+4. Stage 6 已能支撑最终复现结论整理
+
+---
+
+## 12. 一句话结论
+
+Stage 6 的正确打开方式不是“继续往系统里堆功能”，而是：
+
+先用 Stage 5 冻结好的 paper-aligned baseline 作为锚点，再按 `depth -> efficiency -> quantization -> modulation -> robustness` 的顺序，逐类建立可比较、可解释、可收口的证据链。

--- a/docs/run_order.md
+++ b/docs/run_order.md
@@ -221,3 +221,121 @@ Expected output roots:
 - The `samples/epoch_XXX.png` files now show multiple fixed validation samples in one grid.
   Earlier versions only saved the first validation sample each epoch, which made the outputs
   look like the same image was being repeated.
+
+### 6) Stage 5 main run prep: phase-only L=5 on Linux server
+
+This section prepares the real Stage 5 main run for Linux-server execution.
+Do **not** treat the local smoke run as the main result, and do **not** launch
+this full long run in the local workspace.
+
+Dedicated config:
+- `configs/stage5/stage5_trainer_main.yaml`
+
+Recommended shell variables on the Linux server:
+
+```bash
+RUN_NAME=stage5_l5_phase_main
+TRAIN_ROOT=outputs/stage5/main_run/${RUN_NAME}
+BEST_CKPT=${TRAIN_ROOT}/checkpoints/checkpoint_best.pt
+LATEST_CKPT=${TRAIN_ROOT}/checkpoints/checkpoint_latest.pt
+```
+
+First-run notes:
+- the config targets the full Stage 5 main budget: `L=5`, `batch_size=40`, `steps=750000`, `validate_every=1500`
+- the runtime also enables `log_every=25`, `checkpoint_every=100`, and `keep_history_in_memory=false` for long-run observability and bounded checkpoint size
+- the default dataset root is `data/raw/emnist`
+- if EMNIST is not already present on the server, add `--download` to the **first** training command only
+- if the server only has one visible GPU, you can ignore `CUDA_VISIBLE_DEVICES`
+- if the server has multiple GPUs and you want to pin one GPU explicitly, prefix any command with `CUDA_VISIBLE_DEVICES=<id>`
+
+Simplest main training command:
+
+```bash
+python scripts/train_stage5_paper.py \
+  --config configs/stage5/stage5_trainer_main.yaml \
+  --run-name ${RUN_NAME} \
+  --device cuda \
+  --download
+```
+
+If the dataset has already been downloaded, use the same command without `--download`.
+
+Optional single-GPU pinning form:
+
+```bash
+CUDA_VISIBLE_DEVICES=0 python scripts/train_stage5_paper.py \
+  --config configs/stage5/stage5_trainer_main.yaml \
+  --run-name ${RUN_NAME} \
+  --device cuda \
+  --download
+```
+
+Operational monitoring during training:
+- `tail -f ${TRAIN_ROOT}/train.log`
+- `cat ${TRAIN_ROOT}/status.json`
+- `ls ${TRAIN_ROOT}/checkpoints`
+- `nvidia-smi`
+
+Incremental files that now update during the run:
+- `${TRAIN_ROOT}/train.log`
+- `${TRAIN_ROOT}/status.json`
+- `${TRAIN_ROOT}/history.jsonl`
+- `${TRAIN_ROOT}/grad_stats.jsonl`
+- `${TRAIN_ROOT}/loss_curve_points.json`
+
+Important runtime notes:
+- first-time EMNIST download/extract can still spend time before the first training step; this now appears in `train.log`, but `torchvision` itself does not give a rich progress bar
+- `checkpoint_latest.pt` is updated every `100` steps and at validation points, not every step
+- the main config keeps long per-step history out of in-memory checkpoint payloads; use `history.jsonl` and `grad_stats.jsonl` as the authoritative full run trace during long execution
+
+Resume command:
+
+```bash
+python scripts/train_stage5_paper.py \
+  --config configs/stage5/stage5_trainer_main.yaml \
+  --device cuda \
+  --resume ${LATEST_CKPT}
+```
+
+Regular eval on val:
+
+```bash
+python scripts/eval_stage5_paper.py \
+  --config configs/stage5/stage5_eval.yaml \
+  --checkpoint ${BEST_CKPT} \
+  --split val \
+  --run-name ${RUN_NAME}_val_eval \
+  --device cuda
+```
+
+Regular eval on test:
+
+```bash
+python scripts/eval_stage5_paper.py \
+  --config configs/stage5/stage5_eval.yaml \
+  --checkpoint ${BEST_CKPT} \
+  --split test \
+  --run-name ${RUN_NAME}_test_eval \
+  --device cuda
+```
+
+Blind eval:
+
+```bash
+python scripts/eval_stage5_blind_linepair.py \
+  --config configs/stage5/stage5_blind_eval.yaml \
+  --checkpoint ${BEST_CKPT} \
+  --run-name ${RUN_NAME}_blind_eval \
+  --device cuda
+```
+
+Expected output directories:
+- training root: `outputs/stage5/main_run/${RUN_NAME}`
+- val eval root: `outputs/stage5/eval/${RUN_NAME}_val_eval`
+- test eval root: `outputs/stage5/eval/${RUN_NAME}_test_eval`
+- blind eval root: `outputs/stage5/blind_eval/${RUN_NAME}_blind_eval`
+
+Operational boundary:
+- this repo state prepares the launch path only
+- full long-run results remain pending actual Linux-server execution
+- after the server run, record outcomes in `docs/execution/stage5_main_run_report.md`

--- a/scripts/eval_stage5_blind_linepair.py
+++ b/scripts/eval_stage5_blind_linepair.py
@@ -341,7 +341,11 @@ def main() -> None:
         "checkpoint_path": str(checkpoint_path),
         "run_name": run_name,
         "device": str(device),
-        "runtime": runtime_cfg,
+        "runtime": {
+            "device": str(device),
+            "batch_size": int(runtime_cfg["batch_size"]),
+            "preview_limit": preview_limit,
+        },
         "target_generation": target_generation_cfg,
         "checkpoint_snapshot_excerpt": {
             "depth": depth,

--- a/scripts/eval_stage5_paper.py
+++ b/scripts/eval_stage5_paper.py
@@ -386,7 +386,11 @@ def main() -> None:
         "split": split,
         "device": str(device),
         "runtime": {
-            **runtime_cfg,
+            "split": split,
+            "batch_size": int(runtime_cfg["batch_size"]),
+            "num_workers": int(runtime_cfg["num_workers"]),
+            "seed": int(runtime_cfg["seed"]),
+            "device": str(device),
             "subset_size": subset_size,
             "preview_limit": preview_limit,
             "download": bool(args.download or runtime_cfg.get("download", False)),

--- a/scripts/train_stage5_paper.py
+++ b/scripts/train_stage5_paper.py
@@ -8,6 +8,8 @@ import json
 import math
 import random
 import sys
+import time
+import traceback
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -41,6 +43,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--steps", type=int, default=None)
     parser.add_argument("--device", type=str, default=None)
     parser.add_argument("--resume", type=str, default=None)
+    parser.add_argument("--log-every", type=int, default=None)
     parser.add_argument("--preview-limit", type=int, default=None)
     parser.add_argument("--download", action="store_true")
     return parser.parse_args()
@@ -85,8 +88,168 @@ def set_seed(seed: int) -> None:
 
 def save_json(path: Path, payload: Any) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", encoding="utf-8") as handle:
+    temp_path = path.with_suffix(path.suffix + ".tmp")
+    with temp_path.open("w", encoding="utf-8") as handle:
         json.dump(payload, handle, indent=2, ensure_ascii=False)
+    temp_path.replace(path)
+
+
+def append_jsonl(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, ensure_ascii=False) + "\n")
+        handle.flush()
+
+
+def load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+class RunLogger:
+    def __init__(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self.path = path
+        self._handle = path.open("a", encoding="utf-8")
+
+    def log(self, message: str) -> None:
+        timestamp = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        line = f"[{timestamp}] {message}"
+        print(line, flush=True)
+        self._handle.write(line + "\n")
+        self._handle.flush()
+
+    def close(self) -> None:
+        self._handle.close()
+
+
+def format_seconds(seconds: float | None) -> str:
+    if seconds is None or not math.isfinite(seconds):
+        return "unknown"
+    total_seconds = max(0, int(seconds))
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes, secs = divmod(remainder, 60)
+    if hours > 0:
+        return f"{hours:d}h{minutes:02d}m{secs:02d}s"
+    if minutes > 0:
+        return f"{minutes:d}m{secs:02d}s"
+    return f"{secs:d}s"
+
+
+def format_optional_float(value: float | None, *, precision: int = 6) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value:.{precision}f}"
+
+
+def get_cuda_memory_summary(device: torch.device) -> str:
+    if device.type != "cuda":
+        return "cpu"
+    allocated_mb = torch.cuda.memory_allocated(device) / (1024**2)
+    reserved_mb = torch.cuda.memory_reserved(device) / (1024**2)
+    max_allocated_mb = torch.cuda.max_memory_allocated(device) / (1024**2)
+    return (
+        f"cuda_alloc_mb={allocated_mb:.1f} "
+        f"cuda_reserved_mb={reserved_mb:.1f} "
+        f"cuda_max_alloc_mb={max_allocated_mb:.1f}"
+    )
+
+
+def compact_history_artifact(
+    *,
+    artifact_name: str,
+    entries: list[dict[str, Any]] | None,
+    entry_count: int,
+    jsonl_path: Path,
+    last_entry: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if entries is not None:
+        return {
+            "artifact_name": artifact_name,
+            "storage_mode": "in_memory_full_list",
+            "entry_count": entry_count,
+            "entries": entries,
+        }
+    return {
+        "artifact_name": artifact_name,
+        "storage_mode": "jsonl_external",
+        "entry_count": entry_count,
+        "jsonl_path": str(jsonl_path.resolve()),
+        "last_entry": last_entry,
+        "note": (
+            "Full per-step records are stored incrementally in JSONL to avoid "
+            "unbounded checkpoint growth during long Stage 5 runs."
+        ),
+    }
+
+
+def build_status_payload(
+    *,
+    phase: str,
+    mode: str,
+    run_name: str,
+    depth: int,
+    device: torch.device,
+    current_step: int,
+    total_steps: int,
+    current_epoch: int | None,
+    steps_per_epoch: int | None,
+    validate_every: int | None,
+    log_every: int | None,
+    checkpoint_every: int | None,
+    resume_from: str | None,
+    started_at_utc: str,
+    output_root: Path,
+    train_log_path: Path,
+    history_jsonl_path: Path,
+    grad_jsonl_path: Path,
+    best_val_loss: float | None,
+    best_step: int | None,
+    last_train_metrics: dict[str, Any] | None,
+    last_val_metrics: dict[str, Any] | None,
+    note: str | None = None,
+    error: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "phase": phase,
+        "mode": mode,
+        "run_name": run_name,
+        "depth": depth,
+        "device": str(device),
+        "resume_from": resume_from,
+        "runtime": {
+            "current_step": current_step,
+            "total_steps": total_steps,
+            "current_epoch": current_epoch,
+            "steps_per_epoch": steps_per_epoch,
+            "validate_every": validate_every,
+            "log_every": log_every,
+            "checkpoint_every": checkpoint_every,
+        },
+        "best": {
+            "best_val_loss": best_val_loss,
+            "best_step": best_step,
+        },
+        "last_metrics": {
+            "train": last_train_metrics,
+            "val": last_val_metrics,
+        },
+        "artifacts": {
+            "output_root": str(output_root.resolve()),
+            "train_log": str(train_log_path.resolve()),
+            "history_jsonl": str(history_jsonl_path.resolve()),
+            "grad_stats_jsonl": str(grad_jsonl_path.resolve()),
+        },
+        "timestamps": {
+            "started_at_utc": started_at_utc,
+            "updated_at_utc": datetime.now(timezone.utc).isoformat(),
+        },
+    }
+    if note is not None:
+        payload["note"] = note
+    if error is not None:
+        payload["error"] = error
+    return payload
 
 
 def move_batch_to_device(batch: dict[str, Any], device: torch.device) -> dict[str, Any]:
@@ -254,6 +417,7 @@ def build_train_loader(
     *,
     batch_size: int,
     num_workers: int,
+    pin_memory: bool,
     shuffle: bool,
     seed: int,
     epoch: int,
@@ -265,6 +429,8 @@ def build_train_loader(
         batch_size=batch_size,
         shuffle=shuffle,
         num_workers=num_workers,
+        pin_memory=pin_memory,
+        persistent_workers=num_workers > 0,
         generator=generator if shuffle else None,
     )
 
@@ -520,50 +686,70 @@ def save_checkpoint(
     steps_per_epoch: int,
     best_val_loss: float,
     best_step: int | None,
-    history: list[dict[str, Any]],
-    grad_history: list[dict[str, Any]],
+    history: list[dict[str, Any]] | None,
+    grad_history: list[dict[str, Any]] | None,
+    history_entry_count: int,
+    grad_history_entry_count: int,
+    last_history_entry: dict[str, Any] | None,
+    last_grad_history_entry: dict[str, Any] | None,
     encoder: PaperPhaseEncoder,
     decoder: DiffractiveDecoder,
     optimizer: Adam,
     config_snapshot: dict[str, Any],
 ) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    torch.save(
-        {
-            "step": step,
-            "steps_per_epoch": steps_per_epoch,
-            "best_val_loss": best_val_loss,
-            "best_step": best_step,
-            "history": history,
-            "grad_stats_history": grad_history,
-            "encoder_state_dict": encoder.state_dict(),
-            "decoder_state_dict": decoder.state_dict(),
-            "optimizer_state_dict": optimizer.state_dict(),
-            "config_snapshot": config_snapshot,
-        },
-        path,
-    )
+    payload: dict[str, Any] = {
+        "step": step,
+        "steps_per_epoch": steps_per_epoch,
+        "best_val_loss": best_val_loss,
+        "best_step": best_step,
+        "history_entry_count": history_entry_count,
+        "grad_history_entry_count": grad_history_entry_count,
+        "last_history_entry": last_history_entry,
+        "last_grad_history_entry": last_grad_history_entry,
+        "encoder_state_dict": encoder.state_dict(),
+        "decoder_state_dict": decoder.state_dict(),
+        "optimizer_state_dict": optimizer.state_dict(),
+        "config_snapshot": config_snapshot,
+    }
+    if history is not None:
+        payload["history"] = history
+    if grad_history is not None:
+        payload["grad_stats_history"] = grad_history
+    torch.save(payload, path)
+
+
+def split_history_entry_metrics(
+    history_entry: dict[str, Any] | None,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    if history_entry is None:
+        return None, None
+    train_metrics = {
+        key: value for key, value in history_entry.items() if key.startswith("train_")
+    }
+    val_metrics = {
+        key: value
+        for key, value in history_entry.items()
+        if key.startswith("val_") and value is not None
+    }
+    return train_metrics or None, val_metrics or None
 
 
 def main() -> None:
     args = parse_args()
     trainer_root = load_yaml(args.config)
     trainer_cfg = require_mapping(trainer_root, "trainer", "stage5_paper")
-    dataset_cfg = require_mapping(
-        load_yaml(trainer_cfg["config_paths"]["dataset"]), "data", "stage5_display"
-    )
-    optics_cfg = require_mapping(
-        load_yaml(trainer_cfg["config_paths"]["optics"]), "optics", "stage5_paper_aligned"
-    )
-    encoder_cfg = require_mapping(
-        load_yaml(trainer_cfg["config_paths"]["encoder"]), "encoder", "stage5_paper_aligned"
-    )
-    loss_cfg = require_mapping(load_yaml(trainer_cfg["config_paths"]["loss"]), "loss", "stage5_sr")
-
     runtime_cfg = dict(trainer_cfg["runtime"])
     total_steps = int(args.steps if args.steps is not None else runtime_cfg["steps"])
     if total_steps < 1:
         raise ValueError("Total steps must be >= 1.")
+    log_every = int(args.log_every if args.log_every is not None else runtime_cfg.get("log_every", 1))
+    if log_every < 1:
+        raise ValueError("log_every must be >= 1.")
+    checkpoint_every = int(runtime_cfg.get("checkpoint_every", 1))
+    if checkpoint_every < 1:
+        raise ValueError("checkpoint_every must be >= 1.")
+    keep_history_in_memory = bool(runtime_cfg.get("keep_history_in_memory", True))
     preview_limit = int(
         args.preview_limit if args.preview_limit is not None else runtime_cfg["preview_limit"]
     )
@@ -587,323 +773,655 @@ def main() -> None:
         run_dir = output_root / run_name
 
     download = bool(args.download or runtime_cfg.get("download", False))
-    train_base = build_dataset(dataset_cfg, split="train", download=download)
-    val_base = build_dataset(dataset_cfg, split="val", download=download)
-    train_dataset = maybe_subset(
-        train_base, trainer_cfg.get("dataset_selection", {}).get("train_subset_size")
-    )
-    val_dataset = maybe_subset(
-        val_base, trainer_cfg.get("dataset_selection", {}).get("val_subset_size")
-    )
-
-    encoder, decoder = build_encoder_decoder(
-        encoder_cfg,
-        optics_cfg,
-        depth=depth,
-        device=device,
-    )
-    target_adapter = Stage4RoiTargetAdapter(output_crop_hw=decoder.readout_config)
-    loss_fn = build_loss(loss_cfg, device=device)
-    optimizer = build_optimizer(encoder, decoder, trainer_cfg)
-
-    batch_size = int(runtime_cfg["batch_size"])
-    num_workers = int(runtime_cfg["num_workers"])
-    train_shuffle = bool(runtime_cfg["train_shuffle"])
-    steps_per_epoch = math.ceil(len(train_dataset) / batch_size)
-    validate_every = int(runtime_cfg["validate_every"])
-
-    config_snapshot = {
-        "trainer_config_path": str(Path(args.config).resolve()),
-        "mode": trainer_cfg["mode"],
-        "protocol_note": trainer_cfg["protocol_note"],
-        "run_name": run_name,
-        "depth": depth,
-        "device": str(device),
-        "runtime": {
-            **runtime_cfg,
-            "steps": total_steps,
-            "preview_limit": preview_limit,
-            "download": download,
-        },
-        "optimizer": trainer_cfg["optimizer"],
-        "optimizer_parameter_groups": [
-            {"name": "encoder", "lr": float(trainer_cfg["optimizer"]["lr_encoder"])},
-            {"name": "decoder", "lr": float(trainer_cfg["optimizer"]["lr_decoder"])},
-        ],
-        "loss_wiring": {
-            **trainer_cfg["loss_wiring"],
-            "implemented_formula": "input_power = sum(|U0|^2) over full propagation grid per sample",
-            "efficiency_enabled": bool(loss_cfg["efficiency_term"]["enabled"]),
-        },
-        "dataset_protocol": {
-            "train": train_base.get_protocol_summary(),
-            "val": val_base.get_protocol_summary(),
-            "train_subset_size": len(train_dataset),
-            "val_subset_size": len(val_dataset),
-            "subset_note": (
-                "Subset sizes are short-run trainer budget choices only; "
-                "they do not redefine the Stage 5 dataset protocol."
-            ),
-        },
-        "optics_config": optics_cfg,
-        "encoder_config": encoder_cfg,
-        "loss_config": loss_cfg,
-        "resume_from": None if not args.resume else str(Path(args.resume).resolve()),
-        "created_at_utc": datetime.now(timezone.utc).isoformat(),
-    }
-
-    history: list[dict[str, Any]] = []
-    grad_history: list[dict[str, Any]] = []
-    best_val_loss = math.inf
-    best_step: int | None = None
-    start_step = 0
-
-    if args.resume:
-        checkpoint = torch.load(args.resume, map_location=device)
-        encoder.load_state_dict(checkpoint["encoder_state_dict"])
-        decoder.load_state_dict(checkpoint["decoder_state_dict"])
-        optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
-        start_step = int(checkpoint["step"])
-        best_val_loss = float(checkpoint.get("best_val_loss", math.inf))
-        best_step = checkpoint.get("best_step")
-        history = list(checkpoint.get("history", []))
-        grad_history = list(checkpoint.get("grad_stats_history", []))
-
     run_dir.mkdir(parents=True, exist_ok=True)
-    save_json(run_dir / "config_snapshot.json", config_snapshot)
-
-    val_loader = DataLoader(val_dataset, batch_size=batch_size, shuffle=False, num_workers=num_workers)
-    preview_batch = next(iter(val_loader))
-    encoder.eval()
-    decoder.eval()
-    with torch.no_grad():
-        preview_output = run_stage5_batch(
-            encoder,
-            decoder,
-            loss_fn,
-            preview_batch,
-            depth=depth,
-            target_adapter=target_adapter,
-            device=device,
-        )
-    if args.resume:
-        save_preview_grid(run_dir / "preview_resume_start.png", preview_output, preview_limit=preview_limit)
-        save_phase_preview(
-            run_dir / "phi_preview_resume_start.png",
-            preview_output,
-            preview_limit=preview_limit,
-        )
-    else:
-        save_preview_grid(run_dir / "preview_step0.png", preview_output, preview_limit=preview_limit)
-        save_phase_preview(run_dir / "phi_preview_step0.png", preview_output, preview_limit=preview_limit)
-
+    train_log_path = run_dir / "train.log"
+    history_jsonl_path = run_dir / "history.jsonl"
+    grad_jsonl_path = run_dir / "grad_stats.jsonl"
+    status_path = run_dir / "status.json"
+    failure_path = run_dir / "failure.json"
+    loss_curve_points_path = run_dir / "loss_curve_points.json"
     latest_checkpoint_path = run_dir / "checkpoints" / "checkpoint_latest.pt"
     best_checkpoint_path = run_dir / "checkpoints" / "checkpoint_best.pt"
+    started_at_utc = datetime.now(timezone.utc).isoformat()
+    logger = RunLogger(train_log_path)
+    pin_memory = device.type == "cuda"
+    resume_from = None if not args.resume else str(Path(args.resume).resolve())
 
-    current_epoch = start_step // steps_per_epoch
-    step_in_epoch = start_step % steps_per_epoch
-    train_loader = build_train_loader(
-        train_dataset,
-        batch_size=batch_size,
-        num_workers=num_workers,
-        shuffle=train_shuffle,
-        seed=seed,
-        epoch=current_epoch,
-    )
-    train_iterator = iter(train_loader)
-    for _ in range(step_in_epoch):
-        next(train_iterator)
+    dataset_cfg: dict[str, Any] | None = None
+    optics_cfg: dict[str, Any] | None = None
+    encoder_cfg: dict[str, Any] | None = None
+    loss_cfg: dict[str, Any] | None = None
+    encoder: PaperPhaseEncoder | None = None
+    decoder: DiffractiveDecoder | None = None
+    loss_fn: Stage5SuperResolutionLoss | None = None
+    optimizer: Adam | None = None
+    target_adapter: Stage4RoiTargetAdapter | None = None
+    preview_batch: dict[str, Any] | None = None
+    history: list[dict[str, Any]] | None = [] if keep_history_in_memory else None
+    grad_history: list[dict[str, Any]] | None = [] if keep_history_in_memory else None
+    curve_history: list[dict[str, Any]] = []
+    last_history_entry: dict[str, Any] | None = None
+    last_grad_history_entry: dict[str, Any] | None = None
+    last_train_metrics: dict[str, Any] | None = None
+    last_val_metrics: dict[str, Any] | None = None
+    best_val_loss = math.inf
+    best_step: int | None = None
+    history_entry_count = 0
+    grad_history_entry_count = 0
+    start_step = 0
+    current_epoch = 0
+    steps_per_epoch: int | None = None
+    validate_every: int | None = None
+    global_step = 0
+    config_snapshot: dict[str, Any] | None = None
 
-    global_step = start_step
-    while global_step < total_steps:
-        try:
-            batch = next(train_iterator)
-        except StopIteration:
-            current_epoch += 1
-            train_loader = build_train_loader(
-                train_dataset,
-                batch_size=batch_size,
-                num_workers=num_workers,
-                shuffle=train_shuffle,
-                seed=seed,
-                epoch=current_epoch,
+    def write_status(phase: str, note: str, error: dict[str, Any] | None = None) -> None:
+        save_json(
+            status_path,
+            build_status_payload(
+                phase=phase,
+                mode=trainer_cfg["mode"],
+                run_name=run_name,
+                depth=depth,
+                device=device,
+                current_step=global_step,
+                total_steps=total_steps,
+                current_epoch=current_epoch if steps_per_epoch is not None else None,
+                steps_per_epoch=steps_per_epoch,
+                validate_every=validate_every,
+                log_every=log_every,
+                checkpoint_every=checkpoint_every,
+                resume_from=resume_from,
+                started_at_utc=started_at_utc,
+                output_root=run_dir,
+                train_log_path=train_log_path,
+                history_jsonl_path=history_jsonl_path,
+                grad_jsonl_path=grad_jsonl_path,
+                best_val_loss=None if best_step is None else best_val_loss,
+                best_step=best_step,
+                last_train_metrics=last_train_metrics,
+                last_val_metrics=last_val_metrics,
+                note=note,
+                error=error,
+            ),
+        )
+
+    try:
+        logger.log("Stage 5 paper trainer bootstrapping.")
+        logger.log(
+            f"Config={Path(args.config).resolve()} mode={trainer_cfg['mode']} "
+            f"run_name={run_name} depth={depth} device={device} resume_from={resume_from or 'none'}"
+        )
+        logger.log(
+            f"Runtime budget: steps={total_steps} batch_size={runtime_cfg['batch_size']} "
+            f"validate_every={runtime_cfg['validate_every']} log_every={log_every} "
+            f"checkpoint_every={checkpoint_every} preview_limit={preview_limit} seed={seed}"
+        )
+        logger.log(f"Output root={output_root.resolve()} run_dir={run_dir.resolve()}")
+        if download:
+            logger.log(
+                "Dataset download is enabled. If EMNIST is missing, torchvision may spend "
+                "time downloading/extracting before the next trainer log."
             )
-            train_iterator = iter(train_loader)
-            batch = next(train_iterator)
+        write_status("startup", "Trainer started; dataset/model construction has not finished yet.")
 
-        encoder.train()
-        decoder.train()
-        optimizer.zero_grad(set_to_none=True)
-        batch_output = run_stage5_batch(
-            encoder,
-            decoder,
-            loss_fn,
-            batch,
+        dataset_cfg = require_mapping(
+            load_yaml(trainer_cfg["config_paths"]["dataset"]), "data", "stage5_display"
+        )
+        optics_cfg = require_mapping(
+            load_yaml(trainer_cfg["config_paths"]["optics"]), "optics", "stage5_paper_aligned"
+        )
+        encoder_cfg = require_mapping(
+            load_yaml(trainer_cfg["config_paths"]["encoder"]), "encoder", "stage5_paper_aligned"
+        )
+        loss_cfg = require_mapping(
+            load_yaml(trainer_cfg["config_paths"]["loss"]), "loss", "stage5_sr"
+        )
+
+        logger.log(
+            f"Building train dataset split from root={dataset_cfg['dataset_root']} download={download}."
+        )
+        write_status("building_train_dataset", "Building Stage 5 train dataset.")
+        train_base = build_dataset(dataset_cfg, split="train", download=download)
+        logger.log(f"Train dataset ready: base_len={len(train_base)}")
+
+        logger.log("Building val dataset split.")
+        write_status("building_val_dataset", "Building Stage 5 val dataset.")
+        val_base = build_dataset(dataset_cfg, split="val", download=download)
+        logger.log(f"Val dataset ready: base_len={len(val_base)}")
+
+        train_dataset = maybe_subset(
+            train_base, trainer_cfg.get("dataset_selection", {}).get("train_subset_size")
+        )
+        val_dataset = maybe_subset(
+            val_base, trainer_cfg.get("dataset_selection", {}).get("val_subset_size")
+        )
+        logger.log(
+            f"Dataset selection resolved: train_len={len(train_dataset)} val_len={len(val_dataset)} "
+            f"train_subset={trainer_cfg.get('dataset_selection', {}).get('train_subset_size')} "
+            f"val_subset={trainer_cfg.get('dataset_selection', {}).get('val_subset_size')}"
+        )
+
+        encoder, decoder = build_encoder_decoder(
+            encoder_cfg,
+            optics_cfg,
             depth=depth,
-            target_adapter=target_adapter,
             device=device,
         )
-        loss = batch_output["loss_dict"]["loss"]
-        loss.backward()
+        target_adapter = Stage4RoiTargetAdapter(output_crop_hw=decoder.readout_config)
+        loss_fn = build_loss(loss_cfg, device=device)
+        optimizer = build_optimizer(encoder, decoder, trainer_cfg)
 
-        encoder_grad = collect_module_grad_stats(encoder)
-        decoder_grad = collect_module_grad_stats(decoder)
-        optimizer.step()
-        global_step += 1
-
-        train_metrics = summarize_batch_metrics(batch_output)
-        history_entry: dict[str, Any] = {
-            "step": global_step,
-            "epoch": current_epoch,
-            "train_loss": train_metrics["loss"],
-            "train_mae_term": train_metrics["mae_term"],
-            "train_efficiency_term": train_metrics["efficiency_term"],
-            "train_sigma_mean": train_metrics["sigma_mean"],
-            "train_eta_mean": train_metrics["eta_mean"],
-            "train_input_power_mean": train_metrics["input_power_mean"],
-            "train_output_power_mean": train_metrics["output_power_mean"],
-            "val_loss": None,
-            "val_mae_term": None,
-            "val_efficiency_term": None,
-            "val_sigma_mean": None,
-            "val_eta_mean": None,
-        }
-        history.append(history_entry)
-        grad_history.append(
-            {
-                "step": global_step,
-                "encoder": encoder_grad,
-                "decoder": decoder_grad,
-            }
+        batch_size = int(runtime_cfg["batch_size"])
+        num_workers = int(runtime_cfg["num_workers"])
+        train_shuffle = bool(runtime_cfg["train_shuffle"])
+        steps_per_epoch = math.ceil(len(train_dataset) / batch_size)
+        validate_every = int(runtime_cfg["validate_every"])
+        logger.log(
+            f"Model+loss ready: encoder_target_hw={tuple(encoder_cfg['target_hw'])} "
+            f"optics_input_pattern_hw={tuple(optics_cfg['grid']['input_pattern_hw'])} "
+            f"output_crop_hw={tuple(optics_cfg['readout']['output_crop_hw'])}"
+        )
+        logger.log(
+            f"Optimizer groups ready: encoder_lr={float(trainer_cfg['optimizer']['lr_encoder'])} "
+            f"decoder_lr={float(trainer_cfg['optimizer']['lr_decoder'])} "
+            f"pin_memory={pin_memory} num_workers={num_workers}"
         )
 
-        if global_step % validate_every == 0 or global_step == total_steps:
-            val_metrics = evaluate_loader(
+        config_snapshot = {
+            "trainer_config_path": str(Path(args.config).resolve()),
+            "mode": trainer_cfg["mode"],
+            "protocol_note": trainer_cfg["protocol_note"],
+            "run_name": run_name,
+            "depth": depth,
+            "device": str(device),
+            "runtime": {
+                **runtime_cfg,
+                "steps": total_steps,
+                "preview_limit": preview_limit,
+                "download": download,
+                "log_every": log_every,
+                "checkpoint_every": checkpoint_every,
+                "keep_history_in_memory": keep_history_in_memory,
+            },
+            "optimizer": trainer_cfg["optimizer"],
+            "optimizer_parameter_groups": [
+                {"name": "encoder", "lr": float(trainer_cfg["optimizer"]["lr_encoder"] )},
+                {"name": "decoder", "lr": float(trainer_cfg["optimizer"]["lr_decoder"] )},
+            ],
+            "loss_wiring": {
+                **trainer_cfg["loss_wiring"],
+                "implemented_formula": "input_power = sum(|U0|^2) over full propagation grid per sample",
+                "efficiency_enabled": bool(loss_cfg["efficiency_term"]["enabled"]),
+            },
+            "dataset_protocol": {
+                "train": train_base.get_protocol_summary(),
+                "val": val_base.get_protocol_summary(),
+                "train_subset_size": len(train_dataset),
+                "val_subset_size": len(val_dataset),
+                "subset_note": (
+                    "Subset sizes are trainer budget choices only; "
+                    "they do not redefine the Stage 5 dataset protocol."
+                ),
+            },
+            "artifact_policy": {
+                "history_storage_mode": (
+                    "in_memory_full_list" if keep_history_in_memory else "jsonl_incremental"
+                ),
+                "history_jsonl": str(history_jsonl_path.resolve()),
+                "grad_stats_jsonl": str(grad_jsonl_path.resolve()),
+                "status_json": str(status_path.resolve()),
+                "train_log": str(train_log_path.resolve()),
+                "loss_curve_points": str(loss_curve_points_path.resolve()),
+            },
+            "optics_config": optics_cfg,
+            "encoder_config": encoder_cfg,
+            "loss_config": loss_cfg,
+            "resume_from": resume_from,
+            "created_at_utc": started_at_utc,
+        }
+
+        if args.resume:
+            logger.log(f"Loading checkpoint from {resume_from}.")
+            checkpoint = torch.load(args.resume, map_location=device)
+            encoder.load_state_dict(checkpoint["encoder_state_dict"])
+            decoder.load_state_dict(checkpoint["decoder_state_dict"])
+            optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
+            start_step = int(checkpoint["step"])
+            global_step = start_step
+            best_val_loss = float(checkpoint.get("best_val_loss", math.inf))
+            best_step = checkpoint.get("best_step")
+            if history is not None and "history" in checkpoint:
+                history = list(checkpoint["history"])
+            if grad_history is not None and "grad_stats_history" in checkpoint:
+                grad_history = list(checkpoint["grad_stats_history"])
+            history_entry_count = int(
+                checkpoint.get("history_entry_count", 0 if history is None else len(history))
+            )
+            grad_history_entry_count = int(
+                checkpoint.get(
+                    "grad_history_entry_count", 0 if grad_history is None else len(grad_history)
+                )
+            )
+            last_history_entry = checkpoint.get("last_history_entry")
+            last_grad_history_entry = checkpoint.get("last_grad_history_entry")
+            last_train_metrics, last_val_metrics = split_history_entry_metrics(last_history_entry)
+            if loss_curve_points_path.exists():
+                curve_history = list(load_json(loss_curve_points_path))
+            logger.log(
+                f"Resume state restored: start_step={start_step} best_step={best_step} "
+                f"best_val_loss={format_optional_float(None if best_step is None else best_val_loss)} "
+                f"history_entry_count={history_entry_count} "
+                f"grad_history_entry_count={grad_history_entry_count}"
+            )
+
+        save_json(run_dir / "config_snapshot.json", config_snapshot)
+        logger.log(f"Config snapshot saved to {(run_dir / 'config_snapshot.json').resolve()}.")
+
+        val_loader = DataLoader(
+            val_dataset,
+            batch_size=batch_size,
+            shuffle=False,
+            num_workers=num_workers,
+            pin_memory=pin_memory,
+            persistent_workers=num_workers > 0,
+        )
+        preview_batch = next(iter(val_loader))
+        encoder.eval()
+        decoder.eval()
+        with torch.no_grad():
+            preview_output = run_stage5_batch(
                 encoder,
                 decoder,
                 loss_fn,
-                val_loader,
+                preview_batch,
                 depth=depth,
                 target_adapter=target_adapter,
                 device=device,
             )
-            history_entry.update(val_metrics)
-            if float(val_metrics["val_loss"]) < best_val_loss:
-                best_val_loss = float(val_metrics["val_loss"])
-                best_step = global_step
-                with torch.no_grad():
-                    best_preview = run_stage5_batch(
-                        encoder,
-                        decoder,
-                        loss_fn,
-                        preview_batch,
-                        depth=depth,
-                        target_adapter=target_adapter,
-                        device=device,
-                    )
-                save_preview_grid(run_dir / "preview_best.png", best_preview, preview_limit=preview_limit)
-                save_phase_preview(
-                    run_dir / "phi_preview_best.png",
-                    best_preview,
-                    preview_limit=preview_limit,
+        if args.resume:
+            save_preview_grid(
+                run_dir / "preview_resume_start.png",
+                preview_output,
+                preview_limit=preview_limit,
+            )
+            save_phase_preview(
+                run_dir / "phi_preview_resume_start.png",
+                preview_output,
+                preview_limit=preview_limit,
+            )
+        else:
+            save_preview_grid(run_dir / "preview_step0.png", preview_output, preview_limit=preview_limit)
+            save_phase_preview(
+                run_dir / "phi_preview_step0.png",
+                preview_output,
+                preview_limit=preview_limit,
+            )
+        logger.log("Initial preview artifacts saved.")
+
+        current_epoch = start_step // steps_per_epoch
+        step_in_epoch = start_step % steps_per_epoch
+        train_loader = build_train_loader(
+            train_dataset,
+            batch_size=batch_size,
+            num_workers=num_workers,
+            pin_memory=pin_memory,
+            shuffle=train_shuffle,
+            seed=seed,
+            epoch=current_epoch,
+        )
+        train_iterator = iter(train_loader)
+        for _ in range(step_in_epoch):
+            next(train_iterator)
+
+        write_status("training", "Training loop entered.")
+        logger.log(
+            f"Training loop entered: start_step={start_step} steps_per_epoch={steps_per_epoch} "
+            f"validate_every={validate_every}"
+        )
+
+        train_loop_start = time.perf_counter()
+        while global_step < total_steps:
+            try:
+                batch = next(train_iterator)
+            except StopIteration:
+                current_epoch += 1
+                train_loader = build_train_loader(
+                    train_dataset,
+                    batch_size=batch_size,
+                    num_workers=num_workers,
+                    pin_memory=pin_memory,
+                    shuffle=train_shuffle,
+                    seed=seed,
+                    epoch=current_epoch,
                 )
+                train_iterator = iter(train_loader)
+                batch = next(train_iterator)
+
+            step_start = time.perf_counter()
+            encoder.train()
+            decoder.train()
+            optimizer.zero_grad(set_to_none=True)
+            batch_output = run_stage5_batch(
+                encoder,
+                decoder,
+                loss_fn,
+                batch,
+                depth=depth,
+                target_adapter=target_adapter,
+                device=device,
+            )
+            loss = batch_output["loss_dict"]["loss"]
+            loss.backward()
+
+            encoder_grad = collect_module_grad_stats(encoder)
+            decoder_grad = collect_module_grad_stats(decoder)
+            optimizer.step()
+            global_step += 1
+
+            train_metrics = summarize_batch_metrics(batch_output)
+            history_entry = {
+                "step": global_step,
+                "epoch": current_epoch,
+                "train_loss": train_metrics["loss"],
+                "train_mae_term": train_metrics["mae_term"],
+                "train_efficiency_term": train_metrics["efficiency_term"],
+                "train_sigma_mean": train_metrics["sigma_mean"],
+                "train_eta_mean": train_metrics["eta_mean"],
+                "train_input_power_mean": train_metrics["input_power_mean"],
+                "train_output_power_mean": train_metrics["output_power_mean"],
+                "val_loss": None,
+                "val_mae_term": None,
+                "val_efficiency_term": None,
+                "val_sigma_mean": None,
+                "val_eta_mean": None,
+            }
+            grad_entry = {
+                "step": global_step,
+                "encoder": encoder_grad,
+                "decoder": decoder_grad,
+            }
+            if history is not None:
+                history.append(history_entry)
+            if grad_history is not None:
+                grad_history.append(grad_entry)
+            history_entry_count += 1
+            grad_history_entry_count += 1
+            last_history_entry = dict(history_entry)
+            last_grad_history_entry = grad_entry
+            last_train_metrics, _ = split_history_entry_metrics(last_history_entry)
+            append_jsonl(grad_jsonl_path, grad_entry)
+
+            should_validate = global_step % validate_every == 0 or global_step == total_steps
+            if should_validate:
+                logger.log(
+                    f"[validate:start] step={global_step}/{total_steps} val_samples={len(val_dataset)}"
+                )
+                write_status("validating", "Running validation.")
+                val_metrics = evaluate_loader(
+                    encoder,
+                    decoder,
+                    loss_fn,
+                    val_loader,
+                    depth=depth,
+                    target_adapter=target_adapter,
+                    device=device,
+                )
+                history_entry.update(val_metrics)
+                last_history_entry = dict(history_entry)
+                last_train_metrics, last_val_metrics = split_history_entry_metrics(last_history_entry)
+                logger.log(
+                    f"[validate:done] step={global_step}/{total_steps} "
+                    f"val_loss={float(val_metrics['val_loss']):.6f} "
+                    f"val_mae={float(val_metrics['val_mae_term']):.6f} "
+                    f"val_eff={float(val_metrics['val_efficiency_term']):.6f} "
+                    f"val_sigma={float(val_metrics['val_sigma_mean']):.6f} "
+                    f"val_eta={format_optional_float(val_metrics['val_eta_mean'])}"
+                )
+                if float(val_metrics["val_loss"]) < best_val_loss:
+                    best_val_loss = float(val_metrics["val_loss"])
+                    best_step = global_step
+                    with torch.no_grad():
+                        best_preview = run_stage5_batch(
+                            encoder,
+                            decoder,
+                            loss_fn,
+                            preview_batch,
+                            depth=depth,
+                            target_adapter=target_adapter,
+                            device=device,
+                        )
+                    save_preview_grid(
+                        run_dir / "preview_best.png",
+                        best_preview,
+                        preview_limit=preview_limit,
+                    )
+                    save_phase_preview(
+                        run_dir / "phi_preview_best.png",
+                        best_preview,
+                        preview_limit=preview_limit,
+                    )
+                    save_checkpoint(
+                        best_checkpoint_path,
+                        step=global_step,
+                        steps_per_epoch=steps_per_epoch,
+                        best_val_loss=best_val_loss,
+                        best_step=best_step,
+                        history=history,
+                        grad_history=grad_history,
+                        history_entry_count=history_entry_count,
+                        grad_history_entry_count=grad_history_entry_count,
+                        last_history_entry=last_history_entry,
+                        last_grad_history_entry=last_grad_history_entry,
+                        encoder=encoder,
+                        decoder=decoder,
+                        optimizer=optimizer,
+                        config_snapshot=config_snapshot,
+                    )
+                    logger.log(
+                        f"[checkpoint:best] step={global_step}/{total_steps} "
+                        f"best_val_loss={best_val_loss:.6f} path={best_checkpoint_path.resolve()}"
+                    )
+
+            append_jsonl(history_jsonl_path, history_entry)
+
+            step_elapsed = time.perf_counter() - step_start
+            run_elapsed = time.perf_counter() - train_loop_start
+            completed_run_steps = max(1, global_step - start_step)
+            steps_per_second = completed_run_steps / run_elapsed if run_elapsed > 0 else None
+            eta_seconds = (
+                None
+                if steps_per_second is None or steps_per_second <= 0
+                else (total_steps - global_step) / steps_per_second
+            )
+            should_log = global_step == 1 or global_step % log_every == 0 or should_validate
+            should_save_latest = (
+                global_step % checkpoint_every == 0 or should_validate or global_step == total_steps
+            )
+
+            if should_log:
+                curve_history.append(dict(history_entry))
+                save_json(loss_curve_points_path, curve_history)
+
+            if should_save_latest:
                 save_checkpoint(
-                    best_checkpoint_path,
+                    latest_checkpoint_path,
                     step=global_step,
                     steps_per_epoch=steps_per_epoch,
                     best_val_loss=best_val_loss,
                     best_step=best_step,
                     history=history,
                     grad_history=grad_history,
+                    history_entry_count=history_entry_count,
+                    grad_history_entry_count=grad_history_entry_count,
+                    last_history_entry=last_history_entry,
+                    last_grad_history_entry=last_grad_history_entry,
                     encoder=encoder,
                     decoder=decoder,
                     optimizer=optimizer,
                     config_snapshot=config_snapshot,
                 )
+                if should_log:
+                    logger.log(
+                        f"[checkpoint:latest] step={global_step}/{total_steps} "
+                        f"path={latest_checkpoint_path.resolve()}"
+                    )
 
-        save_checkpoint(
-            latest_checkpoint_path,
-            step=global_step,
-            steps_per_epoch=steps_per_epoch,
-            best_val_loss=best_val_loss,
-            best_step=best_step,
-            history=history,
-            grad_history=grad_history,
-            encoder=encoder,
-            decoder=decoder,
-            optimizer=optimizer,
-            config_snapshot=config_snapshot,
+            if should_log:
+                logger.log(
+                    f"[train] step={global_step}/{total_steps} epoch={current_epoch} "
+                    f"train_loss={train_metrics['loss']:.6f} "
+                    f"train_mae={train_metrics['mae_term']:.6f} "
+                    f"train_eff={train_metrics['efficiency_term']:.6f} "
+                    f"last_val_loss={format_optional_float(None if last_val_metrics is None else last_val_metrics.get('val_loss'))} "
+                    f"best_val_loss={format_optional_float(None if best_step is None else best_val_loss)} "
+                    f"encoder_grad_l2={encoder_grad['l2_grad_norm']:.6f} "
+                    f"decoder_grad_l2={decoder_grad['l2_grad_norm']:.6f} "
+                    f"step_time_s={step_elapsed:.3f} "
+                    f"steps_per_sec={format_optional_float(steps_per_second, precision=3)} "
+                    f"eta={format_seconds(eta_seconds)} {get_cuda_memory_summary(device)}"
+                )
+                write_status("training", "Run in progress.")
+
+        encoder.eval()
+        decoder.eval()
+        with torch.no_grad():
+            final_preview = run_stage5_batch(
+                encoder,
+                decoder,
+                loss_fn,
+                preview_batch,
+                depth=depth,
+                target_adapter=target_adapter,
+                device=device,
+            )
+        save_preview_grid(run_dir / "preview_final.png", final_preview, preview_limit=preview_limit)
+        save_phase_preview(
+            run_dir / "phi_preview_final.png",
+            final_preview,
+            preview_limit=preview_limit,
         )
 
-    encoder.eval()
-    decoder.eval()
-    with torch.no_grad():
-        final_preview = run_stage5_batch(
-            encoder,
-            decoder,
-            loss_fn,
-            preview_batch,
-            depth=depth,
-            target_adapter=target_adapter,
-            device=device,
-        )
-    save_preview_grid(run_dir / "preview_final.png", final_preview, preview_limit=preview_limit)
-    save_phase_preview(run_dir / "phi_preview_final.png", final_preview, preview_limit=preview_limit)
+        if history is not None:
+            save_json(run_dir / "history.json", history)
+        else:
+            save_json(
+                run_dir / "history.json",
+                compact_history_artifact(
+                    artifact_name="history",
+                    entries=None,
+                    entry_count=history_entry_count,
+                    jsonl_path=history_jsonl_path,
+                    last_entry=last_history_entry,
+                ),
+            )
+        if grad_history is not None:
+            save_json(run_dir / "grad_stats.json", grad_history)
+        else:
+            save_json(
+                run_dir / "grad_stats.json",
+                compact_history_artifact(
+                    artifact_name="grad_stats",
+                    entries=None,
+                    entry_count=grad_history_entry_count,
+                    jsonl_path=grad_jsonl_path,
+                    last_entry=last_grad_history_entry,
+                ),
+            )
+        save_loss_curve(run_dir / "loss_curve.png", curve_history)
 
-    save_json(run_dir / "history.json", history)
-    save_json(run_dir / "grad_stats.json", grad_history)
-    save_loss_curve(run_dir / "loss_curve.png", history)
+        run_summary = {
+            "mode": trainer_cfg["mode"],
+            "run_name": run_name,
+            "completed_steps": global_step,
+            "steps_per_epoch": steps_per_epoch,
+            "depth": depth,
+            "device": str(device),
+            "optimizer_parameter_groups": config_snapshot["optimizer_parameter_groups"],
+            "input_power_source": config_snapshot["loss_wiring"]["input_power_source"],
+            "input_power_formula": config_snapshot["loss_wiring"]["implemented_formula"],
+            "efficiency_term_enabled": config_snapshot["loss_wiring"]["efficiency_enabled"],
+            "history_storage_mode": config_snapshot["artifact_policy"]["history_storage_mode"],
+            "best_val_loss": None if best_step is None else best_val_loss,
+            "best_step": best_step,
+            "final_train_loss": None if last_history_entry is None else last_history_entry["train_loss"],
+            "final_val_loss": None if last_history_entry is None else last_history_entry["val_loss"],
+            "history_entry_count": history_entry_count,
+            "grad_history_entry_count": grad_history_entry_count,
+            "output_shapes": {
+                "encoder_input": list(final_preview["x_hr"].shape),
+                "phi_lr": list(final_preview["phi_lr"].shape),
+                "U0": list(final_preview["output"]["U0"].shape),
+                "I_out_full": list(final_preview["output"]["I_out_full"].shape),
+                "I_out_roi": list(final_preview["pred_roi"].shape),
+            },
+            "artifacts": {
+                "config_snapshot": str((run_dir / "config_snapshot.json").resolve()),
+                "train_log": str(train_log_path.resolve()),
+                "status": str(status_path.resolve()),
+                "history": str((run_dir / "history.json").resolve()),
+                "history_jsonl": str(history_jsonl_path.resolve()),
+                "grad_stats": str((run_dir / "grad_stats.json").resolve()),
+                "grad_stats_jsonl": str(grad_jsonl_path.resolve()),
+                "loss_curve": str((run_dir / "loss_curve.png").resolve()),
+                "loss_curve_points": str(loss_curve_points_path.resolve()),
+                "preview_best": str((run_dir / "preview_best.png").resolve()),
+                "preview_final": str((run_dir / "preview_final.png").resolve()),
+                "phi_preview_best": str((run_dir / "phi_preview_best.png").resolve()),
+                "phi_preview_final": str((run_dir / "phi_preview_final.png").resolve()),
+                "checkpoint_latest": str(latest_checkpoint_path.resolve()),
+                "checkpoint_best": str(best_checkpoint_path.resolve()),
+            },
+        }
+        if (run_dir / "preview_step0.png").exists():
+            run_summary["artifacts"]["preview_step0"] = str((run_dir / "preview_step0.png").resolve())
+            run_summary["artifacts"]["phi_preview_step0"] = str(
+                (run_dir / "phi_preview_step0.png").resolve()
+            )
+        if (run_dir / "preview_resume_start.png").exists():
+            run_summary["artifacts"]["preview_resume_start"] = str(
+                (run_dir / "preview_resume_start.png").resolve()
+            )
+            run_summary["artifacts"]["phi_preview_resume_start"] = str(
+                (run_dir / "phi_preview_resume_start.png").resolve()
+            )
 
-    run_summary = {
-        "mode": trainer_cfg["mode"],
-        "run_name": run_name,
-        "completed_steps": global_step,
-        "steps_per_epoch": steps_per_epoch,
-        "depth": depth,
-        "device": str(device),
-        "optimizer_parameter_groups": config_snapshot["optimizer_parameter_groups"],
-        "input_power_source": config_snapshot["loss_wiring"]["input_power_source"],
-        "input_power_formula": config_snapshot["loss_wiring"]["implemented_formula"],
-        "efficiency_term_enabled": config_snapshot["loss_wiring"]["efficiency_enabled"],
-        "best_val_loss": None if best_step is None else best_val_loss,
-        "best_step": best_step,
-        "final_train_loss": history[-1]["train_loss"],
-        "final_val_loss": history[-1]["val_loss"],
-        "output_shapes": {
-            "encoder_input": list(final_preview["x_hr"].shape),
-            "phi_lr": list(final_preview["phi_lr"].shape),
-            "U0": list(final_preview["output"]["U0"].shape),
-            "I_out_full": list(final_preview["output"]["I_out_full"].shape),
-            "I_out_roi": list(final_preview["pred_roi"].shape),
-        },
-        "artifacts": {
-            "config_snapshot": str((run_dir / "config_snapshot.json").resolve()),
-            "history": str((run_dir / "history.json").resolve()),
-            "grad_stats": str((run_dir / "grad_stats.json").resolve()),
-            "loss_curve": str((run_dir / "loss_curve.png").resolve()),
-            "preview_best": str((run_dir / "preview_best.png").resolve()),
-            "preview_final": str((run_dir / "preview_final.png").resolve()),
-            "phi_preview_best": str((run_dir / "phi_preview_best.png").resolve()),
-            "phi_preview_final": str((run_dir / "phi_preview_final.png").resolve()),
-            "checkpoint_latest": str(latest_checkpoint_path.resolve()),
-            "checkpoint_best": str(best_checkpoint_path.resolve()),
-        },
-    }
-    if (run_dir / "preview_step0.png").exists():
-        run_summary["artifacts"]["preview_step0"] = str((run_dir / "preview_step0.png").resolve())
-        run_summary["artifacts"]["phi_preview_step0"] = str(
-            (run_dir / "phi_preview_step0.png").resolve()
+        save_json(run_dir / "run_summary.json", run_summary)
+        write_status("completed", "Run completed successfully.")
+        logger.log(f"Run completed successfully. Summary={str((run_dir / 'run_summary.json').resolve())}")
+        print(json.dumps(run_summary, indent=2))
+    except KeyboardInterrupt:
+        interruption_error = {
+            "type": "KeyboardInterrupt",
+            "message": "Training interrupted by user.",
+        }
+        save_json(failure_path, interruption_error)
+        write_status("interrupted", "Run interrupted before completion.", interruption_error)
+        logger.log("Run interrupted by user. status.json and failure.json were updated.")
+        raise
+    except Exception as exc:
+        failure_payload = {
+            "type": type(exc).__name__,
+            "message": str(exc),
+            "traceback": traceback.format_exc(),
+            "failed_at_step": global_step,
+            "created_at_utc": datetime.now(timezone.utc).isoformat(),
+        }
+        save_json(failure_path, failure_payload)
+        write_status(
+            "failed",
+            "Run failed before completion.",
+            {
+                "type": failure_payload["type"],
+                "message": failure_payload["message"],
+                "failure_json": str(failure_path.resolve()),
+            },
         )
-    if (run_dir / "preview_resume_start.png").exists():
-        run_summary["artifacts"]["preview_resume_start"] = str(
-            (run_dir / "preview_resume_start.png").resolve()
-        )
-        run_summary["artifacts"]["phi_preview_resume_start"] = str(
-            (run_dir / "phi_preview_resume_start.png").resolve()
-        )
-
-    save_json(run_dir / "run_summary.json", run_summary)
-    print(json.dumps(run_summary, indent=2))
+        logger.log(f"Run failed with {type(exc).__name__}: {exc}")
+        logger.log(traceback.format_exc())
+        raise
+    finally:
+        logger.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
why:
close out stage5 main-run reporting after the full linux-server training, regular eval, and blind eval artifacts were uploaded, and fix the remaining eval snapshot ambiguity so future audits record effective runtime settings clearly

what:
fill the stage5 main run report with the uploaded L=5 training and eval results, add the final stage5-10 feedback note, and update the eval and blind-eval scripts so config snapshots store effective runtime values instead of stale config defaults