### PR TITLE
docs(execution | stage5-11): consolidate stage5 verdict and stage6 entry

### DIFF
--- a/docs/ai/CodexFeedback/stage5/feedback_stage5-11.md
+++ b/docs/ai/CodexFeedback/stage5/feedback_stage5-11.md
@@ -1,0 +1,97 @@
+# Stage 5.11 反馈
+
+本次 Issue 5.11 没有新增训练、评估或模型实现，而是把已经存在的
+Stage 5 执行证据收口到 repo 的摘要层文档里，并明确给出阶段结论。
+
+## 本次完成的核心结论
+
+- Stage 5 工程完成度结论：`PASS`
+- 论文级质量复现结论：`NOT YET DEMONSTRATED`
+- Stage 6 进入决策：`GO`
+
+这个结论的含义是：
+
+- Stage 5 的 paper-aligned pipeline 现在已经真实存在并有完整 artifact
+- 真实 smoke run、真实 `phase-only / L=5` main run、matching regular eval、
+  matching blind eval 都已经落地
+- 但当前模型在已报告的 `val/test` PSNR 和 SSIM 上仍然落后于 bicubic
+- blind eval 目前仍然是 artifact-first 证据，不应被包装成更强的
+  blind-resolution 成功声明
+
+## 本次更新的文件
+
+- `docs/execution/results_summary.md`
+- `docs/execution/experiment_log.md`
+- `docs/ai/PROJECT_CONTEXT.md`
+- `docs/ai/CodexFeedback/stage5/feedback_stage5-11.md`
+
+## 我在摘要层文档里固定下来的判断
+
+### 1. Stage 5 工程层面已经完成
+
+摘要文档现在明确写清：
+
+- dataset / optics / encoder / loss / trainer / regular eval / blind eval
+  全部已经落地
+- `docs/execution/stage5_smoke_report.md` 是真实 smoke 证据
+- `docs/execution/stage5_main_run_report.md` 是真实主训练证据
+- `outputs/stage5/main_run/stage5_l5_phase_main/run_summary.json`
+- `outputs/stage5/eval/stage5_l5_phase_main_val_eval/summary.json`
+- `outputs/stage5/eval/stage5_l5_phase_main_test_eval/summary.json`
+- `outputs/stage5/blind_eval/stage5_l5_phase_main_blind_eval/summary.json`
+  共同构成了 Stage 5 的执行证据闭环
+
+### 2. Stage 5 经验层面不能夸大
+
+摘要文档现在明确保留这些 caveat：
+
+- main run 虽然真实完成，但不能据此宣称论文结果已经复现
+- bicubic 在当前 `val/test` 报告里都优于模型
+- blind eval 有真实 artifact，但没有 paper-final scalar blind metric
+- Stage 6 的 systematic follow-up 还没有开始执行
+
+### 3. Stage 6 可以进入，但理由是“工程就绪”
+
+`GO` 的理由不是“结果已经很好”，而是：
+
+- 当前 repo 已经有可信的 paper-aligned 起点
+- 已经不再缺 dataset / optics / encoder / loss / trainer / eval 基础设施
+- 后续问题已经从“能不能跑通”转成“为什么当前质量落后于 bicubic，
+  应该如何做系统化排查”
+
+## 最重要的经验 caveat
+
+- `val`:
+  - model `PSNR = 14.9181`
+  - model `SSIM = 0.8126`
+  - bicubic `PSNR = 25.6875`
+  - bicubic `SSIM = 0.9448`
+- `test`:
+  - model `PSNR = 9.5774`
+  - model `SSIM = 0.4386`
+  - bicubic `PSNR = 20.2487`
+  - bicubic `SSIM = 0.8393`
+
+所以 Stage 5 的正确表述必须是：
+
+- 工程完成：是
+- 论文级质量：否
+- 进入 Stage 6：可以
+
+## 推荐的 commit 三段式信息
+
+```text
+docs(execution | stage5-11): consolidate stage5 verdict and stage6 entry
+
+why:
+close out stage5 with an explicit repo-level verdict so the project
+records what the paper-aligned pipeline actually demonstrated, what it
+did not demonstrate, and whether stage6 should begin from the current
+artifact base
+
+what:
+update the summary-layer docs to record stage5 engineering completion as
+pass, preserve the main-run and eval evidence, state that bicubic still
+outperforms the model on reported PSNR/SSIM, and mark stage6 entry as go
+for systematic follow-up work
+```

--- a/docs/ai/PROJECT_CONTEXT.md
+++ b/docs/ai/PROJECT_CONTEXT.md
@@ -6,20 +6,39 @@
 Optical Neural Network Super-Resolution Reproduction
 
 **Primary Goal:**  
-Reproduce the paper *Super-resolution image display using diffractive decoders* with a traceable engineering workflow.
+Reproduce the paper *Super-resolution image display using diffractive decoders*
+with a traceable engineering workflow.
 
 **Current Stage:**  
-Stage 4 learnability gate has **passed**. The project is now ready to enter **Stage 5: paper-alignment** (GO decision pending implementation).
+Stage 5 paper-aligned engineering completion has **passed**.
+The repo is now ready to enter **Stage 6** for systematic follow-up
+experiments.
 
-**Important Stage-4 Principle:**  
-The goal is **not** to chase the paper's final metric yet.  
-The goal is to answer one question:
-
-> Can the full system learn under gradient-driven training once the encoder is connected to the optical decoder?
+**Current high-level claim:**  
+The repo now has a real paper-aligned pipeline and real execution
+artifacts, but it does **not** yet have evidence for paper-final quality
+reproduction.
 
 ---
 
-## 2. Stage Status Snapshot
+## 2. Current Repo Verdict
+
+Three separate statements must stay separate:
+
+1. Stage 5 engineering completion: `PASS`
+2. Paper-quality reproduction claim: `NOT YET DEMONSTRATED`
+3. Stage 6 entry decision: `GO`
+
+This separation matters because:
+
+- the pipeline is real and reproducible
+- the main run and matching eval artifacts exist
+- but the current model still underperforms the bicubic baseline on the
+  reported PSNR / SSIM summaries
+
+---
+
+## 3. Stage Status Snapshot
 
 ### Completed / trusted
 
@@ -28,234 +47,204 @@ The goal is to answer one question:
 - interpolation baseline
 - pure electronic bottleneck baseline
 - unified PSNR / SSIM evaluation helpers
-- run-order documentation
-- experiment logging / troubleshooting / results summary
-- Stage 3 optical decoder skeleton
-- Stage 3 optical forward sanity checks
-- Stage 3 decoder-only single-sample fitting
-- Stage 3 decoder-only small-subset capacity checks
-- Stage 4 minimal encoder + hybrid wrapper + dataset path
-- Stage 4 minimal trainer with artifact saving
+- Stage 3 optical contract and forward sanity
+- Stage 3 decoder-only optical capacity checks
 - Stage 4 single-sample closed-loop acceptance: PASS
-  - summarized in `docs/execution/stage4_single_sample_report.md`
-- Stage 4 small-subset closed-loop acceptance: PASS (with caveats)
+- Stage 4 small-subset closed-loop acceptance: PASS
+- Stage 5 protocol freeze
+- Stage 5 paper-aligned dataset path
+- Stage 5 paper-aligned optics configs
+- Stage 5 phase-only encoder
+- Stage 5 SR loss
+- Stage 5 trainer with artifact saving and resume support
+- Stage 5 regular eval with bicubic baseline
+- Stage 5 blind line-pair hook
+- Stage 5 smoke run
+- Stage 5 full `phase-only / L=5` main run
+- Stage 5 matching regular eval and blind eval artifacts
 
 ### Current focus
 
-- keep Stage 4 evidence as the regression baseline
-- use Stage 5 planning docs as the main paper-alignment entry point
-- avoid sending large, lagging execution docs to helper agents unless a specific claim needs tracing
+- preserve Stage 4 as the learnability baseline
+- preserve Stage 5 as the paper-aligned engineering baseline
+- use Stage 6 for systematic follow-up experiments rather than redoing
+  Stage 5 implementation work
 
 ---
 
-## 3. What Stage 4 Means In This Repo
+## 4. What Stage 5 Means In This Repo
 
-Stage 4 in this repo means:
+Stage 5 in this repo means:
 
-1. connect a minimal encoder
-2. feed encoder output into the existing optical contract
-3. train on a very small dataset first
-4. run single-sample overfit and small-subset sanity checks
-5. save enough intermediate artifacts to debug gradients, phase output, and optical readout
+1. align the system to the paper-path data / optics / encoder / loss /
+   trainer / eval settings
+2. run a real smoke check
+3. run a real full `phase-only / L=5` main training path
+4. record matching regular eval and blind eval artifacts
+5. preserve enough summaries, configs, and outputs for auditability
 
-Stage 4 does **not** mean:
+Stage 5 does **not** mean:
 
-- full paper hyperparameter alignment
-- full `96 -> learned phase pattern -> paper-exact optics` reproduction
-- quantization, misalignment, or robustness studies
-- large-scale sweeps or ablations
-
-Those belong to later stages.
+- paper-final quality has already been reproduced
+- the current model has beaten the bicubic baseline
+- blind line-pair artifacts have already become a strong scalar success
+  claim
+- Stage 6 quantization, robustness, misalignment, or ablation work has
+  already been performed
 
 ---
 
-## 4. Hard Constraints A New Assistant Must Know
+## 5. Hard Constraints A New Assistant Must Know
 
-### 4.1 Optical contract is already frozen
+### 5.1 Optical contract is still frozen
 
-The Stage 3 optical path is already defined as:
+The optical path remains:
 
 `phi_lr -> U0 -> U_out_full -> I_out_full -> I_out_roi`
 
-Any Stage 5 planning or implementation work must build on that contract rather than redesigning the optical core.
+Stage 6 work must build on that contract unless a future task explicitly
+reopens it with evidence and scope approval.
 
-### 4.2 The optical core already exposes the integration hooks we need
+### 5.2 Stage 4 remains the trusted learnability baseline
 
-The current optical decoder already supports:
+Stage 4 answered the "can the encoder + optics path learn at all?"
+question and should not be erased from the repo narrative.
 
-- `forward_from_phase(...)`
-- `forward_from_field(...)`
-- `forward_from_phase_provider(...)`
+Stage 5 is an engineering extension on top of that baseline, not a
+replacement for it.
 
-This means Stage 5 should primarily solve the **paper-aligned encoder / config / loss / eval** problem, not rewrite optics first.
+### 5.3 Stage 5 artifacts now exist and are the current paper-path anchor
 
-### 4.3 Electronic baseline is already trusted
+The most important Stage 5 execution artifacts are:
 
-The pure electronic bottleneck baseline has passed:
+- `docs/execution/stage5_smoke_report.md`
+- `docs/execution/stage5_main_run_report.md`
+- `outputs/stage5/main_run/stage5_l5_phase_main/run_summary.json`
+- `outputs/stage5/eval/stage5_l5_phase_main_val_eval/summary.json`
+- `outputs/stage5/eval/stage5_l5_phase_main_test_eval/summary.json`
+- `outputs/stage5/blind_eval/stage5_l5_phase_main_blind_eval/summary.json`
 
-- single-sample overfit sanity
-- small-subset training sanity
+### 5.4 The key empirical caveat must stay visible
 
-So Stage 4 should reuse it as a training/reference anchor instead of re-opening Stage 1 / 2 questions unless new evidence appears.
+Current Stage 5 evidence shows:
 
-### 4.4 Current Stage 3 training scripts are still toy verification scripts
+- the pipeline is real
+- the run artifacts are real
+- but bicubic currently outperforms the model on the reported PSNR /
+  SSIM summaries for both `val` and `test`
 
-The Stage 3 decoder-only scripts currently use:
+This caveat must not be hidden in future prompts or summary docs.
 
-- synthetic target patterns
-- toy grid sizes such as `24 / 32 / 48 / 20`
+### 5.5 The blind eval result is artifact-first
 
-They are useful for optical learnability verification, but they are **not** the Stage 5 paper-aligned pipeline.
+The Stage 5 blind hook is useful and real, but it currently supports:
 
-### 4.5 Some infrastructure is still missing
+- deterministic blind target generation
+- saved blind target and output artifacts
+- human inspection and later follow-up analysis
 
-The repo does **not yet** have:
-
-- a general Stage 4 eval runner
-- Stage 5 paper-aligned configs
-- a `tests/` directory for systematic automated checks
-
-At the time of this update:
-
-- `scripts/train.py` is empty
-- `scripts/eval.py` is empty
-- `scripts/visualize.py` is empty
-
-Stage 4 has a **minimal** trainer + dataset path for acceptance runs, but it is not a full paper-aligned training/eval framework.
+It does **not** currently justify a stronger paper-final blind metric
+claim.
 
 ---
 
-## 5. Current Code Assets That Matter Most
+## 6. Current Code Assets That Matter Most
 
-### Optical path
+### Paper-path model and optics
 
+- `src/models/encoders/paper_phase_encoder.py`
 - `src/models/optics/diffractive_decoder.py`
 - `src/models/optics/phase_provider.py`
-- `src/models/optics/propagation.py`
 - `src/models/optics/readout.py`
-- `src/models/optics/phase_utils.py`
 
-### Stage 3 verification scripts
+### Stage 5 data / loss / eval
 
-- `scripts/check_optical_readout.py`
-- `scripts/check_optical_forward_depths.py`
-- `scripts/train_decoder_only_single_sample.py`
-- `scripts/train_decoder_only_small_subset.py`
-- `scripts/train_decoder_only_small_subset_sweep.py`
-
-### Stage 1 / 2 trusted baseline path
-
-- `scripts/train_electronic_baseline.py`
-- `src/models/electronic_baseline.py`
-- `src/eval/evaluator.py`
+- `src/datasets/stage5_emnist_display.py`
+- `src/datasets/target_adapter.py`
+- `src/losses/stage5_sr_loss.py`
 - `src/eval/metrics.py`
+- `src/eval/evaluator.py`
+- `src/eval/stage5_blind_targets.py`
+
+### Stage 5 execution scripts
+
+- `scripts/train_stage5_paper.py`
+- `scripts/eval_stage5_paper.py`
+- `scripts/eval_stage5_blind_linepair.py`
+
+### Stage 5 configs
+
+- `configs/stage5/stage5_emnist_display.yaml`
+- `configs/stage5/stage5_optics_paper_aligned.yaml`
+- `configs/stage5/stage5_paper_encoder.yaml`
+- `configs/stage5/stage5_sr_loss.yaml`
+- `configs/stage5/stage5_trainer_smoke.yaml`
+- `configs/stage5/stage5_trainer_main.yaml`
+- `configs/stage5/stage5_eval.yaml`
+- `configs/stage5/stage5_blind_eval.yaml`
 
 ---
 
-## 6. Stage-5 Review Facts A Helper Agent Should Assume
+## 7. What A Helper Assistant Should Assume Now
 
-If a helper agent is asked to review or generate prompts for Stage 5, it should assume the following unless newer code disproves it:
+If a helper agent is asked to review or extend the repo after Stage 5,
+it should assume the following unless newer code disproves it:
 
-1. Stage 4 learnability gate has passed, but quality is still far from paper-final.
-2. Stage 5 is the first phase that should align to the paper's full settings.
-3. The optical core contract remains:
-   `phi_lr -> U0 -> U_out_full -> I_out_full -> I_out_roi`
-4. Stage 5 must not silently pull Stage 6 scope forward:
-   - no quantization sweep
-   - no robustness / misalignment study
-   - no large ablation matrix
-5. The canonical Stage 4 acceptance evidence lives in:
-   - `docs/execution/stage4_single_sample_report.md`
-   - `docs/execution/stage4_small_subset_report.md`
+1. Stage 5 engineering completion has passed.
+2. Stage 5 empirical quality is still below the bicubic baseline on the
+   reported PSNR / SSIM summaries.
+3. The repo is ready to enter Stage 6 because the paper-aligned pipeline
+   and evidence base are real.
+4. Stage 4 remains the trusted learnability baseline for regressions.
+5. Stage 6 should not rebuild Stage 5 from scratch unless a concrete
+   blocker or regression is found.
 
 ---
 
-## 7. Current Documentation Sources Of Truth
+## 8. Current Documentation Sources Of Truth
 
-For Stage 5 review or prompt-generation tasks, prioritize documents in this order:
+For Stage 6 review or prompt-generation tasks, prioritize documents in
+this order:
 
 1. `AGENTS.md`
 2. `docs/ai/PROJECT_CONTEXT.md`
-3. `docs/paper/paper_notes.md`
-4. `docs/plan/stage_plan/stage5/stage5_plan.md`
-5. `docs/plan/stage_plan/stage5/stage5_issue_plan.md`
-6. current code in `src/` and `scripts/`
+3. `docs/plan/stage_plan/stage5/stage5_protocol_freeze.md`
+4. `docs/execution/stage5_main_run_report.md`
+5. `docs/execution/results_summary.md`
+6. `docs/execution/experiment_log.md`
+7. `docs/paper/paper_notes.md`
 
-Only pull in the following if a specific claim must be verified:
+Add these when the task needs historical scope or issue ownership:
 
-- `docs/plan/plan_overview.md`
-- `docs/plan/stage_plan/stage4/stage4_protocol_freeze.md`
-- `docs/execution/stage4_single_sample_report.md`
-- `docs/execution/stage4_small_subset_report.md`
-- `docs/execution/results_summary.md`
-- `docs/execution/experiment_log.md`
-
-This ordering is intentional: the execution logs are useful, but they are verbose, partially redundant, and more likely to lag than the curated context + Stage 5 planning docs.
-
----
-
-## 8. Immediate Stage-5 Engineering Gaps
-
-The most likely Stage 5 work items are:
-
-1. align optics/encoder configs with paper settings
-2. scale data protocol beyond minimal EMNIST setup
-3. define Stage 5 training schedule and evaluation pipeline
-4. keep Stage 4 artifacts as traceable baseline for regressions
-
----
-
-## 9. Known Risks
-
-The main current risks are:
-
-1. confusing Stage 3 toy verification with Stage 4 real closed-loop training
-2. jumping straight to paper-aligned full settings before proving end-to-end learnability
-3. hiding unresolved choices such as phase range mapping or training scale selection
-4. writing a large trainer before defining a small acceptance protocol
-5. losing traceability by not saving configs, summaries, and intermediate visualizations
-
----
-
-## 10. Recommended Minimal File Package For Stage-5 Review / Prompting
-
-If a user wants another assistant to review Stage 5 plans or generate prompts for Codex, the default minimal package should be only these 5 files:
-
-- `AGENTS.md`
-- `docs/ai/PROJECT_CONTEXT.md`
-- `docs/paper/paper_notes.md`
 - `docs/plan/stage_plan/stage5/stage5_plan.md`
 - `docs/plan/stage_plan/stage5/stage5_issue_plan.md`
+- `docs/execution/stage5_smoke_report.md`
 
-Add these only when the task explicitly needs them:
-
-- `docs/plan/plan_overview.md`
-- `docs/plan/stage_plan/stage4/stage4_protocol_freeze.md`
-- `docs/execution/stage4_single_sample_report.md`
-- `docs/execution/stage4_small_subset_report.md`
-- `docs/execution/experiment_log.md`
-- `docs/execution/results_summary.md`
-
-Do **not** send large execution logs by default just because they exist. Send them only when the helper agent needs to verify a factual claim, a run result, or a documentation gap.
+Only pull in older Stage 3 / Stage 4 execution logs when a specific
+claim must be verified.
 
 ---
 
-## 11. One-Screen Summary
+## 9. One-Screen Summary
 
 This is a long-running reproduction project for a hybrid
 `encoder -> diffractive optical decoder` super-resolution paper.
 
 The repo has already passed:
 
-- Stage 1 / 2 baseline and evaluation groundwork
 - Stage 3 optical module verification
 - Stage 4 minimal closed-loop learnability acceptance
+- Stage 5 paper-aligned engineering completion
 
-The repo is now preparing Stage 5:
+The repo has **not** yet shown:
 
-- align the system to the paper's data / optics / loss / eval settings
-- keep Stage 4 as the trusted learnability baseline
-- avoid drifting into Stage 6 ablations too early
+- paper-final quality reproduction
+- superiority over the bicubic baseline on the reported regular-eval
+  summaries
 
-For prompt-writing or review tasks, the most efficient context package is:
-`AGENTS.md` + `PROJECT_CONTEXT.md` + `paper_notes.md` + `stage5_plan.md` + `stage5_issue_plan.md`.
+The current next-step decision is:
+
+- enter Stage 6 with a `GO` decision
+- keep Stage 4 and Stage 5 artifacts as regression anchors
+- use Stage 6 to investigate the quality gap rather than questioning
+  whether the Stage 5 pipeline exists

--- a/docs/execution/experiment_log.md
+++ b/docs/execution/experiment_log.md
@@ -1,196 +1,202 @@
 # Experiment Log
 
-本文档按时间顺序记录当前仓库中已经实现并运行过的关键里程碑。
+This document records the major execution milestones that have actually
+been implemented or run in this repo.
 
-记录范围：
+It is chronological and evidence-first.
+Planned future work belongs in planning docs, not here.
 
-- Stage 3 optical module verification
-- Stage 4 minimal closed-loop acceptance
+## Stage 3: Optical Module Verification
 
-不记录内容：
+### S3 optical contract and readout path landed
 
-- 尚未执行的 Stage 5 paper-aligned implementation
-- 计划文档中的未来任务
-- 仅存在于讨论中、没有运行证据的结论
+Key outcome:
 
----
+- The optical contract was frozen as
+  `phi_lr -> U0 -> U_out_full -> I_out_full -> I_out_roi`.
+- Full-grid intensity and ROI readout were separated cleanly.
+- Crop behavior became explicit and auditable.
 
-## S3-02 Optical Propagation Core
+Key references:
 
-- 对应任务：Issue 2 `feat: extract paper-aligned propagation core from sdn_upstream`
-- 做了什么：
-  - 从 `external/sdn_upstream` 参考并重写 centered FFT / IFFT、Rayleigh-Sommerfeld transfer kernel、phase-mask modulation。
-  - 在 `src/models/optics/propagation.py`、`src/models/optics/phase_utils.py`、`src/models/optics/diffractive_decoder.py` 中落地为当前 repo 的 clean optics core。
-  - 去掉 classification head、electrical decoder 以及上游任务耦合逻辑。
-- 最小结论：
-  - optical core 已与 upstream 任务层解耦。
-  - `L` 的语义固定为 trainable diffractive phase masks 数量。
-  - distance schedule 已显式区分 `input_to_first / inter_layer / last_to_sensor`。
+- `src/models/optics/diffractive_decoder.py`
+- `src/models/optics/readout.py`
+- `scripts/check_optical_readout.py`
 
-## S3-03 Readout / Crop Contract
+### S3 forward sanity passed for `L=1/3/5`
 
-- 对应任务：Issue 3 `feat: add output FOV crop and optical direct-readout contract`
-- 做了什么：
-  - 新增 `src/models/optics/readout.py`，把 `I_out_full = |U_out_full|^2` 和 deterministic center crop 从脚本中抽离。
-  - decoder 稳定返回 `U_out_full`、`I_out_full`、`I_out_roi`。
-  - `output_crop_hw` 成为显式配置，crop 越界会报错。
-- 运行证据：
-  - `scripts/check_optical_readout.py`
-- 最小结论：
-  - full-grid 与 ROI readout 的职责已稳定。
-  - crop contract 已进入模块层，不再隐藏在脚本里。
+Key outcome:
 
-## S3-04 Forward Sanity For L=1/3/5
+- The current optical core could run forward for `L=1/3/5`
+  without changing the contract.
 
-- 对应任务：Issue 4 `feat: add Stage 3 forward sanity scripts for L=1/3/5`
-- 做了什么：
-  - 新增 `scripts/check_optical_forward_depths.py`
-  - 在同一最小协议下检查 `L=1/3/5` 的 forward 行为
-- 运行证据：
-  - `scripts/check_optical_forward_depths.py`
-- 最小结论：
-  - `L=1/3/5` 都能成功 forward
-  - 输出接口一致，invalid distance schedule 会显式失败
+Key reference:
 
-## S3-05 Decoder-Only Single-Sample Fitting
+- `scripts/check_optical_forward_depths.py`
 
-- 对应任务：Issue 5 `feat: add decoder-only single-sample fitting runner`
-- 做了什么：
-  - 新增 `scripts/train_decoder_only_single_sample.py`
-  - 直接优化 learnable input phase，不引入 encoder
-  - 在 ROI 上使用 normalized MAE 拟合单个 synthetic target
-- 运行证据：
-  - `outputs/optics/decoder_only_single_sample_smoke/summary.json`
-- 最小结论：
-  - decoder-only 单样本路径可学
-  - 这只说明 optical decoder 有容量，不等价于 end-to-end 结果
+### S3 decoder-only capacity checks passed
 
-## S3-06 Decoder-Only Small-Subset Depth Sweep
+Key outcome:
 
-- 对应任务：Issue 6 `feat: run small-subset optical capacity experiment across L=1/3/5`
-- 做了什么：
-  - 新增 `scripts/train_decoder_only_small_subset.py`
-  - 新增 `scripts/train_decoder_only_small_subset_sweep.py`
-  - 对固定 deterministic subset 执行 `L=1/3/5` sweep
-- 运行证据：
-  - `outputs/optics/decoder_only_small_subset_sweep_run1/sweep_summary.json`
-  - `outputs/optics/decoder_only_small_subset_sweep_run1/depth_comparison.csv`
-- 最小结论：
-  - 三种 depth 在同一 tiny protocol 下都能下降
-  - 当前结果不构成 paper performance 排序结论
+- Decoder-only single-sample fitting and small-subset depth checks showed
+  that the optical decoder stack has learnable capacity under the Stage 3
+  verification protocol.
 
-## S3-07 Phase-Provider Hook
+Key references:
 
-- 对应任务：Task3-7 `feat: add clean phase-provider hook for future Stage 4 integration`
-- 做了什么：
-  - 新增 `src/models/optics/phase_provider.py`
-  - 明确 `PhaseProvider` contract：`upstream_input -> phase tensor`
-  - 在 decoder 中稳定 `forward_from_phase(...)`、`forward_from_field(...)`、`forward_from_phase_provider(...)`
-- 最小结论：
-  - future encoder 接入点已冻结
-  - Stage 4 不需要重新设计 optical core 接口
+- `outputs/optics/decoder_only_single_sample_smoke/summary.json`
+- `outputs/optics/decoder_only_small_subset_sweep_run1/sweep_summary.json`
 
----
+Important boundary:
 
-## S4-01 Single-Sample Closed-Loop Acceptance
+- These were optical verification results, not paper-aligned Stage 5
+  results.
 
-- 对应任务：Issue 4.6 `Run Stage 4 single-sample overfit sanity and write acceptance report`
-- 做了什么：
-  - 使用现有 `scripts/train_stage4_minimal.py` 执行正式单样本 overfit 验收
-  - 未重写 optical core、dataset path、wrapper 或 trainer
-- 运行命令：
+## Stage 4: Minimal Closed-Loop Learnability Gate
 
-```bash
-python scripts/train_stage4_minimal.py \
-  --single-sample \
-  --steps 100 \
-  --device cuda \
-  --dataset-root data/raw/emnist \
-  --download \
-  --run-name issue4_6_single_sample_100
-```
+### S4 single-sample acceptance passed
 
-```bash
-python scripts/train_stage4_minimal.py \
-  --single-sample \
-  --steps 300 \
-  --device cuda \
-  --dataset-root data/raw/emnist \
-  --run-name issue4_6_single_sample_300
-```
+Key outcome:
 
-- 工件目录：
-  - `outputs/stage4/minimal_trainer/issue4_6_single_sample_100/`
-  - `outputs/stage4/minimal_trainer/issue4_6_single_sample_300/`
-- 结果摘要：
+- End-to-end training with encoder + optics could overfit a single sample
+  without NaN / Inf.
 
-| run | steps | initial_loss | best_loss | final_loss | verdict |
-| --- | ---: | ---: | ---: | ---: | --- |
-| `issue4_6_single_sample_100` | 100 | 0.213564 | 0.164205 | 0.164152 | PASS |
-| `issue4_6_single_sample_300` | 300 | 0.213564 | 0.117267 | 0.116939 | PASS |
+Key references:
 
-- 最小结论：
-  - loss 明确下降
-  - encoder / optics 梯度持续可观测
-  - 无 NaN / Inf
-  - 单样本 closed-loop learnability 成立
-- 详细报告：
-  - `docs/execution/stage4_single_sample_report.md`
+- `docs/execution/stage4_single_sample_report.md`
+- `outputs/stage4/minimal_trainer/issue4_6_single_sample_100/run_summary.json`
+- `outputs/stage4/minimal_trainer/issue4_6_single_sample_300/run_summary.json`
 
-## S4-02 Small-Subset Closed-Loop Acceptance
+### S4 small-subset acceptance passed
 
-- 对应任务：Issue 4.7 `Run Stage 4 small-subset closed-loop training and summarize learnability`
-- 做了什么：
-  - 使用同一 Stage 4 最小训练栈运行真实小子集闭环训练
-  - 保持 Stage 4 范围，不扩展到 Stage 5 paper settings
-- 运行命令：
+Key outcome:
 
-```bash
-python scripts/train_stage4_minimal.py \
-  --subset-size 16 \
-  --batch-size 4 \
-  --steps 200 \
-  --preview-limit 4 \
-  --device cuda \
-  --dataset-root data/raw/emnist \
-  --run-name issue4_7_small_subset_16_s200
-```
+- The minimal closed-loop path trained on a small real subset with
+  interpretable loss behavior and observable gradients.
 
-```bash
-python scripts/train_stage4_minimal.py \
-  --subset-size 16 \
-  --batch-size 4 \
-  --steps 400 \
-  --preview-limit 4 \
-  --device cuda \
-  --dataset-root data/raw/emnist \
-  --run-name issue4_7_small_subset_16_s400
-```
+Key references:
 
-- 工件目录：
-  - `outputs/stage4/minimal_trainer/issue4_7_small_subset_16_s200/`
-  - `outputs/stage4/minimal_trainer/issue4_7_small_subset_16_s400/`
-- 结果摘要：
+- `docs/execution/stage4_small_subset_report.md`
+- `outputs/stage4/minimal_trainer/issue4_7_small_subset_16_s200/run_summary.json`
+- `outputs/stage4/minimal_trainer/issue4_7_small_subset_16_s400/run_summary.json`
 
-| run | steps | initial_loss | best_loss | final_loss | val_loss | verdict |
-| --- | ---: | ---: | ---: | ---: | ---: | --- |
-| `issue4_7_small_subset_16_s200` | 200 | 0.217708 | 0.149736 | 0.180445 | 0.192186 | PASS |
-| `issue4_7_small_subset_16_s400` | 400 | 0.217708 | 0.144116 | 0.171176 | 0.190612 | PASS |
+Stage-level meaning:
 
-- 最小结论：
-  - 小子集上 loss 下降
-  - encoder / optics 梯度持续可观测
-  - 输出随输入变化，没有明显 collapse
-  - 输出质量仍偏模糊，PSNR / SSIM 偏低
-- 详细报告：
-  - `docs/execution/stage4_small_subset_report.md`
+- Stage 4 answered the learnability question.
+- Stage 4 remains the trusted regression baseline for later stages.
 
----
+## Stage 5: Paper-Aligned Pipeline Landing
 
-## 当前日志边界
+### S5.1 protocol freeze landed
 
-- 本文档当前记录到 Stage 4 learnability acceptance 为止。
-- Stage 5 目前只有 planning docs：
-  - `docs/plan/stage_plan/stage5/stage5_plan.md`
-  - `docs/plan/stage_plan/stage5/stage5_issue_plan.md`
-- 在尚未出现 paper-aligned 真实运行证据前，不应在本日志中提前写入 Stage 5 结果结论。
+Key outcome:
+
+- The Stage 5 scope, inherited contracts, paper-aligned defaults,
+  unresolved-item ownership, and Stage 6 boundary were frozen explicitly.
+
+Key reference:
+
+- `docs/plan/stage_plan/stage5/stage5_protocol_freeze.md`
+
+### S5.2 through S5.8 landed the full paper-path stack
+
+Key outcome:
+
+- Stage 5 dataset path landed.
+- Stage 5 optics configs for `L=1/3/5` landed.
+- Stage 5 phase-only encoder landed.
+- Stage 5 SR loss landed.
+- Stage 5 trainer landed.
+- Stage 5 regular eval with bicubic baseline landed.
+- Stage 5 blind line-pair hook landed.
+
+Key references:
+
+- `configs/stage5/stage5_emnist_display.yaml`
+- `configs/stage5/stage5_optics_paper_aligned.yaml`
+- `configs/stage5/stage5_paper_encoder.yaml`
+- `configs/stage5/stage5_sr_loss.yaml`
+- `configs/stage5/stage5_trainer_short.yaml`
+- `configs/stage5/stage5_eval.yaml`
+- `configs/stage5/stage5_blind_eval.yaml`
+
+### S5.9 smoke training completed
+
+Key outcome:
+
+- A real paper-aligned smoke run completed.
+- The run stayed finite and produced checkpoints, previews, and summaries.
+- Post-run regular eval and blind eval both executed successfully.
+
+Key reference:
+
+- `docs/execution/stage5_smoke_report.md`
+
+### S5.10 full `phase-only / L=5` main run completed
+
+Key outcome:
+
+- A full Stage 5 main run completed with the paper-aligned `L=5` path.
+- Matching regular eval and blind eval artifacts were generated for the
+  same best checkpoint.
+
+Main run facts:
+
+- run name: `stage5_l5_phase_main`
+- completed steps: `750000`
+- equivalent budget: `500` epochs
+- best step: `745500`
+- best val loss: `0.0188692901`
+- final train loss: `0.0201732814`
+- final val loss: `0.0188748985`
+
+Regular eval facts:
+
+| split | model PSNR | model SSIM | bicubic PSNR | bicubic SSIM |
+| --- | ---: | ---: | ---: | ---: |
+| `val` | `14.9181` | `0.8126` | `25.6875` | `0.9448` |
+| `test` | `9.5774` | `0.4386` | `20.2487` | `0.8393` |
+
+Blind eval facts:
+
+- deterministic `line_pair` target family
+- `24` blind targets
+- artifact-first blind reporting
+
+Key references:
+
+- `docs/execution/stage5_main_run_report.md`
+- `outputs/stage5/main_run/stage5_l5_phase_main/run_summary.json`
+- `outputs/stage5/eval/stage5_l5_phase_main_val_eval/summary.json`
+- `outputs/stage5/eval/stage5_l5_phase_main_test_eval/summary.json`
+- `outputs/stage5/blind_eval/stage5_l5_phase_main_blind_eval/summary.json`
+
+### S5.11 consolidation verdict
+
+Key outcome:
+
+- Stage 5 engineering completion verdict: `PASS`
+- Paper-quality reproduction claim: `NOT YET DEMONSTRATED`
+- Stage 6 entry decision: `GO`
+
+Reason for the caveat:
+
+- On both reported regular-eval splits, bicubic outperforms the current
+  model on PSNR and SSIM.
+- Blind eval provides real artifacts but does not justify a stronger
+  paper-final blind-resolution claim.
+
+## Current Log Boundary
+
+This log now records the repo through Stage 5 completion and Stage 6
+entry.
+
+What comes next belongs to Stage 6:
+
+- quantization follow-up
+- robustness / misalignment checks
+- systematic ablations
+- investigation of why the current Stage 5 model underperforms bicubic
+
+Those follow-up experiments should build on the current Stage 5 evidence
+base rather than rewriting the Stage 5 pipeline.

--- a/docs/execution/results_summary.md
+++ b/docs/execution/results_summary.md
@@ -1,149 +1,159 @@
 # Results Summary
 
-本文档汇总当前仓库已经获得的事实性结果，用于回答两个问题：
+This document summarizes the current repo-level execution verdicts.
+It is intentionally evidence-first and separates engineering completion
+from paper-quality success claims.
 
-1. 现在已经被验证的工程结论是什么。
-2. 现在还不能声称已经完成了什么。
+## Current Verdict
 
-本文档是结果摘要，不是实现说明书，也不是后续阶段计划文档。
+- Stage 5 engineering completion: `PASS`
+- Paper-quality reproduction claim: `NOT YET DEMONSTRATED`
+- Stage 6 entry decision: `GO`
 
----
+Why this is the current verdict:
 
-## 当前阶段
+- The full Stage 5 paper-aligned pipeline now exists end to end:
+  dataset, optics configs, phase-only encoder, Stage 5 loss, trainer,
+  regular eval, and blind eval hook.
+- A real Stage 5 smoke run exists and completed stably.
+- A real full `phase-only / L=5` main run exists.
+- Matching regular eval and blind eval artifacts exist for that main run.
+- The reported model PSNR/SSIM results do not currently beat the bicubic
+  baseline, so Stage 5 is an engineering completion milestone rather
+  than a paper-final quality success milestone.
 
-- 当前可信阶段结论：`Stage 4 minimal closed-loop learnability = PASS`
-- 当前工程状态：
-  - Stage 3 optical module verification 已完成
-  - Stage 4 单样本 closed-loop 验收已完成
-  - Stage 4 小子集 closed-loop 验收已完成（带保留项）
-  - Stage 5 paper-aligned planning 已起草，但 paper-aligned implementation 尚未开始
+## Primary Stage 5 Evidence
 
----
+- `docs/execution/stage5_smoke_report.md`
+- `docs/execution/stage5_main_run_report.md`
+- `outputs/stage5/main_run/stage5_l5_phase_main/run_summary.json`
+- `outputs/stage5/eval/stage5_l5_phase_main_val_eval/summary.json`
+- `outputs/stage5/eval/stage5_l5_phase_main_test_eval/summary.json`
+- `outputs/stage5/blind_eval/stage5_l5_phase_main_blind_eval/summary.json`
 
-## 当前已验证的事实
+## What Stage 5 Demonstrated
 
-### 1. Stage 3 optical contract 已冻结并落地
+### 1. The paper-aligned pipeline is real and reproducible
 
-- 当前主链路稳定为：
-  - `phi_lr -> U0 -> U_out_full -> I_out_full -> I_out_roi`
-- full-grid forward 与 ROI supervision 已显式分离
-- `U_out_full`、`I_out_full`、`I_out_roi` 由 optical module 直接返回
+Stage 5 landed the following paper-path components in the repo:
 
-### 2. Readout / crop / forward sanity 已通过
+- EMNIST `96x96` display dataset path
+- Stage 5 optics configs for `L=1/3/5`
+- phase-only encoder with explicit `phi_lr` semantics
+- Stage 5 super-resolution loss with configurable efficiency term
+- Stage 5 trainer with checkpointing and artifact saving
+- regular val/test eval with bicubic baseline
+- blind line-pair artifact path
 
-来源：
+This means the repo now has a credible paper-aligned starting point for
+systematic follow-up work.
 
-- `scripts/check_optical_readout.py`
-- `scripts/check_optical_forward_depths.py`
+### 2. Smoke training showed the pipeline is stable enough to launch
 
-最小事实：
+The smoke run recorded in `docs/execution/stage5_smoke_report.md` showed:
 
-- `I_out_full` / `I_out_roi` 保持 real 且 nonnegative
-- `U_out_full` 保持 complex
-- `output_crop_hw` 越界会显式报错
-- `L=1/3/5` 在当前 Stage 3 tiny setting 下都可 forward
+- end-to-end training completed without NaN / Inf
+- checkpoints, previews, and summaries were written successfully
+- regular eval and blind eval hooks both ran after training
 
-### 3. Decoder-only optical capacity 已通过最小验证
+That smoke result is not a quality claim, but it is valid engineering
+evidence that the Stage 5 stack is launchable and inspectable.
 
-来源：
+### 3. A full `phase-only / L=5` main run completed
 
-- `outputs/optics/decoder_only_single_sample_smoke/summary.json`
-- `outputs/optics/decoder_only_small_subset_sweep_run1/sweep_summary.json`
+From `outputs/stage5/main_run/stage5_l5_phase_main/run_summary.json`:
 
-最小事实：
+- run name: `stage5_l5_phase_main`
+- depth: `L=5`
+- completed steps: `750000`
+- equivalent budget: `500` epochs
+- best step: `745500`
+- best val loss: `0.0188692901`
+- final train loss: `0.0201732814`
+- final val loss: `0.0188748985`
+- history storage mode: `jsonl_incremental`
 
-- decoder-only 单样本拟合中，loss 可明确下降
-- decoder-only 小子集 fixed-protocol sweep 中，`L=1/3/5` 都能在多个样本上下降
-- 这些结果说明 optical decoder stack 具备可优化容量
-- 这些结果不等价于 paper-aligned end-to-end 性能已经成立
+This is real long-run execution evidence, not just launch preparation.
 
-### 4. Stage 4 单样本 closed-loop 验收已通过
+### 4. Matching regular eval artifacts exist for the same best checkpoint
 
-来源：
+The regular eval summaries score `I_out_roi` against the frozen
+`target_roi` path and use the Stage 5 bicubic baseline with
+`32x32 -> 96x96` downsample-then-upsample.
 
-- `docs/execution/stage4_single_sample_report.md`
-- `outputs/stage4/minimal_trainer/issue4_6_single_sample_100/run_summary.json`
-- `outputs/stage4/minimal_trainer/issue4_6_single_sample_300/run_summary.json`
+| split | model PSNR | model SSIM | bicubic PSNR | bicubic SSIM |
+| --- | ---: | ---: | ---: | ---: |
+| `val` | `14.9181` | `0.8126` | `25.6875` | `0.9448` |
+| `test` | `9.5774` | `0.4386` | `20.2487` | `0.8393` |
 
-结果摘要：
+Artifact sources:
 
-| run | steps | initial_loss | best_loss | final_loss | encoder grad | optics grad | NaN/Inf |
-| --- | ---: | ---: | ---: | ---: | --- | --- | --- |
-| `issue4_6_single_sample_100` | 100 | 0.213564 | 0.164205 | 0.164152 | observed | observed | none |
-| `issue4_6_single_sample_300` | 300 | 0.213564 | 0.117267 | 0.116939 | observed | observed | none |
+- `outputs/stage5/eval/stage5_l5_phase_main_val_eval/summary.json`
+- `outputs/stage5/eval/stage5_l5_phase_main_test_eval/summary.json`
 
-最小事实：
+### 5. Matching blind eval artifacts exist for the same best checkpoint
 
-- loss 明确下降
-- encoder / optics 梯度全程可观测
-- 无 NaN / Inf
-- 预测 ROI 从初始扩散亮斑演化到与 target 更接近的结构
+From `outputs/stage5/blind_eval/stage5_l5_phase_main_blind_eval/summary.json`:
 
-### 5. Stage 4 小子集 closed-loop 验收已通过
+- blind target family: `line_pair`
+- deterministic blind target count: `24`
+- target canvas: `96x96`
+- target orientations: `horizontal`, `vertical`
+- line widths: `1 px`, `2 px`
+- gap ladder: `1, 2, 3, 4, 6, 8 px`
 
-来源：
+This demonstrates that the blind-test hook is real, deterministic, and
+artifact-producing for the Stage 5 main checkpoint.
 
-- `docs/execution/stage4_small_subset_report.md`
-- `outputs/stage4/minimal_trainer/issue4_7_small_subset_16_s200/run_summary.json`
-- `outputs/stage4/minimal_trainer/issue4_7_small_subset_16_s400/run_summary.json`
+## What Stage 5 Did Not Demonstrate
 
-结果摘要：
+The current evidence does **not** justify the following stronger claims:
 
-| run | steps | initial_loss | best_loss | final_loss | val_loss | encoder grad | optics grad | verdict |
-| --- | ---: | ---: | ---: | ---: | ---: | --- | --- | --- |
-| `issue4_7_small_subset_16_s200` | 200 | 0.217708 | 0.149736 | 0.180445 | 0.192186 | observed | observed | PASS |
-| `issue4_7_small_subset_16_s400` | 400 | 0.217708 | 0.144116 | 0.171176 | 0.190612 | observed | observed | PASS |
+- It does not show paper-final quality reproduction.
+- It does not show that the current model is competitive with the
+  bicubic baseline on the reported PSNR / SSIM summaries.
+- It does not show a strong blind-resolution success claim.
+- It does not complete Stage 6 studies such as quantization,
+  robustness, misalignment, or systematic ablations.
 
-最小事实：
+The most important empirical caveat is explicit:
 
-- 小子集上 train loss 明确下降
-- val loss 从初始状态下降后进入平台
-- 输出对输入仍有响应，没有明显 collapse 到单一模式
-- 无 NaN / Inf
+- On both `val` and `test`, the reported bicubic baseline outperforms
+  the current Stage 5 model on PSNR and SSIM.
 
----
+The blind-eval caveat is also explicit:
 
-## 当前可以说的结论
+- The Stage 5 blind result is artifact-first.
+- It saves reproducible target and output grids.
+- It does not introduce or justify a paper-final scalar blind score.
 
-- 当前仓库已经通过 Stage 4 learnability gate。
-- 现有 optical core 不需要在 Stage 5 之前重写。
-- Stage 5 应把重点放在 paper-aligned dataset / optics config / encoder / loss / eval，而不是重新证明“系统能不能学”。
-- Stage 4 的单样本和小子集工件应被保留为后续 Stage 5 回归基线。
+## What Still Matters From Stage 4
 
----
+Stage 4 remains the trusted learnability baseline.
+Stage 5 should be read as a paper-aligned engineering extension on top
+of Stage 4, not as a replacement for that earlier acceptance evidence.
 
-## 当前不能说的结论
+This distinction matters because:
 
-- 不能说论文指标已经复现。
-- 不能说 paper-aligned pipeline 已经落地。
-- 不能说 `L=5` 或任何更深 depth 已被严格证明更优。
-- 不能说当前 Stage 4 结果可直接外推为 paper-final 质量。
-- 不能说 blind line-pair、量化、鲁棒性或系统化消融已经完成。
+- Stage 4 answered whether the encoder + optics path can learn at all.
+- Stage 5 answered whether the repo can run the full paper-aligned path
+  end to end with real artifacts.
+- Stage 6 should now investigate why paper-quality performance has not
+  yet been demonstrated.
 
----
+## Stage 6 Entry Decision
 
-## 已知限制与风险
+Decision: `GO`
 
-- 当前 Stage 4 使用的是最小闭环协议，不是 paper-final setting。
-- 当前 raw 读出质量仍偏模糊，PSNR / SSIM 偏低。
-- Stage 4 的主损失是 normalized MAE；其优化目标与 raw 强度可视化 / PSNR / SSIM 不完全同向。
-- 400x400 propagation grid、paper dataset protocol、efficiency penalty 和 line-pair eval 尚未进入正式实现。
+Reasoning:
 
----
+- The repo now has a real, reproducible, paper-aligned starting point.
+- The main run, regular eval, and blind eval all exist as auditable
+  artifacts.
+- The remaining problem is no longer "can we build or run the Stage 5
+  path?" but rather "why does the current Stage 5 path underperform the
+  bicubic baseline, and which Stage 6 experiments are needed to explain
+  that gap?"
 
-## 对 Stage 5 的含义
-
-- 结论：`GO`
-- 解释：
-  - Stage 4 已经回答“encoder + optics 是否可学”
-  - Stage 5 的任务不再是 learnability gate，而是把系统对齐到论文设定
-  - Stage 5 仍需对未决项保持诚实记录，不能把假设伪装成论文已明确
-
----
-
-## 相关文档
-
-- `docs/execution/stage4_single_sample_report.md`
-- `docs/execution/stage4_small_subset_report.md`
-- `docs/plan/stage_plan/stage5/stage5_plan.md`
-- `docs/plan/stage_plan/stage5/stage5_issue_plan.md`
+Stage 6 should therefore begin from the current frozen Stage 5 pipeline,
+not by re-litigating whether the Stage 5 engineering path exists.


### PR DESCRIPTION
why:
close out stage5 with an explicit repo-level verdict so the project records what the paper-aligned pipeline actually demonstrated, what it did not demonstrate, and whether stage6 should begin from the current artifact base

what:
update the summary-layer docs to record stage5 engineering completion as pass, preserve the main-run and eval evidence, state that bicubic still outperforms the model on reported PSNR/SSIM, and mark stage6 entry as go for systematic follow-up work